### PR TITLE
Set new thread as daemon to allow application shutdown

### DIFF
--- a/src/io/ably/transport/ConnectionManager.java
+++ b/src/io/ably/transport/ConnectionManager.java
@@ -131,6 +131,8 @@ public class ConnectionManager extends Thread implements ConnectListener {
 			Log.e(getClass().getName(), msg, e);
 			throw new RuntimeException(msg, e);
 		}
+
+		setDaemon(true);
 		synchronized(this) {
 			setSuspendTime();
 			this.start();


### PR DESCRIPTION
Hi,

When our application starts up, if it detects invalid configuration then it fails fast. Adding ably to our application then prevents this behaviour.

When ably creates a new ConnectionManager it doesn't explicitly set the daemon property. Since this is a user thread (by default), when the main thread then terminates the application doesn't shut down, leaving the application in a non functioning state. Please see http://docs.oracle.com/javase/6/docs/api/java/lang/Thread.html for more information on daemon vs user threads.

This request then changes the connection manager immediately after creation to be a daemon thread so that when the main thread terminates the application then terminates too.
