### PR TITLE
Set new thread as daemon to allow application shutdown

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -362,6 +362,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 		synchronized(this) {
 			if(mgrThread == null) {
 				mgrThread = new Thread(this);
+				mgrThread.setDaemon(true);
 				state = states.get(ConnectionState.initialized);
 				creating = true;
 			}


### PR DESCRIPTION
Further to [pull request 51](https://github.com/ably/ably-java/pull/51), I have made the same change in the gradle build branch.

I tried the gradle-build branch as is, but my application still hung as connection manager was creating a new user thread.  This fix ensures that if the main thread is terminated, the separate connection manager thread is terminated too.