### PR TITLE
0.9 fallbackHostUseDefault

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/Hosts.java
+++ b/lib/src/main/java/io/ably/lib/transport/Hosts.java
@@ -18,6 +18,7 @@ public class Hosts {
 	private final String defaultHost;
 	private final String[] fallbackHosts;
 	private final boolean fallbackHostsIsDefault;
+	private final boolean fallbackHostsUseDefault;
 
 	/**
 	 * Create Hosts object
@@ -55,6 +56,7 @@ public class Hosts {
 		} else {
 			setHost(defaultHost);
 		}
+		fallbackHostsUseDefault = options.fallbackHostsUseDefault;
 		if (options.fallbackHosts == null) {
 			fallbackHosts = Arrays.copyOf(Defaults.HOST_FALLBACKS, Defaults.HOST_FALLBACKS.length);
 			fallbackHostsIsDefault = true;
@@ -62,6 +64,11 @@ public class Hosts {
 			/* RSC15a: use ClientOptions#fallbackHosts if set */
 			fallbackHosts = Arrays.copyOf(options.fallbackHosts, options.fallbackHosts.length);
 			fallbackHostsIsDefault = false;
+			if (options.fallbackHostsUseDefault) {
+				/* TO3k7: It is never valid to configure fallbackHost and set
+				 * fallbackHostsUseDefault to true */
+				throw AblyException.fromErrorInfo(new ErrorInfo("cannot set both fallbackHosts and fallbackHostsUseDefault options", 40000, 400));
+			}
 		}
 		/* RSC15a: shuffle the fallback hosts. */
 		Collections.shuffle(Arrays.asList(fallbackHosts));
@@ -97,9 +104,10 @@ public class Hosts {
 			return null;
 		int idx;
 		if (lastHost.equals(primaryHost)) {
-			/* RSC15b: only use fallback if the hostname has not been overridden
+			/* RSC15b, RTN17b: only use fallback if the hostname has not been overridden
+			 * or if ClientOptions#fallbackHostsUseDefault is true
 			 * or if ClientOptions#fallbackHosts was provided. */
-			if (!primaryHostIsDefault && fallbackHostsIsDefault)
+			if (!primaryHostIsDefault && !fallbackHostsUseDefault && fallbackHostsIsDefault)
 				return null;
 			idx = 0;
 		} else {

--- a/lib/src/main/java/io/ably/lib/types/ClientOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ClientOptions.java
@@ -152,6 +152,12 @@ public class ClientOptions extends AuthOptions {
 	public String[] fallbackHosts;
 
 	/**
+	 * Spec: TO3k7 Set to use default fallbackHosts even when overriding
+	 * environment or restHost/realtimeHost
+	 */
+	public boolean fallbackHostsUseDefault;
+
+	/**
 	 * When a TokenParams object is provided, it will override
 	 * the client library defaults described in TokenParams
 	 * Spec: TO3j11

--- a/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
@@ -210,4 +210,36 @@ public class ConnectionManagerTest {
 		System.out.println("got failed");
 		assertThat(connectionManager.getHost(), is(equalTo("realtime.ably.io")));
 	}
+
+	/**
+	 * Test that default fallback happens with a non-default host if
+	 * fallbackHostsUseDefault is set.
+	 */
+	@Test
+	public void connectionmanager_reconnect_default_fallback() throws AblyException {
+		Setup.TestVars testVars = Setup.getTestVars();
+		ClientOptions opts = testVars.createOptions(testVars.keys[0].keyStr);
+		// Use a host that does not normally support fallback.
+		opts.realtimeHost = "nondefault.ably.io";
+		opts.environment = null;
+		opts.fallbackHostsUseDefault = true;
+		/* Use an incorrect port number for TLS. Using 80 rather than some
+		 * random number (e.g. 1234) makes the failure almost immediate,
+		 * instead of taking 15s to time out at each fallback host. */
+		opts.tls = true;
+		opts.tlsPort = 80;
+		AblyRealtime ably = new AblyRealtime(opts);
+		ConnectionManager connectionManager = ably.connection.connectionManager;
+
+		System.out.println("waiting for disconnected");
+		new Helpers.ConnectionManagerWaiter(connectionManager).waitFor(ConnectionState.disconnected);
+		System.out.println("got disconnected");
+
+		/* Verify that,
+		 *   - connectionManager is disconnected
+		 *   - connectionManager's last host was a fallback host
+		 */
+		assertThat(connectionManager.getConnectionState().state, is(ConnectionState.disconnected));
+		assertThat(connectionManager.getHost(), is(not(equalTo(opts.realtimeHost))));
+	}
 }

--- a/lib/src/test/java/io/ably/lib/test/realtime/HostsTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/HostsTest.java
@@ -140,4 +140,55 @@ public class HostsTest {
 			fail("Unexpected exception " + e);
 		}
 	}
+
+	/**
+	 * Expect a null, when realtimeHost is non-default
+	 */
+	@Test
+	public void hosts_fallback_overridden_host() {
+		try {
+			ClientOptions options = new ClientOptions();
+			String host = "overridden.ably.io";
+			Hosts hosts = new Hosts(host, Defaults.HOST_REALTIME, options);
+			host = hosts.getFallback(host);
+			assertThat(host, is(equalTo(null)));
+		} catch (Exception e) {
+			fail("Unexpected exception " + e);
+		}
+	}
+
+	/**
+	 * Expect that returned host is contained within default host list
+	 * when realtimeHost is non-default and fallbackHostsUseDefault is set
+	 */
+	@Test
+	public void hosts_fallback_use_default(){
+		try {
+			ClientOptions options = new ClientOptions();
+			options.fallbackHostsUseDefault = true;
+			String host = "overridden.ably.io";
+			Hosts hosts = new Hosts(host, Defaults.HOST_REALTIME, options);
+			int idx;
+			boolean shuffled = false;
+			boolean allFound = true;
+			for (idx = 0; ; ++idx) {
+				host = hosts.getFallback(host);
+				if (host == null)
+					break;
+				int found = Arrays.asList(Defaults.HOST_FALLBACKS).indexOf(host);
+				if (found < 0)
+					allFound = false;
+				else if (found != idx)
+					shuffled = true;
+			}
+			assertTrue(idx == Defaults.HOST_FALLBACKS.length);
+			assertTrue(allFound);
+			assertTrue(shuffled);
+		} catch (Exception e) {
+			fail("Unexpected exception " + e);
+		}
+	}
+
+
+
 }


### PR DESCRIPTION
TO3k7, RSC15b, RTN17b:
fallbackHostsUseDefault boolean - optionally allows the default fallback
hosts [a-e].ably-realtime.com to be used when environment is not
production or a custom realtime or REST host endpoint is being used. It
is never valid to configure fallbackHost and set fallbackHostsUseDefault
to true