### PR TITLE
New test RealtimeResumeTest.resume_none

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -627,6 +627,12 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	private void handleStateRequest() {
 		boolean handled = false;
 		switch(requestedState.state) {
+		case disconnected:
+			if(transport != null) {
+				transport.close(false);
+				handled = true;
+			}
+			break;
 		case failed:
 			if(transport != null) {
 				transport.abort(requestedState.reason);


### PR DESCRIPTION
This tests resuming of a channel that has had no messages. It passes,
but, if you turn on logging, you get a caught null pointer exception on
the way due to an unexpected ack from the server. I am adding this test
just to illustrate that in realtime issue
https://github.com/ably/realtime/issues/748
(since fixed)
