### PR TITLE
Avoid stalled state from previous connection when reusing Realtime.

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
+++ b/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
@@ -49,8 +49,8 @@ public class AblyRealtime extends AblyRest {
 	 */
 	public AblyRealtime(ClientOptions options) throws AblyException {
 		super(options);
-		channels = new Channels();
 		connection = new Connection(this);
+		channels = new Channels();
 		if(options.autoConnect) connection.connect();
 	}
 
@@ -70,6 +70,16 @@ public class AblyRealtime extends AblyRest {
 	 */
 	@SuppressWarnings("serial")
 	public class Channels extends HashMap<String, Channel> {
+		public Channels() {
+			/* remove all channels when the connection is closed, to avoid stalled state */
+			connection.on(ConnectionState.closed, new ConnectionStateListener() {
+				@Override
+				public void onConnectionStateChanged(ConnectionStateListener.ConnectionStateChange state) {
+					Channels.this.clear();
+				}
+			});
+		}
+
 		/**
 		 * Get the named channel; if it does not already exist,
 		 * create it with default options.

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -739,6 +739,17 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	private class PendingMessageQueue {
 		private long startSerial = 0L;
 		private ArrayList<QueuedMessage> queue = new ArrayList<QueuedMessage>();
+
+		public PendingMessageQueue() {
+			/* put startSerial to 0 every time the connection is closed */
+			connection.on(ConnectionState.closed, new ConnectionStateListener() {
+				@Override
+				public void onConnectionStateChanged(ConnectionStateListener.ConnectionStateChange state) {
+					startSerial = 0L;
+				}
+			});
+		}
+
 		public synchronized void push(QueuedMessage msg) {
 			queue.add(msg);
 		}

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectTest.java
@@ -147,6 +147,17 @@ public class RealtimeConnectTest {
 			ConnectionWaiter connectionWaiter = new ConnectionWaiter(ably.connection);
 			connectionWaiter.waitFor(ConnectionState.connected);
 			assertEquals("Verify connected state is reached", ConnectionState.connected, ably.connection.state);
+
+			/* send a few channels to increment PendingMessageQueue.startSerial */
+			for (int i = 0; i < 3; i++) {
+				/* publish to the channel */
+				CompletionWaiter msgComplete = new CompletionWaiter();
+				ably.channels.get("test_channel").publish("test_event", "Test message", msgComplete);
+				/* wait for the publish callback to be called */
+				msgComplete.waitFor();
+				assertTrue("Verify success callback was called", msgComplete.success);
+			}
+
 			ably.close();
 			connectionWaiter.waitFor(ConnectionState.closed);
 			assertEquals("Verify closed state is reached", ConnectionState.closed, ably.connection.state);
@@ -155,6 +166,14 @@ public class RealtimeConnectTest {
 			ably.connection.connect();
 			connectionWaiter.waitFor(ConnectionState.connected);
 			assertEquals("Verify connected state is reached", ConnectionState.connected, ably.connection.state);
+
+			/* publish to the channel in the new connection to check that it works */
+			CompletionWaiter msgComplete = new CompletionWaiter();
+			ably.channels.get("test_channel").publish("test_event", "Test message", msgComplete);
+			/* wait for the publish callback to be called */
+			msgComplete.waitFor();
+			assertTrue("Verify success callback was called", msgComplete.success);
+
 			ably.close();
 			connectionWaiter.waitFor(ConnectionState.closed);
 			assertEquals("Verify closed state is reached", ConnectionState.closed, ably.connection.state);


### PR DESCRIPTION
After the connection transitions to CLOSED, some state has to be
reset. The changed test fails if channels are not purged and if
the pending message queue's last processed serial isn't resetted.