### PR TITLE
0.9 authorise->authorize, and fix param order

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ either a real device or the Android emulator.
 Download [the latest JAR](https://github.com/ably/ably-java/releases) or grab via Gradle:
 
 ```groovy
-compile 'io.ably:ably-java:0.8.4'
+compile 'io.ably:ably-java:0.9.pre'
 ```
 
 or
 
 ```groovy
-compile 'io.ably:ably-android:0.8.4'
+compile 'io.ably:ably-android:0.9.pre'
 ```
 
 and add following repo for a sub-dependency,
@@ -353,25 +353,25 @@ long serviceTime = ably.time();
 This library uses [semantic versioning](http://semver.org/). For each release, the following needs to be done:
 
 * Replace all references of the current version number with the new version number (check this file [README.md](./README.md) and [build.gradle](./build.gradle)) and commit the changes
-* Run [`github_changelog_generator`](https://github.com/skywinder/Github-Changelog-Generator) to automate the update of the [CHANGELOG](./CHANGELOG.md). Once the CHANGELOG has completed, manually change the `Unreleased` heading and link with the current version number such as `v0.8.4`. Also ensure that the `Full Changelog` link points to the new version tag instead of the `HEAD`. Commit this change.
-* Add a tag and push to origin such as `git tag v0.8.4 && git push origin v0.8.4`
+* Run [`github_changelog_generator`](https://github.com/skywinder/Github-Changelog-Generator) to automate the update of the [CHANGELOG](./CHANGELOG.md). Once the CHANGELOG has completed, manually change the `Unreleased` heading and link with the current version number such as `v0.9.pre`. Also ensure that the `Full Changelog` link points to the new version tag instead of the `HEAD`. Commit this change.
+* Add a tag and push to origin such as `git tag v0.9.pre && git push origin v0.9.pre`
 * Run `gradle java:assemble` to build the JRE-specific JARs for this release
 * Run `gradle android:assemble` to build the Android AAR for this release
-* Visit [https://github.com/ably/ably-java/tags](https://github.com/ably/ably-java/tags) and `Add release notes` for the release, then attach the generated JARs (`ably-java-0.8.4.jar` and `ably-java-0.8.4-full.jar`) in the folder `java/build/libs`,
-  and the generated AAR (`ably-android-0.8.4-release.aar` in the folder `android/build/outputs/aar`.
+* Visit [https://github.com/ably/ably-java/tags](https://github.com/ably/ably-java/tags) and `Add release notes` for the release, then attach the generated JARs (`ably-java-0.9.pre.jar` and `ably-java-0.9.pre-full.jar`) in the folder `java/build/libs`,
+  and the generated AAR (`ably-android-0.9.pre-release.aar` in the folder `android/build/outputs/aar`.
 
 ### Publishing to JCenter (Maven)
 
-* Go to the home page https://bintray.com/ably-io/ably/java. Select [New version](https://bintray.com/ably-io/ably/java/new/version), enter the new version such as "0.8.4" in name and save
+* Go to the home page https://bintray.com/ably-io/ably/java. Select [New version](https://bintray.com/ably-io/ably/java/new/version), enter the new version such as "0.9.pre" in name and save
 * Run `gradle java:generateRelease` locally to generate the files
-* Open local relative folder such as `/lib/build/release/0.8.4/`
-* Then go to the new version in JFrog Bintray and go to files such as https://bintray.com/ably-io/ably/java/0.8.4#files/io/ably/ably-java, then click on Upload files
-* Type in `io/ably/ably-java/0.8.4` into "Target Repository Path" ensuring the correct version is included. The drag in the files in `java/build/release/0.8.4/`
-* You will see a notice "You have 8 unpublished item(s) for this version", make sure you click "Publish". Wait a few minutes and check that your version has all the necessary files at https://bintray.com/ably-io/ably/java/v0.8.4?sort=&order=#files/io/ably/ably-java/0.8.4 for example.
+* Open local relative folder such as `/lib/build/release/0.9.pre/`
+* Then go to the new version in JFrog Bintray and go to files such as https://bintray.com/ably-io/ably/java/0.9.pre#files/io/ably/ably-java, then click on Upload files
+* Type in `io/ably/ably-java/0.9.pre` into "Target Repository Path" ensuring the correct version is included. The drag in the files in `java/build/release/0.9.pre/`
+* You will see a notice "You have 8 unpublished item(s) for this version", make sure you click "Publish". Wait a few minutes and check that your version has all the necessary files at https://bintray.com/ably-io/ably/java/v0.9.pre?sort=&order=#files/io/ably/ably-java/0.9.pre for example.
 
 Similarly for the Android release at `https://bintray.com/ably-io/ably/android`.
 Run `gradle android:generateRelease` locally to generate the files, and drag in the files in
-`android/build/release/0.8.4/`.
+`android/build/release/0.9.pre/`.
 
 ## Support, feedback and troubleshooting
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,6 @@ allprojects {
 }
 
 subprojects {
-  version = '0.8.4'
+  version = '0.9.pre'
   description = """Ably java client library"""
 }

--- a/lib/src/main/java/io/ably/lib/http/Http.java
+++ b/lib/src/main/java/io/ably/lib/http/Http.java
@@ -293,13 +293,13 @@ public class Http {
 				options.force = true;
 			}
 
-			auth.authorise(null, options);
+			auth.authorize(null, options);
 			authHeader = "Bearer " + auth.getTokenAuth().getEncodedToken();
 		}
 		return authHeader;
 	}
 
-	void authorise(boolean renew) throws AblyException {
+	void authorize(boolean renew) throws AblyException {
 		getAuthorizationHeader(renew);
 	}
 
@@ -461,12 +461,12 @@ public class Http {
 			} catch(AuthRequiredException are) {
 				if(are.authChallenge != null && allowAblyAuth) {
 					if(authPending) {
-						authorise(false);
+						authorize(false);
 						authPending = false;
 						continue;
 					}
 					if(are.expired && renewPending) {
-						authorise(true);
+						authorize(true);
 						renewPending = false;
 						continue;
 					}

--- a/lib/src/main/java/io/ably/lib/http/Http.java
+++ b/lib/src/main/java/io/ably/lib/http/Http.java
@@ -293,7 +293,7 @@ public class Http {
 				options.force = true;
 			}
 
-			auth.authorise(options, null);
+			auth.authorise(null, options);
 			authHeader = "Bearer " + auth.getTokenAuth().getEncodedToken();
 		}
 		return authHeader;

--- a/lib/src/main/java/io/ably/lib/http/HttpUtils.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpUtils.java
@@ -16,8 +16,7 @@ import io.ably.lib.types.Param;
 public class HttpUtils {
 	/* Headers */
 	public static final String X_ABLY_VERSION_HEADER = "X-Ably-Version";
-	public static final String X_ABLY_VERSION_VALUE = BuildConfig.VERSION.substring(0,
-          BuildConfig.VERSION.indexOf('.', BuildConfig.VERSION.indexOf('.') + 1));
+	public static final String X_ABLY_VERSION_VALUE = "0.8";
 	public static final String X_ABLY_LIB_HEADER = "X-Ably-Lib";
 	public static final String X_ABLY_LIB_VALUE = String.format("%s-%s", BuildConfig.LIBRARY_NAME, BuildConfig.VERSION);
 

--- a/lib/src/main/java/io/ably/lib/http/HttpUtils.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpUtils.java
@@ -16,7 +16,7 @@ import io.ably.lib.types.Param;
 public class HttpUtils {
 	/* Headers */
 	public static final String X_ABLY_VERSION_HEADER = "X-Ably-Version";
-	public static final String X_ABLY_VERSION_VALUE = "0.8";
+	public static final String X_ABLY_VERSION_VALUE = "0.9";
 	public static final String X_ABLY_LIB_HEADER = "X-Ably-Lib";
 	public static final String X_ABLY_LIB_VALUE = String.format("%s-%s", BuildConfig.LIBRARY_NAME, BuildConfig.VERSION);
 

--- a/lib/src/main/java/io/ably/lib/http/TokenAuth.java
+++ b/lib/src/main/java/io/ably/lib/http/TokenAuth.java
@@ -36,21 +36,21 @@ public class TokenAuth {
 		this.encodedToken = Base64Coder.encodeString(tokenDetails.token).replace("=", "");
 	}
 
-	public TokenDetails authorise(AuthOptions options, TokenParams params) throws AblyException {
-		Log.i("TokenAuth.authorise()", "");
+	public TokenDetails authorize(AuthOptions options, TokenParams params) throws AblyException {
+		Log.i("TokenAuth.authorize()", "");
 		if(tokenDetails != null) {
 			if(tokenDetails.expires == 0 || tokenValid(tokenDetails)) {
 				if(options == null || !options.force) {
-					Log.i("TokenAuth.authorise()", "using cached token; expires = " + tokenDetails.expires);
+					Log.i("TokenAuth.authorize()", "using cached token; expires = " + tokenDetails.expires);
 					return tokenDetails;
 				}
 			} else {
 				/* expired, so remove */
-				Log.i("TokenAuth.authorise()", "deleting expired token");
+				Log.i("TokenAuth.authorize()", "deleting expired token");
 				clear();
 			}
 		}
-		Log.i("TokenAuth.authorise()", "requesting new token");
+		Log.i("TokenAuth.authorize()", "requesting new token");
 		setTokenDetails(auth.requestToken(params, options));
 		return tokenDetails;
 	}

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -384,8 +384,6 @@ public class Auth {
 	 * Authorisation will use the parameters supplied on construction except
 	 * where overridden with the options supplied in the call.
 	 *
-	 * @param options
-	 *
 	 * @param params
 	 * an object containing the request params:
 	 * - key:        (optional) the key to use; if not specified, the key
@@ -407,8 +405,10 @@ public class Auth {
 	 *
 	 * - queryTime   (optional) boolean indicating that the Ably system should be
 	 *               queried for the current time when none is specified explicitly.
+	 *
+	 * @param options
 	 */
-	public TokenDetails authorise(AuthOptions options, TokenParams params) throws AblyException {
+	public TokenDetails authorise(TokenParams params, AuthOptions options) throws AblyException {
 		/* To avoid breaking compatibility in 0.8 versions of the library, merge
 		 * supplied options and params with stored defaults. This needs to be
 		 * removed in 0.9 to comply with RSA10j. */

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -146,7 +146,7 @@ public class Auth {
 		}
 
 		/**
-		 * Stores the AuthOptions arguments as defaults for subsequent authorisations
+		 * Stores the AuthOptions arguments as defaults for subsequent authorizations
 		 * with the exception of the attributes {@link AuthOptions#queryTime}
 		 * and {@link AuthOptions#force}
 		 * <p>
@@ -280,7 +280,7 @@ public class Auth {
 		}
 
 		/**
-		 * Stores the TokenParams arguments as defaults for subsequent authorisations
+		 * Stores the TokenParams arguments as defaults for subsequent authorizations
 		 * with the exception of the attributes {@link TokenParams#timestamp}
 		 * <p>
 		 * Spec: RSA10g
@@ -381,7 +381,7 @@ public class Auth {
 	 * Ensure valid auth credentials are present. This may rely in an already-known
 	 * and valid token, and will obtain a new token if necessary or explicitly
 	 * requested.
-	 * Authorisation will use the parameters supplied on construction except
+	 * Authorization will use the parameters supplied on construction except
 	 * where overridden with the options supplied in the call.
 	 *
 	 * @param params
@@ -408,7 +408,7 @@ public class Auth {
 	 *
 	 * @param options
 	 */
-	public TokenDetails authorise(TokenParams params, AuthOptions options) throws AblyException {
+	public TokenDetails authorize(TokenParams params, AuthOptions options) throws AblyException {
 		/* To avoid breaking compatibility in 0.8 versions of the library, merge
 		 * supplied options and params with stored defaults. This needs to be
 		 * removed in 0.9 to comply with RSA10j. */
@@ -425,10 +425,10 @@ public class Auth {
 		options = (options == null) ? this.authOptions : options.copy();
 		params = (params == null) ? this.tokenParams : params.copy();
 
-		TokenDetails tokenDetails = tokenAuth.authorise(options, params);
+		TokenDetails tokenDetails = tokenAuth.authorize(options, params);
 
 		/* RTC8
-		 *  If authorise is called with AuthOptions#force set to true
+		 *  If authorize is called with AuthOptions#force set to true
 		 *  the client will obtain a new token, disconnect the current transport
 		 *  and resume the connection
 		 */
@@ -438,10 +438,18 @@ public class Auth {
 	}
 
 	/**
+	 * Alias of authorize() (0.9 RSA10l)
+	 */
+	public TokenDetails authorise(TokenParams params, AuthOptions options) throws AblyException {
+		Log.w(TAG, "authorise() alias will be removed in 1.0");
+		return authorize(params, options);
+	}
+
+	/**
 	 * Make a token request. This will make a token request now, even if the library already
 	 * has a valid token. It would typically be used to issue tokens for use by other clients.
-	 * @param params : see {@link #authorise} for params
-	 * @param options : see {@link #authorise} for options
+	 * @param params : see {@link #authorize} for params
+	 * @param options : see {@link #authorize} for options
 	 * @return: the TokenDetails
 	 * @throws AblyException
 	 */
@@ -564,8 +572,8 @@ public class Auth {
 	 * Create a signed token request based on known credentials
 	 * and the given token params. This would typically be used if creating
 	 * signed requests for submission by another client.
-	 * @param options: see {@link #authorise} for options
-	 * @param params: see {@link #authorise} for params
+	 * @param options: see {@link #authorize} for options
+	 * @param params: see {@link #authorize} for params
 	 * @return: the params augmented with the mac.
 	 * @throws AblyException
 	 */
@@ -661,7 +669,7 @@ public class Auth {
 			params = new Param[]{new Param("key", authOptions.key) };
 			break;
 		case token:
-			authorise(null, null);
+			authorize(null, null);
 			params = new Param[]{new Param("access_token", tokenAuth.getTokenDetails().token) };
 			break;
 		}
@@ -747,6 +755,7 @@ public class Auth {
 		} catch (GeneralSecurityException e) { Log.e("Auth.hmac", "Unexpected exception", e); return null; }
 	}
 
+	private static final String TAG = Auth.class.getName();
 	private final AblyRest ably;
 	private final AuthMethod method;
 	private AuthOptions authOptions;

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -279,7 +279,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	 * In the current protocol version we are not able to update auth params on the fly;
 	 * so disconnect, and the new auth params will be used for subsequent reconnection
 	 * * <p>
-	 * Spec: RTC8 (reauthorise) (0.8 spec)
+	 * Spec: RTC8 (reauthorize) (0.8 spec)
 	 * </p>
 	 *
 	 */

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeReauthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeReauthTest.java
@@ -27,11 +27,11 @@ public class RealtimeReauthTest {
 
 	/**
 	 * RTC8 (0.8 spec)
-	 *  If authorise is called with AuthOptions#force set to true
+	 *  If authorize is called with AuthOptions#force set to true
 	 *  the client will obtain a new token, disconnect the current transport
 	 *  and resume the connection
 	 *
-	 * use authorise({force: true}) to reauth with a token with a different set of capabilities
+	 * use authorize({force: true}) to reauth with a token with a different set of capabilities
 	 */
 	@Test
 	public void reauth_tokenDetails() {
@@ -92,14 +92,14 @@ public class RealtimeReauthTest {
 			Auth.TokenDetails secondToken = ablyForToken.auth.requestToken(tokenParams, null);
 			assertNotNull("Expected token value", secondToken.token);
 
-			/* reauthorise */
+			/* reauthorize */
 			Auth.AuthOptions authOptions = new Auth.AuthOptions();
 			authOptions.key = optsTestVars.keys[0].keyStr;
 			authOptions.tokenDetails = secondToken;
 			authOptions.force = true;
-			Auth.TokenDetails reauthTokenDetails = ablyRealtime.auth.authorise(null, authOptions);
+			Auth.TokenDetails reauthTokenDetails = ablyRealtime.auth.authorize(null, authOptions);
 			assertNotNull("Expected token value", reauthTokenDetails.token);
-			System.out.println("done reauthorise");
+			System.out.println("done reauthorize");
 			/* Delay 2s to allow connection to go disconnected (and probably
 			 * then onto connecting and connected). This is a workaround for
 			 * https://github.com/ably/ably-java/issues/180 */

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeReauthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeReauthTest.java
@@ -97,7 +97,7 @@ public class RealtimeReauthTest {
 			authOptions.key = optsTestVars.keys[0].keyStr;
 			authOptions.tokenDetails = secondToken;
 			authOptions.force = true;
-			Auth.TokenDetails reauthTokenDetails = ablyRealtime.auth.authorise(authOptions, null);
+			Auth.TokenDetails reauthTokenDetails = ablyRealtime.auth.authorise(null, authOptions);
 			assertNotNull("Expected token value", reauthTokenDetails.token);
 			System.out.println("done reauthorise");
 			/* Delay 2s to allow connection to go disconnected (and probably

--- a/lib/src/test/java/io/ably/lib/test/rest/HttpHeaderTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/HttpHeaderTest.java
@@ -85,7 +85,7 @@ public class HttpHeaderTest {
 			/* Check header */
 			Assert.assertNotNull("Expected headers", headers);
 			Assert.assertTrue(String.format("Expected header %s", HttpUtils.X_ABLY_VERSION_HEADER), headers.containsKey(ably_version_header));
-			Assert.assertEquals(headers.get(ably_version_header), "0.8");
+			Assert.assertEquals(headers.get(ably_version_header), "0.9");
 			Assert.assertTrue(String.format("Expected header %s", HttpUtils.X_ABLY_LIB_HEADER), headers.containsKey(ably_lib_header));
 			Assert.assertEquals(headers.get(ably_lib_header), HttpUtils.X_ABLY_LIB_VALUE);
 		} catch (AblyException e) {

--- a/lib/src/test/java/io/ably/lib/test/rest/RestAuthAttributeTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestAuthAttributeTest.java
@@ -76,7 +76,7 @@ public class RestAuthAttributeTest {
 			}};
 
 			/* authorise with custom options */
-			TokenDetails tokenDetails1 = ably.auth.authorise(authOptions, tokenParams);
+			TokenDetails tokenDetails1 = ably.auth.authorise(tokenParams, authOptions);
 
 			/* Verify that,
 			 * tokenDetails1 isn't null,
@@ -123,11 +123,11 @@ public class RestAuthAttributeTest {
 			final String clientId1 = tokenDetails1.clientId;
 
 			/* authorise with force attribute */
-			TokenDetails tokenDetails2 = ably.auth.authorise(
+			TokenDetails tokenDetails2 = ably.auth.authorise(null,
 					new AuthOptions() {{
 						force = true;
 						key = ably.options.key;
-					}}, null);
+					}});
 			final String token2 = tokenDetails2.token;
 			final String clientId2 = tokenDetails2.clientId;
 
@@ -187,7 +187,7 @@ public class RestAuthAttributeTest {
 
 			/* authorise for store custom AuthOptions that has attribute queryTime */
 			try {
-				ablyForTime.auth.authorise(authOptions, tokenParams);
+				ablyForTime.auth.authorise(tokenParams, authOptions);
 			} catch (Throwable e) {
 			}
 
@@ -248,13 +248,13 @@ public class RestAuthAttributeTest {
 			authOptions.authCallback = tokenCallback;
 			TokenParams tokenParams = new TokenParams();
 			tokenParams.timestamp = expectedTimestamp;
-			TokenDetails tokenDetails1 = ably.auth.authorise(authOptions, tokenParams);
+			TokenDetails tokenDetails1 = ably.auth.authorise(tokenParams, authOptions);
 			final String token1 = tokenDetails1.token;
 			final String clientId1 = tokenDetails1.clientId;
 
 			/* force authorise with stored TokenParams values */
 			authOptions.force = true;
-			TokenDetails tokenDetails2 = ably.auth.authorise(authOptions, null);
+			TokenDetails tokenDetails2 = ably.auth.authorise(null, authOptions);
 			final String token2 = tokenDetails2.token;
 			final String clientId2 = tokenDetails2.clientId;
 
@@ -306,7 +306,7 @@ public class RestAuthAttributeTest {
 			}};
 
 			/* authorise with custom AuthOptions */
-			TokenDetails tokenDetails2 = ably.auth.authorise(authOptions, null);
+			TokenDetails tokenDetails2 = ably.auth.authorise(null, authOptions);
 
 			/* Verify that,
 			 * tokenDetails1 and tokenDetails2 aren't null,

--- a/lib/src/test/java/io/ably/lib/test/rest/RestAuthAttributeTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestAuthAttributeTest.java
@@ -41,7 +41,7 @@ public class RestAuthAttributeTest {
 	}
 
 	/**
-	 * Stores the AuthOptions and TokenParams arguments as defaults for subsequent authorisations
+	 * Stores the AuthOptions and TokenParams arguments as defaults for subsequent authorizations
 	 * <p>
 	 * Spec: RSA10g
 	 * </p>
@@ -75,7 +75,9 @@ public class RestAuthAttributeTest {
 				key = testVars.keys[1].keyStr;
 			}};
 
-			/* authorise with custom options */
+			/* authorise with custom options
+			 * Deliberate use of British spelling alias authorise() to check that
+			 * it works (0.9 RSA10l) */
 			TokenDetails tokenDetails1 = ably.auth.authorise(tokenParams, authOptions);
 
 			/* Verify that,
@@ -90,8 +92,8 @@ public class RestAuthAttributeTest {
 				Thread.sleep(5000L);
 			} catch(InterruptedException ie) {}
 
-			/* authorise with default options */
-			TokenDetails tokenDetails2 = ably.auth.authorise(null, null);
+			/* authorize with default options */
+			TokenDetails tokenDetails2 = ably.auth.authorize(null, null);
 
 			/* Verify that,
 			 * tokenDetails2 isn't null,
@@ -108,7 +110,7 @@ public class RestAuthAttributeTest {
 	}
 
 	/**
-	 * Verify that {@link AuthOptions#force} attribute don't stored/used for subsequent authorisations
+	 * Verify that {@link AuthOptions#force} attribute don't stored/used for subsequent authorizations
 	 * <p>
 	 * Spec: RSA10g
 	 * </p>
@@ -117,13 +119,13 @@ public class RestAuthAttributeTest {
 	public void auth_stores_options_exception_force() {
 		try {
 			setup();
-			/* authorise with default values */
-			TokenDetails tokenDetails1 = ably.auth.authorise(null, null);
+			/* authorize with default values */
+			TokenDetails tokenDetails1 = ably.auth.authorize(null, null);
 			final String token1 = tokenDetails1.token;
 			final String clientId1 = tokenDetails1.clientId;
 
-			/* authorise with force attribute */
-			TokenDetails tokenDetails2 = ably.auth.authorise(null,
+			/* authorize with force attribute */
+			TokenDetails tokenDetails2 = ably.auth.authorize(null,
 					new AuthOptions() {{
 						force = true;
 						key = ably.options.key;
@@ -137,8 +139,8 @@ public class RestAuthAttributeTest {
 			assertEquals(clientId1, clientId2);
 			assertNotEquals(token1, token2);
 
-			/* authorise with stored values */
-			TokenDetails tokenDetails3 = ably.auth.authorise(null, null);
+			/* authorize with stored values */
+			TokenDetails tokenDetails3 = ably.auth.authorize(null, null);
 			final String token3 = tokenDetails3.token;
 			final String clientId3 = tokenDetails3.clientId;
 
@@ -153,7 +155,7 @@ public class RestAuthAttributeTest {
 	}
 
 	/**
-	 * Verify that {@link AuthOptions#queryTime} attribute don't stored/used for subsequent authorisations
+	 * Verify that {@link AuthOptions#queryTime} attribute don't stored/used for subsequent authorizations
 	 * <p>
 	 * Spec: RSA10g
 	 * </p>
@@ -185,9 +187,9 @@ public class RestAuthAttributeTest {
 			assertEquals(expectedClientId, tokenRequest.clientId);
 			assertEquals(fakeServerTime, tokenRequest.timestamp);
 
-			/* authorise for store custom AuthOptions that has attribute queryTime */
+			/* authorize for store custom AuthOptions that has attribute queryTime */
 			try {
-				ablyForTime.auth.authorise(tokenParams, authOptions);
+				ablyForTime.auth.authorize(tokenParams, authOptions);
 			} catch (Throwable e) {
 			}
 
@@ -208,7 +210,7 @@ public class RestAuthAttributeTest {
 	}
 
 	/**
-	 * Verify that {@link TokenParams#timestamp} attribute don't stored/used for subsequent authorisations
+	 * Verify that {@link TokenParams#timestamp} attribute don't stored/used for subsequent authorizations
 	 * <p>
 	 * Spec: RSA10g
 	 * </p>
@@ -242,25 +244,25 @@ public class RestAuthAttributeTest {
 				}
 			}.setTimestampCapturedList(timestampCapturedList);
 
-			/* authorise with custom timestamp */
+			/* authorize with custom timestamp */
 			AuthOptions authOptions = new AuthOptions();
 			authOptions.key = ably.options.key;
 			authOptions.authCallback = tokenCallback;
 			TokenParams tokenParams = new TokenParams();
 			tokenParams.timestamp = expectedTimestamp;
-			TokenDetails tokenDetails1 = ably.auth.authorise(tokenParams, authOptions);
+			TokenDetails tokenDetails1 = ably.auth.authorize(tokenParams, authOptions);
 			final String token1 = tokenDetails1.token;
 			final String clientId1 = tokenDetails1.clientId;
 
-			/* force authorise with stored TokenParams values */
+			/* force authorize with stored TokenParams values */
 			authOptions.force = true;
-			TokenDetails tokenDetails2 = ably.auth.authorise(null, authOptions);
+			TokenDetails tokenDetails2 = ably.auth.authorize(null, authOptions);
 			final String token2 = tokenDetails2.token;
 			final String clientId2 = tokenDetails2.clientId;
 
 			/* Verify that,
 			* 	 - new token was issued
-			* 	 - authorise called twice
+			* 	 - authorize called twice
 			* 	 - first timestamp value equals expected timestamp
 			* 	 - second timestamp value is not expected
 			* tokenDetails1 and tokenDetails2 aren't null,
@@ -287,11 +289,11 @@ public class RestAuthAttributeTest {
 	 * </p>
 	 */
 	@Test
-	public void auth_authorise_force() {
+	public void auth_authorize_force() {
 		try {
 			setup();
-			/* authorise with default options */
-			TokenDetails tokenDetails1 = ably.auth.authorise(null, null);
+			/* authorize with default options */
+			TokenDetails tokenDetails1 = ably.auth.authorize(null, null);
 
 			/* init custom AuthOptions with force value is true */
 			final String custom_test_value = "test_forced_token";
@@ -305,8 +307,8 @@ public class RestAuthAttributeTest {
 				force = true;
 			}};
 
-			/* authorise with custom AuthOptions */
-			TokenDetails tokenDetails2 = ably.auth.authorise(null, authOptions);
+			/* authorize with custom AuthOptions */
+			TokenDetails tokenDetails2 = ably.auth.authorize(null, authOptions);
 
 			/* Verify that,
 			 * tokenDetails1 and tokenDetails2 aren't null,
@@ -318,7 +320,7 @@ public class RestAuthAttributeTest {
 			assertEquals(tokenDetails2.token, custom_test_value);
 		} catch (Exception e) {
 			e.printStackTrace();
-			fail("auth_custom_options_authorise: Unexpected exception");
+			fail("auth_custom_options_authorize: Unexpected exception");
 		}
 	}
 }


### PR DESCRIPTION
I think we haven't decided yet about whether to fix param order in 0.8, but in the meantime one of the two commits here fixes it in 0.9.