### PR TITLE
Fixed param order mix-up in new RestAuthAttributeTest.auth_authorise_…

### DIFF
--- a/lib/src/test/java/io/ably/lib/test/rest/RestAuthAttributeTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestAuthAttributeTest.java
@@ -306,7 +306,7 @@ public class RestAuthAttributeTest {
 			}};
 
 			/* authorise with custom AuthOptions */
-			TokenDetails tokenDetails2 = ably.auth.authorise(null, authOptions);
+			TokenDetails tokenDetails2 = ably.auth.authorise(authOptions, null);
 
 			/* Verify that,
 			 * tokenDetails1 and tokenDetails2 aren't null,


### PR DESCRIPTION
…force test

Param order to authorise() will change in 0.9 to match spec, but in 0.8
remains the wrong way round.