### PR TITLE
Proxy support

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -8,11 +8,11 @@ dependencies {
   compile 'org.msgpack:msgpack-core:0.8.2'
   compile 'org.java-websocket:Java-WebSocket:1.3.1'
   compile 'com.google.code.gson:gson:2.5'
+  testCompile 'org.hamcrest:hamcrest-all:1.3'
   testCompile 'junit:junit:4.12'
   testCompile 'com.nanohttpd:nanohttpd:2.2.0'
   testCompile 'org.nanohttpd:nanohttpd-nanolets:2.2.0'
   testCompile 'org.mockito:mockito-all:2.0.2-beta'
-  testCompile 'org.hamcrest:hamcrest-all:1.3'
 }
 
 task fullJar(type: Jar) {

--- a/lib/src/main/java/io/ably/lib/http/AsyncHttp.java
+++ b/lib/src/main/java/io/ably/lib/http/AsyncHttp.java
@@ -1,12 +1,19 @@
 package io.ably.lib.http;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.Proxy;
 import java.net.URL;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import io.ably.lib.http.Http.RequestBody;
 import io.ably.lib.http.Http.ResponseHandler;
+import io.ably.lib.transport.Hosts;
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.Callback;
 import io.ably.lib.types.ErrorInfo;
@@ -23,8 +30,8 @@ public class AsyncHttp extends ThreadPoolExecutor {
 	 * @param responseHandler
 	 * @param callback
 	 */
-	public <T> void get(String path, Param[] headers, Param[] params, ResponseHandler<T> responseHandler, Callback<T> callback) {
-		ablyHttpExecute(path, Http.GET, headers, params, null, responseHandler, callback);
+	public <T> Future<T> get(String path, Param[] headers, Param[] params, ResponseHandler<T> responseHandler, Callback<T> callback) {
+		return ablyHttpExecuteWithFallback(path, Http.GET, headers, params, null, responseHandler, callback);
 	}
 
 	/**
@@ -36,8 +43,8 @@ public class AsyncHttp extends ThreadPoolExecutor {
 	 * @param responseHandler
 	 * @param callback
 	 */
-	public <T> void post(String path, Param[] headers, Param[] params, RequestBody requestBody, ResponseHandler<T> responseHandler, Callback<T> callback) {
-		ablyHttpExecute(path, Http.POST, headers, params, requestBody, responseHandler, callback);
+	public <T> Future<T> post(String path, Param[] headers, Param[] params, RequestBody requestBody, ResponseHandler<T> responseHandler, Callback<T> callback) {
+		return ablyHttpExecuteWithFallback(path, Http.POST, headers, params, requestBody, responseHandler, callback);
 	}
 
 	/**
@@ -48,13 +55,262 @@ public class AsyncHttp extends ThreadPoolExecutor {
 	 * @param responseHandler
 	 * @param callback
 	 */
-	public <T> void del(String path, Param[] headers, Param[] params, ResponseHandler<T> responseHandler, Callback<T> callback) {
-		ablyHttpExecute(path, Http.DELETE, headers, params, null, responseHandler, callback);
+	public <T> Future<T> del(String path, Param[] headers, Param[] params, ResponseHandler<T> responseHandler, Callback<T> callback) {
+		return ablyHttpExecuteWithFallback(path, Http.DELETE, headers, params, null, responseHandler, callback);
 	}
 
 	/**************************
 	 *     Internal API
 	 **************************/
+
+	/**
+	 * An AsyncRequest type representing a request to a specific URL
+	 * @param <T>
+	 */
+	private class UrlRequest<T> extends AsyncRequest<T> implements Runnable {
+		private UrlRequest(
+				URL url,
+				final Proxy proxy,
+				final String method,
+				final Param[] headers,
+				final Param[] params,
+				final RequestBody requestBody,
+				final boolean withCredentials,
+				final ResponseHandler<T> responseHandler,
+				final Callback<T> callback) {
+			super(proxy, method, headers, params, requestBody, withCredentials, responseHandler, callback);
+			this.url = url;
+		}
+		@Override
+		public void run() {
+			try {
+				createConnection(url);
+				T result = httpExecute();
+				setResult(result);
+			} catch(AblyException e) {
+				setError(e.errorInfo);
+			} finally {
+				disposeConnection();
+			}
+		}
+		private final URL url;
+	}
+
+	/**
+	 * An AsyncRequest type representing a request to an Ably endpoint specified by host and path,
+	 * supporting reauthentication on receipt of WWW-Authenticate
+	 * @param <T>
+	 */
+	private class AblyRequestWithRetry<T> extends AsyncRequest<T> implements Runnable {
+		private AblyRequestWithRetry(
+				String host,
+				String path,
+				final Proxy proxy,
+				final String method,
+				final Param[] headers,
+				final Param[] params,
+				final RequestBody requestBody,
+				final ResponseHandler<T> responseHandler,
+				final Callback<T> callback) {
+			super(proxy, method, headers, params, requestBody, true, responseHandler, callback);
+			this.host = host;
+			this.path = path;
+		}
+		@Override
+		public void run() {
+			try {
+				result = httpExecuteWithRetry(host, path);
+				setResult(result);
+			} catch(AblyException e) {
+				setError(e.errorInfo);
+			} finally {
+				disposeConnection();
+			}
+		}
+		private final String host;
+		private final String path;
+	}
+
+	/**
+	 * An AsyncRequest type representing a request to an Ably endpoint specified by path,
+	 * supporting host fallback and reauthentication on receipt of WWW-Authenticate
+	 * @param <T>
+	 */
+	private class AblyRequestWithFallback<T> extends AsyncRequest<T> implements Runnable {
+		private AblyRequestWithFallback(
+				String path,
+				final Proxy proxy,
+				final String method,
+				final Param[] headers,
+				final Param[] params,
+				final RequestBody requestBody,
+				final ResponseHandler<T> responseHandler,
+				final Callback<T> callback) {
+			super(proxy, method, headers, params, requestBody, true, responseHandler, callback);
+			this.path = path;
+		}
+		@Override
+		public void run() {
+			int retryCountRemaining = Hosts.isRestFallbackSupported(http.host) ? http.options.httpMaxRetryCount : 0;
+			String candidateHost = http.host;
+
+			while(!isCancelled) {
+				try {
+					result = httpExecuteWithRetry(candidateHost, path);
+					setResult(result);
+					break;
+				} catch (AblyException.HostFailedException e) {
+					if(--retryCountRemaining < 0) {
+						setError(new ErrorInfo("Connection failed; no host available", 404, 80000));
+						break;
+					}
+					Log.d(TAG, "Connection failed to host `" + candidateHost + "`. Searching for new host...");
+					candidateHost = Hosts.getFallback(candidateHost);
+					Log.d(TAG, "Switched to `" + candidateHost + "`.");
+				} catch(AblyException e) {
+					setError(e.errorInfo);
+					break;
+				} finally {
+					disposeConnection();
+				}
+			}
+		}
+		private final String path;
+	}
+
+	/**
+	 * A class encapsulating a scheduled or in-process async HTTP request
+	 * @param <T>
+	 */
+	private abstract class AsyncRequest<T> implements Future<T> {
+		private AsyncRequest(
+				final Proxy proxy,
+				final String method,
+				final Param[] headers,
+				final Param[] params,
+				final RequestBody requestBody,
+				final boolean withCredentials,
+				final ResponseHandler<T> responseHandler,
+				final Callback<T> callback) {
+			this.proxy = (proxy == null) ? Proxy.NO_PROXY : proxy;
+			this.method = method;
+			this.headers = headers;
+			this.params = params;
+			this.requestBody = requestBody;
+			this.withCredentials = withCredentials;
+			this.responseHandler = responseHandler;
+			this.callback = callback;
+		}
+
+		/**************************
+		 *    Future<T> methods
+		 **************************/
+		@Override
+		public boolean cancel(boolean mayInterruptIfRunning) {
+			isCancelled = true;
+			return disposeConnection();
+		}
+		@Override
+		public boolean isCancelled() {
+			return isCancelled;
+		}
+		@Override
+		public boolean isDone() {
+			return isDone;
+		}
+		@Override
+		public T get() throws InterruptedException, ExecutionException {
+			synchronized(this) {
+				while(!isDone) {
+					wait();
+				}
+				if(err != null) {
+					throw new ExecutionException(AblyException.fromErrorInfo(err));
+				}
+			}
+			return result;
+		}
+		@Override
+		public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+			long remaining = unit.toMillis(timeout), deadline = System.currentTimeMillis() + remaining;
+			synchronized(this) {
+				while(remaining > 0) {
+					wait(remaining);
+					if(isDone) { break; }
+					remaining = deadline - System.currentTimeMillis();
+				}
+				if(!isDone) {
+					throw new TimeoutException();
+				}
+				if(err != null) {
+					throw new ExecutionException(AblyException.fromErrorInfo(err));
+				}
+			}
+			return result;
+		}
+
+		/**************************
+		 *        Private
+		 **************************/
+
+		protected synchronized void createConnection(URL url) throws AblyException {
+			try {
+				conn = (HttpURLConnection)url.openConnection(proxy);
+			} catch(IOException ioe) {
+				throw AblyException.fromThrowable(ioe);
+			}
+		}
+		protected T httpExecute() throws AblyException {
+			return http.httpExecute(conn, method, headers, requestBody, withCredentials, responseHandler);
+		}
+		protected T httpExecuteWithRetry(String host, String path) throws AblyException {
+			URL url = Http.buildURL(http.scheme, host, http.port, path, params);
+			return http.httpExecuteWithRetry(url, proxy, method, headers, requestBody, responseHandler);
+		}
+		protected void setResult(T result) {
+			synchronized(this) {
+				this.result = result;
+				this.isDone = true;
+				notifyAll();
+			}
+			if(callback != null) {
+				callback.onSuccess(result);
+			}
+		}
+		protected void setError(ErrorInfo err) {
+			synchronized(this) {
+				this.err = err;
+				this.isDone = true;
+				notifyAll();
+			}
+			if(callback != null) {
+				callback.onError(err);
+			}
+		}
+		protected synchronized boolean disposeConnection() {
+			boolean hasConnection = conn != null;
+			if(hasConnection) {
+				conn.disconnect();
+				conn = null;
+			}
+			return hasConnection;
+		}
+
+		protected HttpURLConnection conn;
+		protected T result;
+		protected ErrorInfo err;
+
+		protected final Proxy proxy;
+		protected final String method;
+		protected final Param[] headers;
+		protected final Param[] params;
+		protected final RequestBody requestBody;
+		protected final boolean withCredentials;
+		protected final ResponseHandler<T> responseHandler;
+		protected final Callback<T> callback;
+		protected boolean isCancelled = false;
+		protected boolean isDone = false;
+}
 
 	public AsyncHttp(Http http) {
 		super(DEFAULT_POOL_SIZE, MAX_POOL_SIZE, KEEP_ALIVE_TIME, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>());
@@ -65,7 +321,18 @@ public class AsyncHttp extends ThreadPoolExecutor {
 		this.setCorePoolSize(size);
 	}
 
-	public <T> void httpExecute(
+	/**
+	 * Make an asynchronous HTTP request to a given URL
+	 * @param url
+	 * @param method
+	 * @param headers
+	 * @param requestBody
+	 * @param withCredentials
+	 * @param responseHandler
+	 * @param callback
+	 * @return
+	 */
+	public <T> Future<T> httpExecute(
 			final URL url,
 			final String method,
 			final Param[] headers,
@@ -74,22 +341,23 @@ public class AsyncHttp extends ThreadPoolExecutor {
 			final ResponseHandler<T> responseHandler,
 			final Callback<T> callback) {
 
-		submit(new Runnable() {
-			@Override
-			public void run() {
-				T result = null;
-				try {
-					result = http.httpExecute(url, method, headers, requestBody, withCredentials, responseHandler);
-				} catch(AblyException e) {
-					callback.onError(e.errorInfo);
-					return;
-				}
-				callback.onSuccess(result);
-			}
-		});
+		UrlRequest<T> request = new UrlRequest<>(url, http.proxy, method, headers, null, requestBody, withCredentials, responseHandler, callback);
+		execute(request);
+		return request;
 	}
 
-	public <T> void ablyHttpExecute(
+	/**
+	 * Make an asynchronous HTTP request to an Ably endpoint, using the Ably auth credentials and fallback hosts if necessary
+	 * @param path
+	 * @param method
+	 * @param headers
+	 * @param params
+	 * @param requestBody
+	 * @param responseHandler
+	 * @param callback
+	 * @return
+	 */
+	public <T> Future<T> ablyHttpExecuteWithFallback(
 			final String path,
 			final String method,
 			final Param[] headers,
@@ -98,26 +366,36 @@ public class AsyncHttp extends ThreadPoolExecutor {
 			final ResponseHandler<T> responseHandler,
 			final Callback<T> callback) {
 
-		submit(new Runnable() {
-			@Override
-			public void run() {
-				T result = null;
-				ErrorInfo error = null;
-				try {
-					result = http.ablyHttpExecute(path, method, headers, params, requestBody, responseHandler);
-				} catch(AblyException e) {
-					error = e.errorInfo;
-				}
-				try {
-					if(error != null)
-						callback.onError(error);
-					else
-						callback.onSuccess(result);
-				} catch(Throwable t) {
-					Log.e(TAG, "Exception invoking callback", t);
-				}
-			}
-		});
+		AblyRequestWithFallback<T> request = new AblyRequestWithFallback<>(path, http.proxy, method, headers, null, requestBody, responseHandler, callback);
+		execute(request);
+		return request;
+	}
+
+	/**
+	 * Make an asynchronous HTTP request to an Ably endpoint, using the Ably auth credentials and reauthentication if necessary
+	 * @param host
+	 * @param path
+	 * @param method
+	 * @param headers
+	 * @param params
+	 * @param requestBody
+	 * @param responseHandler
+	 * @param callback
+	 * @return
+	 */
+	public <T> Future<T> ablyHttpExecuteWithRetry(
+			final String host,
+			final String path,
+			final String method,
+			final Param[] headers,
+			final Param[] params,
+			final RequestBody requestBody,
+			final ResponseHandler<T> responseHandler,
+			final Callback<T> callback) {
+
+		AblyRequestWithRetry<T> request = new AblyRequestWithRetry<>(host, path, http.proxy, method, headers, null, requestBody, responseHandler, callback);
+		execute(request);
+		return request;
 	}
 
 	public void dispose() {

--- a/lib/src/main/java/io/ably/lib/http/Http.java
+++ b/lib/src/main/java/io/ably/lib/http/Http.java
@@ -375,7 +375,8 @@ public class Http {
 		HttpURLConnection conn = null;
 		try {
 			conn = (HttpURLConnection)url.openConnection(proxy);
-			return httpExecute(conn, method, headers, requestBody, withCredentials, (proxy != Proxy.NO_PROXY), responseHandler);
+			boolean withProxyCredentials = (proxy != Proxy.NO_PROXY) && (proxyAuth != null);
+			return httpExecute(conn, method, headers, requestBody, withCredentials, withProxyCredentials, responseHandler);
 		} catch(IOException ioe) {
 			throw AblyException.fromThrowable(ioe);
 		} finally {

--- a/lib/src/main/java/io/ably/lib/http/HttpAuth.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpAuth.java
@@ -1,0 +1,151 @@
+package io.ably.lib.http;
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Random;
+
+import io.ably.lib.types.AblyException;
+import io.ably.lib.types.ErrorInfo;
+import io.ably.lib.util.Base64Coder;
+
+class HttpAuth {
+
+	HttpAuth(String username, String password) {
+		this.username = username;
+		this.password = password;
+	}
+
+	public String getHeader(String authHeader, String method, String uri, byte[] requestBody) throws AblyException {
+		int delimiterIdx = authHeader.indexOf(' ');
+		if(delimiterIdx == -1) { throw AblyException.fromErrorInfo(new ErrorInfo("Invalid authenticate header", 40000, 400)); }
+		String authScheme = authHeader.substring(0,  delimiterIdx).trim();
+		String authDetails = authHeader.substring(delimiterIdx + 1).trim();
+		if(authScheme.equals("Basic")) {
+			return "Basic " + Base64Coder.encodeString(username + ':' + password);
+		}
+		if(authScheme.equals("Digest")) {
+			return getDigestHeader(authDetails, method, uri, requestBody);
+		}
+		return null;
+	}
+
+	private String getDigestHeader(String detailsString, String method, String uri, byte[] requestBody) throws AblyException {
+		HashMap<String, String> authFields = splitAuthFields(detailsString);
+
+		String realm = authFields.get("realm");
+		String HA1 = digestString(username + ':' + realm + ':' + password);
+
+		String qop = authFields.get("qop");
+		if(qop != null) {
+			String[] qops = qop.split(",");
+			qop = null;
+			for(String candidateQop : qops) {
+				if(requestBody != null && candidateQop.trim().equals("auth-int")) {
+					qop = "auth-int";
+					break;
+				}
+				if(candidateQop.trim().equals("auth")) {
+					qop = "auth";
+					break;
+				}
+			}
+		}
+		String HA2, HA3, nc = null, cnonce = null, nonce = authFields.get("nonce");
+		if(qop == null) {
+			HA2 = digestString(method + ':' + uri);
+			HA3 = digestString(HA1 + ':' + nonce + ':' + HA2);
+		} else if(qop.equals("auth")) {
+			nc = String.format("%05d", ncCounter++);
+			cnonce = getNonce();
+			HA2 = digestString(method + ':' + uri);
+			HA3 = digestString(HA1 + ':' + nonce + ':' + nc + ':' + cnonce + ':' + qop + ':' + HA2);
+		} else {
+			nc = String.format("%05d", ncCounter++);
+			cnonce = getNonce();
+			HA2 = digestString(method + ':' + uri + ':' + digestBytes(requestBody));
+			HA3 = digestString(HA1 + ':' + nonce + ':' + nc + ':' + cnonce + ':' + qop + ':' + HA2);
+		}
+
+		String opaque = authFields.get("opaque");
+		StringBuilder sb = new StringBuilder(128);
+		sb.append("Digest ");
+		sb.append("username"    ).append("=\"").append(username).append("\",");
+		sb.append("realm"       ).append("=\"").append(realm   ).append("\",");
+		sb.append("nonce"       ).append("=\"").append(nonce   ).append("\",");
+		sb.append("uri"         ).append("=\"").append(uri     ).append("\",");
+
+		if(qop != null) {
+			sb.append("qop"     ).append("=\"").append(qop     ).append("\",");
+			sb.append("nc"      ).append("=\"").append(nc      ).append("\",");
+			sb.append("cnonce"  ).append("=\"").append(cnonce  ).append("\",");
+		}
+
+		if(opaque != null) {
+			sb.append("response").append("=\"").append(HA3     ).append("\",");
+			sb.append("opaque"  ).append("=\"").append(opaque  ).append("\"");
+		} else {
+			sb.append("response").append("=\"").append(HA3     ).append("\"");
+		}
+		return sb.toString();
+	}
+
+	private static HashMap<String, String> splitAuthFields(String detailsString) {
+        HashMap<String, String> values = new HashMap<String, String>();
+        String keyValueArray[] = detailsString.split(",");
+        for (String keyval : keyValueArray) {
+            if (keyval.contains("=")) {
+                String key = keyval.substring(0, keyval.indexOf("="));
+                String value = keyval.substring(keyval.indexOf("=") + 1);
+                values.put(key.trim(), value.replaceAll("\"", "").trim());
+            }
+        }
+        return values;
+	}
+
+	private static String digestBytes(byte[] buf) {
+		md5.reset();
+		md5.update(buf);
+		byte[] ha1bytes = md5.digest();
+		return bytesToHexString(ha1bytes);
+	}
+
+	private static String digestString(String text) {
+		try{
+			return digestBytes(text.getBytes("ISO-8859-1"));
+		}
+		catch(UnsupportedEncodingException e){ return null; }
+	}
+
+	private static final String HEX_LOOKUP = "0123456789abcdef";
+	private static String bytesToHexString(byte[] bytes)
+	{
+		StringBuilder sb = new StringBuilder(bytes.length * 2);
+		for(int i = 0; i < bytes.length; i++){
+			sb.append(HEX_LOOKUP.charAt((bytes[i] & 0xF0) >> 4));
+			sb.append(HEX_LOOKUP.charAt((bytes[i] & 0x0F) >> 0));
+		}
+		return sb.toString();
+	}
+
+    private static String getNonce() {
+        String fmtDate = (new SimpleDateFormat("yyyy:MM:dd:hh:mm:ss")).format(new Date());
+        Integer randomInt = (new Random(100000)).nextInt();
+        return digestString(fmtDate + randomInt.toString());
+    }
+
+	private static MessageDigest md5 = null;
+	static {
+		try{
+			md5 = MessageDigest.getInstance("MD5");
+		}
+		catch(NoSuchAlgorithmException e) {}
+	}
+
+	private static int ncCounter = 1;
+	private final String username;
+	private final String password;
+}

--- a/lib/src/main/java/io/ably/lib/http/HttpAuth.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpAuth.java
@@ -4,45 +4,121 @@ import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Random;
 
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.ErrorInfo;
 import io.ably.lib.util.Base64Coder;
 
-class HttpAuth {
+public class HttpAuth {
 
-	HttpAuth(String username, String password) {
+	public enum Type {
+		BASIC,
+		DIGEST,
+		X_ABLY_TOKEN
+	}
+
+	HttpAuth(String username, String password, Type prefType) {
 		this.username = username;
 		this.password = password;
+		this.prefType = prefType;
 	}
 
-	public String getHeader(String authHeader, String method, String uri, byte[] requestBody) throws AblyException {
-		int delimiterIdx = authHeader.indexOf(' ');
-		if(delimiterIdx == -1) { throw AblyException.fromErrorInfo(new ErrorInfo("Invalid authenticate header", 40000, 400)); }
-		String authScheme = authHeader.substring(0,  delimiterIdx).trim();
-		String authDetails = authHeader.substring(delimiterIdx + 1).trim();
-		if(authScheme.equals("Basic")) {
+	boolean hasChallenge() {
+		return (type != null);
+	}
+
+	/**
+	 * Split a compound authenticate header string to get details for each auth type
+	 * @param authenticateHeaders
+	 * @return
+	 * @throws AblyException
+	 */
+	public static Map<Type, String> sortAuthenticateHeaders(Collection<String> authenticateHeaders) throws AblyException {
+		Map<Type, String> sortedHeaders = new HashMap<>();
+		for(String header : authenticateHeaders) {
+			int delimiterIdx = header.indexOf(' ');
+			if(delimiterIdx == -1) { throw AblyException.fromErrorInfo(new ErrorInfo("Invalid authenticate header (no delimiter)", 40000, 400)); }
+			String authType = header.substring(0,  delimiterIdx).trim();
+			String authDetails = header.substring(delimiterIdx + 1).trim();
+			sortedHeaders.put(Type.valueOf(authType.toUpperCase().replace('-', '_')), authDetails);
+		}
+		return sortedHeaders;
+	}
+
+	/**
+	 * Get authorization header based on the last-received server nonce.
+	 * This increments nc, and generates a new cnonce
+	 * @param method
+	 * @param uri
+	 * @param requestBody
+	 * @return
+	 * @throws AblyException
+	 */
+	public String getAuthorizationHeader(String method, String uri, byte[] requestBody) throws AblyException {
+		switch(type) {
+		case BASIC:
 			return "Basic " + Base64Coder.encodeString(username + ':' + password);
+		case DIGEST:
+			return getDigestHeader(method, uri, requestBody);
+		default:
+			return null;
 		}
-		if(authScheme.equals("Digest")) {
-			return getDigestHeader(authDetails, method, uri, requestBody);
-		}
-		return null;
 	}
 
-	private String getDigestHeader(String detailsString, String method, String uri, byte[] requestBody) throws AblyException {
+	/**
+	 * Process a challenge; this selects the auth type to use and caches all
+	 * possible values based on the challenge in the case of digest auth
+	 * @param authenticateHeaders
+	 * @throws AblyException
+	 */
+	public void processAuthenticateHeaders(Map<Type, String> authenticateHeaders) throws AblyException {
+		String authDetails = authenticateHeaders.get(type = prefType);
+		if(authDetails == null) {
+			Entry<Type, String> firstEntry = authenticateHeaders.entrySet().iterator().next();
+			if(firstEntry == null) { throw AblyException.fromErrorInfo(new ErrorInfo("Invalid authenticate header (no entries)", 40000, 400)); }
+			type = firstEntry.getKey();
+			authDetails = firstEntry.getValue();
+		}
+		if(type == Type.DIGEST) {
+			processDigestHeader(authDetails);
+		}
+	}
+
+	/**
+	 * For digest auth, process the challenge details
+	 * @param detailsString
+	 * @throws AblyException
+	 */
+	private synchronized void processDigestHeader(String detailsString) throws AblyException {
 		HashMap<String, String> authFields = splitAuthFields(detailsString);
+		realm = authFields.get("realm");
+		nonce = authFields.get("nonce");
+		opaque = authFields.get("opaque");
+		HA1 = digestString(username + ':' + realm + ':' + password);
 
-		String realm = authFields.get("realm");
-		String HA1 = digestString(username + ':' + realm + ':' + password);
+		String qopStr = authFields.get("qop");
+		if(qopStr != null) {
+			qops = qopStr.split(",");
+		}
+	}
 
-		String qop = authFields.get("qop");
-		if(qop != null) {
-			String[] qops = qop.split(",");
-			qop = null;
+	/**
+	 * Get the Digest authorization header for a given request, based on already-processed challenge
+	 * @param method
+	 * @param uri
+	 * @param requestBody
+	 * @return
+	 * @throws AblyException
+	 */
+	private String getDigestHeader(String method, String uri, byte[] requestBody) throws AblyException {
+		String qop = null;
+		if(qops != null) {
 			for(String candidateQop : qops) {
 				if(requestBody != null && candidateQop.trim().equals("auth-int")) {
 					qop = "auth-int";
@@ -54,33 +130,34 @@ class HttpAuth {
 				}
 			}
 		}
-		String HA2, HA3, nc = null, cnonce = null, nonce = authFields.get("nonce");
+
+		String HA2, HA3, nc = null, cnonce = null;
 		if(qop == null) {
 			HA2 = digestString(method + ':' + uri);
 			HA3 = digestString(HA1 + ':' + nonce + ':' + HA2);
 		} else if(qop.equals("auth")) {
-			nc = String.format("%05d", ncCounter++);
-			cnonce = getNonce();
+			nc = String.format("%08X", ncCounter++);
+			cnonce = getClientNonce();
 			HA2 = digestString(method + ':' + uri);
 			HA3 = digestString(HA1 + ':' + nonce + ':' + nc + ':' + cnonce + ':' + qop + ':' + HA2);
 		} else {
-			nc = String.format("%05d", ncCounter++);
-			cnonce = getNonce();
+			nc = String.format("%08X", ncCounter++);
+			cnonce = getClientNonce();
 			HA2 = digestString(method + ':' + uri + ':' + digestBytes(requestBody));
 			HA3 = digestString(HA1 + ':' + nonce + ':' + nc + ':' + cnonce + ':' + qop + ':' + HA2);
 		}
 
-		String opaque = authFields.get("opaque");
 		StringBuilder sb = new StringBuilder(128);
 		sb.append("Digest ");
 		sb.append("username"    ).append("=\"").append(username).append("\",");
 		sb.append("realm"       ).append("=\"").append(realm   ).append("\",");
 		sb.append("nonce"       ).append("=\"").append(nonce   ).append("\",");
 		sb.append("uri"         ).append("=\"").append(uri     ).append("\",");
+		sb.append("algorithm"   ).append("=\"").append("MD5"   ).append("\",");
 
 		if(qop != null) {
 			sb.append("qop"     ).append("=\"").append(qop     ).append("\",");
-			sb.append("nc"      ).append("=\"").append(nc      ).append("\",");
+			sb.append("nc"      ).append("="  ).append(nc      ).append(",");
 			sb.append("cnonce"  ).append("=\"").append(cnonce  ).append("\",");
 		}
 
@@ -131,10 +208,10 @@ class HttpAuth {
 		return sb.toString();
 	}
 
-    private static String getNonce() {
+    private static String getClientNonce() {
         String fmtDate = (new SimpleDateFormat("yyyy:MM:dd:hh:mm:ss")).format(new Date());
         Integer randomInt = (new Random(100000)).nextInt();
-        return digestString(fmtDate + randomInt.toString());
+        return digestString(fmtDate + randomInt.toString()).substring(0,  8);
     }
 
 	private static MessageDigest md5 = null;
@@ -145,7 +222,16 @@ class HttpAuth {
 		catch(NoSuchAlgorithmException e) {}
 	}
 
-	private static int ncCounter = 1;
+	private String realm;
+	private String nonce;
+	private String[] qops;
+	private String opaque;
+	private Type type;
+	private int ncCounter = 1;
+
+	private String HA1;
+
 	private final String username;
 	private final String password;
+	private final Type prefType;
 }

--- a/lib/src/main/java/io/ably/lib/types/AblyException.java
+++ b/lib/src/main/java/io/ably/lib/types/AblyException.java
@@ -16,7 +16,7 @@ public class AblyException extends Exception {
 	/**
 	 * Constructor for use where there is an ErrorInfo available
 	 */
-	AblyException(Throwable throwable, ErrorInfo reason) {
+	protected AblyException(Throwable throwable, ErrorInfo reason) {
 		super(throwable);
 		this.errorInfo = reason;
 	}
@@ -49,8 +49,6 @@ public class AblyException extends Exception {
 
 		return new AblyException(t, ErrorInfo.fromThrowable(t));
 	}
-
-
 
 	public static class HostFailedException extends AblyException {
 		private static final long serialVersionUID = 1L;

--- a/lib/src/main/java/io/ably/lib/types/ClientOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ClientOptions.java
@@ -113,6 +113,12 @@ public class ClientOptions extends AuthOptions {
 	public String recover;
 
 	/**
+	 * Proxy settings
+	 */
+	public String proxyHost = null;
+	public int proxyPort = 0;
+
+	/**
 	 * Spec: TO313
 	 */
 	public int httpOpenTimeout = Defaults.TIMEOUT_HTTP_OPEN;

--- a/lib/src/main/java/io/ably/lib/types/ClientOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ClientOptions.java
@@ -115,8 +115,7 @@ public class ClientOptions extends AuthOptions {
 	/**
 	 * Proxy settings
 	 */
-	public String proxyHost = null;
-	public int proxyPort = 0;
+	public ProxyOptions proxy;
 
 	/**
 	 * Spec: TO313

--- a/lib/src/main/java/io/ably/lib/types/ProxyOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ProxyOptions.java
@@ -1,9 +1,12 @@
 package io.ably.lib.types;
 
+import io.ably.lib.http.HttpAuth;
+
 public class ProxyOptions {
 	public String host;
 	public int port;
 	public String username;
 	public String password;
 	public String[] nonProxyHosts;
+	public HttpAuth.Type prefAuthType = HttpAuth.Type.BASIC;
 }

--- a/lib/src/main/java/io/ably/lib/types/ProxyOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ProxyOptions.java
@@ -1,0 +1,9 @@
+package io.ably.lib.types;
+
+public class ProxyOptions {
+	public String host;
+	public int port;
+	public String username;
+	public String password;
+	public String[] nonProxyHosts;
+}

--- a/lib/src/test/java/io/ably/lib/http/HttpTest.java
+++ b/lib/src/test/java/io/ably/lib/http/HttpTest.java
@@ -99,12 +99,12 @@ public class HttpTest {
 			List<String> urlArgumentStack;
 
 			@Override
-			<T> T httpExecute(URL url, String method, Param[] headers, RequestBody requestBody, boolean withCredentials, ResponseHandler<T> responseHandler) throws AblyException {
+			<T> T httpExecute(URL url, String method, Param[] headers, RequestBody requestBody, ResponseHandler<T> responseHandler) throws AblyException {
 				// Store a copy of given argument
 				urlArgumentStack.add(url.getHost());
 
 				// Execute the original method without changing behavior
-				return super.httpExecute(url, method, headers, requestBody, withCredentials, responseHandler);
+				return super.httpExecute(url, method, headers, requestBody, responseHandler);
 			}
 
 			public Http setUrlArgumentStack(List<String> urlArgumentStack) {
@@ -174,7 +174,6 @@ public class HttpTest {
 						anyString(), /* Ignore */
 						aryEq(new Param[0]), /* Ignore */
 						any(Http.RequestBody.class), /* Ignore */
-						anyBoolean(), /* Ignore */
 						any(Http.ResponseHandler.class) /* Ignore */
 				);
 
@@ -198,7 +197,6 @@ public class HttpTest {
 						anyString(), /* Ignore */
 						aryEq(new Param[0]), /* Ignore */
 						any(Http.RequestBody.class), /* Ignore */
-						anyBoolean(), /* Ignore */
 						any(Http.ResponseHandler.class) /* Ignore */
 				);
 
@@ -240,7 +238,6 @@ public class HttpTest {
 						anyString(), /* Ignore */
 						aryEq(new Param[0]), /* Ignore */
 						any(Http.RequestBody.class), /* Ignore */
-						anyBoolean(), /* Ignore */
 						any(Http.ResponseHandler.class) /* Ignore */
 				);
 
@@ -266,7 +263,6 @@ public class HttpTest {
 						anyString(), /* Ignore */
 						aryEq(new Param[0]), /* Ignore */
 						any(Http.RequestBody.class), /* Ignore */
-						anyBoolean(), /* Ignore */
 						any(Http.ResponseHandler.class) /* Ignore */
 				);
 
@@ -308,7 +304,6 @@ public class HttpTest {
 						anyString(), /* Ignore */
 						aryEq(new Param[0]), /* Ignore */
 						any(Http.RequestBody.class), /* Ignore */
-						anyBoolean(), /* Ignore */
 						any(Http.ResponseHandler.class) /* Ignore */
 				);
 
@@ -342,7 +337,6 @@ public class HttpTest {
 						anyString(), /* Ignore */
 						aryEq(new Param[0]), /* Ignore */
 						any(Http.RequestBody.class), /* Ignore */
-						anyBoolean(), /* Ignore */
 						any(Http.ResponseHandler.class) /* Ignore */
 				);
 	}
@@ -381,7 +375,6 @@ public class HttpTest {
 						anyString(), /* Ignore */
 						aryEq(new Param[0]), /* Ignore */
 						any(Http.RequestBody.class), /* Ignore */
-						anyBoolean(), /* Ignore */
 						any(Http.ResponseHandler.class) /* Ignore */
 				);
 
@@ -406,7 +399,6 @@ public class HttpTest {
 						anyString(), /* Ignore */
 						aryEq(new Param[0]), /* Ignore */
 						any(Http.RequestBody.class), /* Ignore */
-						anyBoolean(), /* Ignore */
 						any(Http.ResponseHandler.class) /* Ignore */
 				);
 
@@ -457,7 +449,6 @@ public class HttpTest {
 						anyString(), /* Ignore */
 						aryEq(new Param[0]), /* Ignore */
 						any(Http.RequestBody.class), /* Ignore */
-						anyBoolean(), /* Ignore */
 						any(Http.ResponseHandler.class) /* Ignore */
 				);
 
@@ -503,7 +494,7 @@ public class HttpTest {
 			hfe = null;
 
 			try {
-				http.httpExecute(url, Http.GET, new Param[0], requestBody, false, null);
+				http.httpExecute(url, Http.GET, new Param[0], requestBody, null);
 			} catch (AblyException.HostFailedException e) {
 				hfe = e;
 			}
@@ -537,7 +528,7 @@ public class HttpTest {
 			url = new URL("http://localhost:" + server.getListeningPort() + "/status/" + statusCode);
 
 			try {
-				http.httpExecute(url, Http.GET, new Param[0], requestBody, false, null);
+				http.httpExecute(url, Http.GET, new Param[0], requestBody, null);
 			} catch (AblyException.HostFailedException e) {
 				Assert.fail("Informal status code " + statusCode + " shouldn't throw an exception");
 			} catch (Exception e) {
@@ -552,7 +543,7 @@ public class HttpTest {
 			url = new URL("http://localhost:" + server.getListeningPort() + "/status/" + statusCode);
 
 			try {
-				http.httpExecute(url, Http.GET, new Param[0], requestBody, false, null);
+				http.httpExecute(url, Http.GET, new Param[0], requestBody, null);
 			} catch (AblyException.HostFailedException e) {
 				Assert.fail("Multiple choices status code " + statusCode + " shouldn't throw an exception");
 			} catch (Exception e) {
@@ -567,7 +558,7 @@ public class HttpTest {
 			url = new URL("http://localhost:" + server.getListeningPort() + "/status/" + statusCode);
 
 			try {
-				http.httpExecute(url, Http.GET, new Param[0], requestBody, false, null);
+				http.httpExecute(url, Http.GET, new Param[0], requestBody, null);
 			} catch (AblyException.HostFailedException e) {
 				Assert.fail("Client error status code " + statusCode + " shouldn't throw an exception");
 			} catch (Exception e) {

--- a/lib/src/test/java/io/ably/lib/test/rest/RestProxyTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestProxyTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
+import io.ably.lib.http.HttpAuth;
 import io.ably.lib.rest.AblyRest;
 import io.ably.lib.test.common.Setup;
 import io.ably.lib.test.common.Setup.TestVars;
@@ -34,7 +35,7 @@ public class RestProxyTest {
 			AblyRest ably = new AblyRest(opts);
 
 			/* attempt the call, expecting no exception */
-			PaginatedResult<Stats> stats = ably.stats(null);
+			ably.stats(null);
 			fail("proxy_simple_invalid_host: call succeeded unexpectedly");
 		} catch (AblyException e) {
 			assertEquals("Verify expected error code", e.errorInfo.code, 80000);
@@ -58,7 +59,7 @@ public class RestProxyTest {
 			AblyRest ably = new AblyRest(opts);
 
 			/* attempt the call, expecting no exception */
-			PaginatedResult<Stats> stats = ably.stats(null);
+			ably.stats(null);
 			fail("proxy_simple_invalid_port: call succeeded unexpectedly");
 		} catch (AblyException e) {
 			assertEquals("Verify expected error code", e.errorInfo.code, 80000);
@@ -66,10 +67,38 @@ public class RestProxyTest {
 	}
 
 	/**
+	 * Check access to stats API via proxy, non-TLS
+	 */
+	@Test
+	public void proxy_simple_plain() {
+		try {
+			/* setup client */
+			TestVars testVars = Setup.getTestVars();
+			ClientOptions opts = new ClientOptions(testVars.keys[0].keyStr);
+			testVars.fillInOptions(opts);
+			opts.clientId = "testClientId"; /* force use of token auth */
+			opts.tls = false;
+			opts.proxy = new ProxyOptions() {{
+				host = "sandbox-proxy.ably.io";
+				port = 6128;
+			}};
+			AblyRest ably = new AblyRest(opts);
+
+			/* attempt the call, expecting no exception */
+			PaginatedResult<Stats> stats = ably.stats(null);
+			assertNotNull("Expected non-null stats", stats);
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("proxy_simple_plain: Unexpected exception");
+			return;
+		}
+	}
+
+	/**
 	 * Check access to stats API via proxy
 	 */
 	@Test
-	public void proxy_simple() {
+	public void proxy_simple_tls() {
 		try {
 			/* setup client */
 			TestVars testVars = Setup.getTestVars();
@@ -86,16 +115,77 @@ public class RestProxyTest {
 			assertNotNull("Expected non-null stats", stats);
 		} catch (AblyException e) {
 			e.printStackTrace();
-			fail("proxy_simple: Unexpected exception");
+			fail("proxy_simple_tls: Unexpected exception");
 			return;
 		}
 	}
 
 	/**
-	 * Check access to stats API via proxy with authentication
+	 * Check access to stats API via proxy with authentication, non-tls
 	 */
 	@Test
-	public void proxy_basic_auth() {
+	public void proxy_basic_auth_plain() {
+		try {
+			/* setup client */
+			TestVars testVars = Setup.getTestVars();
+			ClientOptions opts = new ClientOptions(testVars.keys[0].keyStr);
+			testVars.fillInOptions(opts);
+			opts.clientId = "testClientId";
+			opts.tls = false;
+			opts.proxy = new ProxyOptions() {{
+				host = "sandbox-proxy.ably.io";
+				port = 6129;
+				username = "ably";
+				password = "password";
+			}};
+			AblyRest ably = new AblyRest(opts);
+	
+			/* attempt the call, expecting no exception */
+			PaginatedResult<Stats> stats = ably.stats(null);
+			assertNotNull("Expected non-null stats", stats);
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("proxy_basic_auth_plain: Unexpected exception");
+			return;
+		}
+	}
+
+	/**
+	 * Check access to stats API via proxy with authentication, non-tls
+	 */
+	//@Test
+	public void proxy_digest_auth_plain() {
+		try {
+			/* setup client */
+			TestVars testVars = Setup.getTestVars();
+			ClientOptions opts = new ClientOptions(testVars.keys[0].keyStr);
+			testVars.fillInOptions(opts);
+			opts.clientId = "testClientId";
+			opts.tls = false;
+			opts.proxy = new ProxyOptions() {{
+				host = "sandbox-proxy.ably.io";
+				port = 6129;
+				username = "ably";
+				password = "digest-password";
+				prefAuthType = HttpAuth.Type.DIGEST;
+			}};
+			AblyRest ably = new AblyRest(opts);
+	
+			/* attempt the call, expecting no exception */
+			PaginatedResult<Stats> stats = ably.stats(null);
+			assertNotNull("Expected non-null stats", stats);
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("proxy_digest_auth_plain: Unexpected exception");
+			return;
+		}
+	}
+
+	/**
+	 * Check access to stats API via proxy with authentication, tls
+	 */
+	//@Test
+	public void proxy_basic_auth_tls() {
 		try {
 			/* setup client */
 			TestVars testVars = Setup.getTestVars();
@@ -114,7 +204,7 @@ public class RestProxyTest {
 			assertNotNull("Expected non-null stats", stats);
 		} catch (AblyException e) {
 			e.printStackTrace();
-			fail("proxy_simple: Unexpected exception");
+			fail("proxy_basic_auth_tls: Unexpected exception");
 			return;
 		}
 	}

--- a/lib/src/test/java/io/ably/lib/test/rest/RestProxyTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestProxyTest.java
@@ -1,0 +1,121 @@
+package io.ably.lib.test.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import io.ably.lib.rest.AblyRest;
+import io.ably.lib.test.common.Setup;
+import io.ably.lib.test.common.Setup.TestVars;
+import io.ably.lib.types.AblyException;
+import io.ably.lib.types.ClientOptions;
+import io.ably.lib.types.PaginatedResult;
+import io.ably.lib.types.ProxyOptions;
+import io.ably.lib.types.Stats;
+
+public class RestProxyTest {
+
+	/**
+	 * Check access to stats API via proxy with invalid host, expecting failure
+	 */
+	@Test
+	public void proxy_simple_invalid_host() {
+		try {
+			/* setup client */
+			TestVars testVars = Setup.getTestVars();
+			ClientOptions opts = new ClientOptions(testVars.keys[0].keyStr);
+			testVars.fillInOptions(opts);
+			opts.proxy = new ProxyOptions() {{
+				host = "not-sandbox-proxy.ably.io";
+				port = 6128;
+			}};
+			AblyRest ably = new AblyRest(opts);
+
+			/* attempt the call, expecting no exception */
+			PaginatedResult<Stats> stats = ably.stats(null);
+			fail("proxy_simple_invalid_host: call succeeded unexpectedly");
+		} catch (AblyException e) {
+			assertEquals("Verify expected error code", e.errorInfo.code, 80000);
+		}
+	}
+
+	/**
+	 * Check access to stats API via proxy with invalid port, expecting failure
+	 */
+	@Test
+	public void proxy_simple_invalid_port() {
+		try {
+			/* setup client */
+			TestVars testVars = Setup.getTestVars();
+			ClientOptions opts = new ClientOptions(testVars.keys[0].keyStr);
+			testVars.fillInOptions(opts);
+			opts.proxy = new ProxyOptions() {{
+				host = "sandbox-proxy.ably.io";
+				port = 6127;
+			}};
+			AblyRest ably = new AblyRest(opts);
+
+			/* attempt the call, expecting no exception */
+			PaginatedResult<Stats> stats = ably.stats(null);
+			fail("proxy_simple_invalid_port: call succeeded unexpectedly");
+		} catch (AblyException e) {
+			assertEquals("Verify expected error code", e.errorInfo.code, 80000);
+		}
+	}
+
+	/**
+	 * Check access to stats API via proxy
+	 */
+	@Test
+	public void proxy_simple() {
+		try {
+			/* setup client */
+			TestVars testVars = Setup.getTestVars();
+			ClientOptions opts = new ClientOptions(testVars.keys[0].keyStr);
+			testVars.fillInOptions(opts);
+			opts.proxy = new ProxyOptions() {{
+				host = "sandbox-proxy.ably.io";
+				port = 6128;
+			}};
+			AblyRest ably = new AblyRest(opts);
+
+			/* attempt the call, expecting no exception */
+			PaginatedResult<Stats> stats = ably.stats(null);
+			assertNotNull("Expected non-null stats", stats);
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("proxy_simple: Unexpected exception");
+			return;
+		}
+	}
+
+	/**
+	 * Check access to stats API via proxy with authentication
+	 */
+	@Test
+	public void proxy_basic_auth() {
+		try {
+			/* setup client */
+			TestVars testVars = Setup.getTestVars();
+			ClientOptions opts = new ClientOptions(testVars.keys[0].keyStr);
+			testVars.fillInOptions(opts);
+			opts.proxy = new ProxyOptions() {{
+				host = "sandbox-proxy.ably.io";
+				port = 6129;
+				username = "ably";
+				password = "password";
+			}};
+			AblyRest ably = new AblyRest(opts);
+	
+			/* attempt the call, expecting no exception */
+			PaginatedResult<Stats> stats = ably.stats(null);
+			assertNotNull("Expected non-null stats", stats);
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("proxy_simple: Unexpected exception");
+			return;
+		}
+	}
+}

--- a/lib/src/test/java/io/ably/lib/test/rest/RestProxyTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestProxyTest.java
@@ -165,8 +165,8 @@ public class RestProxyTest {
 			opts.proxy = new ProxyOptions() {{
 				host = "sandbox-proxy.ably.io";
 				port = 6129;
-				username = "ably";
-				password = "digest-password";
+				username = "ably-digest";
+				password = "password";
 				prefAuthType = HttpAuth.Type.DIGEST;
 			}};
 			AblyRest ably = new AblyRest(opts);

--- a/lib/src/test/java/io/ably/lib/test/rest/RestSuite.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestSuite.java
@@ -13,16 +13,16 @@ import io.ably.lib.test.common.Setup;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-	RestAppStatsTest.class,
-	RestInitTest.class,
-	RestTimeTest.class,
-	RestAuthTest.class,
-	RestTokenTest.class,
-	RestCapabilityTest.class,
-	RestChannelHistoryTest.class,
-	RestChannelPublishTest.class,
-	RestCryptoTest.class,
-	RestPresenceTest.class,
+//	RestAppStatsTest.class,
+//	RestInitTest.class,
+//	RestTimeTest.class,
+//	RestAuthTest.class,
+//	RestTokenTest.class,
+//	RestCapabilityTest.class,
+//	RestChannelHistoryTest.class,
+//	RestChannelPublishTest.class,
+//	RestCryptoTest.class,
+//	RestPresenceTest.class,
 	RestProxyTest.class
 })
 public class RestSuite {

--- a/lib/src/test/java/io/ably/lib/test/rest/RestSuite.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestSuite.java
@@ -22,7 +22,8 @@ import io.ably.lib.test.common.Setup;
 	RestChannelHistoryTest.class,
 	RestChannelPublishTest.class,
 	RestCryptoTest.class,
-	RestPresenceTest.class
+	RestPresenceTest.class,
+	RestProxyTest.class
 })
 public class RestSuite {
 

--- a/lib/src/test/java/io/ably/lib/test/rest/RestSuite.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestSuite.java
@@ -13,16 +13,16 @@ import io.ably.lib.test.common.Setup;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-//	RestAppStatsTest.class,
-//	RestInitTest.class,
-//	RestTimeTest.class,
-//	RestAuthTest.class,
-//	RestTokenTest.class,
-//	RestCapabilityTest.class,
-//	RestChannelHistoryTest.class,
-//	RestChannelPublishTest.class,
-//	RestCryptoTest.class,
-//	RestPresenceTest.class,
+	RestAppStatsTest.class,
+	RestInitTest.class,
+	RestTimeTest.class,
+	RestAuthTest.class,
+	RestTokenTest.class,
+	RestCapabilityTest.class,
+	RestChannelHistoryTest.class,
+	RestChannelPublishTest.class,
+	RestCryptoTest.class,
+	RestPresenceTest.class,
 	RestProxyTest.class
 })
 public class RestSuite {


### PR DESCRIPTION
This PR adds partial support for proxies for the ably-java library.

Current limitations:

- HTTP support only; no support for websockets;
- Basic auth for proxy authentication only; digest support is implemented but tests are failing;
- no support for proxy authentication over TLS, because user-supplied headers on a `HttpURLConnection` are not set on any HTTP `CONNECT` request used to initiate a tunnel.

Partially-fixes: https://github.com/ably/ably-java/issues/120
Fixes: https://github.com/ably/ably-java/issues/92