### PR TITLE
RSC1 and RSC2 - initialisation and default logging behaviour

### DIFF
--- a/test/io/ably/test/rest/RestInit.java
+++ b/test/io/ably/test/rest/RestInit.java
@@ -38,27 +38,27 @@ public class RestInit {
 	 */
 	@Test
 	public void init_null_key_string() {
-	  try {
-	    String key = null;
-	    new AblyRest(key);
-	    fail("init_null_key_string: Expected AblyException to be thrown when instantiating library with null key");
-	  } catch (AblyException e) {}
+		try {
+			String key = null;
+			new AblyRest(key);
+			fail("init_null_key_string: Expected AblyException to be thrown when instantiating library with null key");
+		} catch (AblyException e) {}
 	}
 
 	/**
-  * Init library with a key in options (RSC1)
-  */
-  @Test
-  public void init_key_opts() {
-    try {
-        String sampleKey = "sample:key";
-        ClientOptions opts = new ClientOptions(sampleKey);
-        new AblyRest(opts);
-      } catch (AblyException e) {
-        e.printStackTrace();
-        fail("init_key_opts: Unexpected exception instantiating library");
-      }
-  }
+	 * Init library with a key in options (RSC1)
+	 */
+	@Test
+	public void init_key_opts() {
+		try {
+			String sampleKey = "sample:key";
+			ClientOptions opts = new ClientOptions(sampleKey);
+			new AblyRest(opts);
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("init_key_opts: Unexpected exception instantiating library");
+		}
+	}
 	
 	/**
 	 * Init library with a null key in options (RSC1)
@@ -67,8 +67,8 @@ public class RestInit {
 	public void init_null_key_opts() {
 		try {
 			ClientOptions opts = new ClientOptions(null);
-      new AblyRest(opts);
-      fail("init_null_key_opts: Expected AblyException to be thrown when instantiating library with null key in options");
+			new AblyRest(opts);
+			fail("init_null_key_opts: Expected AblyException to be thrown when instantiating library with null key in options");
 		} catch (AblyException e) {}
 	}
 
@@ -199,29 +199,29 @@ public class RestInit {
 	 */
 	@Test
 	public void init_default_log_level() {
-	  try {
-	    String sampleKey = "sample:key";
-	    ClientOptions opts = new ClientOptions(sampleKey);
-	    assertTrue("The default logLevel is not WARN", opts.logLevel == Log.WARN);
-	  } catch (AblyException e) {
-	    e.printStackTrace();
-	    fail("init_default_log_level: Unexpected exception instantiating library");
-	  }
+		try {
+			String sampleKey = "sample:key";
+			ClientOptions opts = new ClientOptions(sampleKey);
+			assertTrue("The default logLevel is not WARN", opts.logLevel == Log.WARN);
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("init_default_log_level: Unexpected exception instantiating library");
+		}
 	}
 	
 	/**
-   * Check that the logger outputs to System.out by default (RSC2)
-   */
-  @Test
-  public void init_default_log_output_stream() {
-    ByteArrayOutputStream outContent = new ByteArrayOutputStream();
-    PrintStream defaultOs = System.out;
-    try {
-      System.setOut(new PrintStream(outContent));
-      Log.w(null, "hello");
-      assertEquals("hello", outContent.toString());
-    } finally {
-      System.setOut(defaultOs);
-    }
-  }
+	 * Check that the logger outputs to System.out by default (RSC2)
+	 */
+	@Test
+	public void init_default_log_output_stream() {
+		ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+		PrintStream defaultOs = System.out;
+		try {
+			System.setOut(new PrintStream(outContent));
+			Log.w(null, "hello");
+			assertEquals("hello", outContent.toString());
+		} finally {
+			System.setOut(defaultOs);
+		}
+	}
 }

--- a/test/io/ably/test/rest/RestInit.java
+++ b/test/io/ably/test/rest/RestInit.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import io.ably.rest.AblyRest;
 import io.ably.test.rest.RestSetup.TestVars;
 import io.ably.transport.Defaults;
@@ -12,6 +11,9 @@ import io.ably.types.AblyException;
 import io.ably.types.ClientOptions;
 import io.ably.util.Log;
 import io.ably.util.Log.LogHandler;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 
 import org.junit.Test;
 
@@ -32,32 +34,42 @@ public class RestInit {
 	}
 
 	/**
-	 * Init library with a key in options
+	 * Init library with a null key (RSC1)
 	 */
 	@Test
-	public void init_key_opts() {
-		try {
-			TestVars testVars = RestSetup.getTestVars();
-			new AblyRest(new ClientOptions(testVars.keys[0].keyStr));
-		} catch (AblyException e) {
-			e.printStackTrace();
-			fail("init1: Unexpected exception instantiating library");
-		}
+	public void init_null_key_string() {
+	  try {
+	    String key = null;
+	    new AblyRest(key);
+	    fail("init_null_key_string: Expected AblyException to be thrown when instantiating library with null key");
+	  } catch (AblyException e) {}
 	}
 
 	/**
-	 * Init library with key string
+  * Init library with a key in options (RSC1)
+  */
+  @Test
+  public void init_key_opts() {
+    try {
+        String sampleKey = "sample:key";
+        ClientOptions opts = new ClientOptions(sampleKey);
+        new AblyRest(opts);
+      } catch (AblyException e) {
+        e.printStackTrace();
+        fail("init_key_opts: Unexpected exception instantiating library");
+      }
+  }
+	
+	/**
+	 * Init library with a null key in options (RSC1)
 	 */
 	@Test
-	public void init_key() {
+	public void init_null_key_opts() {
 		try {
-			TestVars testVars = RestSetup.getTestVars();
-			ClientOptions opts = new ClientOptions(testVars.keys[0].keyStr);
-			new AblyRest(opts);
-		} catch (AblyException e) {
-			e.printStackTrace();
-			fail("init2: Unexpected exception instantiating library");
-		}
+			ClientOptions opts = new ClientOptions(null);
+      new AblyRest(opts);
+      fail("init_null_key_opts: Expected AblyException to be thrown when instantiating library with null key in options");
+		} catch (AblyException e) {}
 	}
 
 	/**
@@ -181,4 +193,35 @@ public class RestInit {
 			fail("init9: Unexpected exception instantiating library");
 		}
 	}
+	
+	/**
+	 * Check that the default logLevel is WARN (RSC2)
+	 */
+	@Test
+	public void init_default_log_level() {
+	  try {
+	    String sampleKey = "sample:key";
+	    ClientOptions opts = new ClientOptions(sampleKey);
+	    assertTrue("The default logLevel is not WARN", opts.logLevel == Log.WARN);
+	  } catch (AblyException e) {
+	    e.printStackTrace();
+	    fail("init_default_log_level: Unexpected exception instantiating library");
+	  }
+	}
+	
+	/**
+   * Check that the logger outputs to System.out by default (RSC2)
+   */
+  @Test
+  public void init_default_log_output_stream() {
+    ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    PrintStream defaultOs = System.out;
+    try {
+      System.setOut(new PrintStream(outContent));
+      Log.w(null, "hello");
+      assertEquals("hello", outContent.toString());
+    } finally {
+      System.setOut(defaultOs);
+    }
+  }
 }


### PR DESCRIPTION
(RSC1) The constructor accepts either an API key, a token string, or a set of ClientOptions. An exception is raised if invalid arguments are provided such as no API key, token and no means to create a token
(RSC2) The logger by default outputs to STDOUT (or other logging medium as appropriate to the platform) and the log level is set to warning