### PR TITLE
0.9: removed AuthOptions.force

### DIFF
--- a/lib/src/main/java/io/ably/lib/http/Http.java
+++ b/lib/src/main/java/io/ably/lib/http/Http.java
@@ -287,13 +287,10 @@ public class Http {
 		if(auth.getAuthMethod() == AuthMethod.basic) {
 			authHeader = "Basic " + Base64Coder.encodeString(auth.getBasicCredentials());
 		} else {
-			Auth.AuthOptions options = null;
-			if (renew) {
-				options = new Auth.AuthOptions();
-				options.force = true;
-			}
-
-			auth.authorize(null, options);
+			if (renew)
+				auth.authorize(null, null);
+			else
+				auth.ensureValidAuth();
 			authHeader = "Bearer " + auth.getTokenAuth().getEncodedToken();
 		}
 		return authHeader;

--- a/lib/src/main/java/io/ably/lib/http/TokenAuth.java
+++ b/lib/src/main/java/io/ably/lib/http/TokenAuth.java
@@ -36,11 +36,11 @@ public class TokenAuth {
 		this.encodedToken = Base64Coder.encodeString(tokenDetails.token).replace("=", "");
 	}
 
-	public TokenDetails authorize(TokenParams params, AuthOptions options) throws AblyException {
+	public TokenDetails authorize(TokenParams params, AuthOptions options, boolean force) throws AblyException {
 		Log.i("TokenAuth.authorize()", "");
 		if(tokenDetails != null) {
 			if(tokenDetails.expires == 0 || tokenValid(tokenDetails)) {
-				if(options == null || !options.force) {
+				if (!force) {
 					Log.i("TokenAuth.authorize()", "using cached token; expires = " + tokenDetails.expires);
 					return tokenDetails;
 				}

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -429,7 +429,7 @@ public class Auth {
 	 * Alias of authorize() (0.9 RSA10l)
 	 */
 	public TokenDetails authorise(TokenParams params, AuthOptions options) throws AblyException {
-		Log.w(TAG, "authorise() alias will be removed in 1.0");
+		Log.w(TAG, "authorise() is deprecated and will be removed in 1.0. Please use authorize() instead");
 		return authorize(params, options);
 	}
 

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeReauthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeReauthTest.java
@@ -26,12 +26,10 @@ import static org.junit.Assert.fail;
 public class RealtimeReauthTest {
 
 	/**
-	 * RTC8 (0.8 spec)
-	 *  If authorize is called with AuthOptions#force set to true
+	 * RTC8 (0.8 spec with 0.9 removal of AuthOptions.force)
+	 *  If authorize is called
 	 *  the client will obtain a new token, disconnect the current transport
 	 *  and resume the connection
-	 *
-	 * use authorize({force: true}) to reauth with a token with a different set of capabilities
 	 */
 	@Test
 	public void reauth_tokenDetails() {
@@ -96,7 +94,6 @@ public class RealtimeReauthTest {
 			Auth.AuthOptions authOptions = new Auth.AuthOptions();
 			authOptions.key = optsTestVars.keys[0].keyStr;
 			authOptions.tokenDetails = secondToken;
-			authOptions.force = true;
 			Auth.TokenDetails reauthTokenDetails = ablyRealtime.auth.authorize(null, authOptions);
 			assertNotNull("Expected token value", reauthTokenDetails.token);
 			System.out.println("done reauthorize");

--- a/lib/src/test/java/io/ably/lib/test/rest/RestAuthAttributeTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestAuthAttributeTest.java
@@ -110,51 +110,6 @@ public class RestAuthAttributeTest {
 	}
 
 	/**
-	 * Verify that {@link AuthOptions#force} attribute don't stored/used for subsequent authorizations
-	 * <p>
-	 * Spec: RSA10g
-	 * </p>
-	 */
-	@Test
-	public void auth_stores_options_exception_force() {
-		try {
-			setup();
-			/* authorize with default values */
-			TokenDetails tokenDetails1 = ably.auth.authorize(null, null);
-			final String token1 = tokenDetails1.token;
-			final String clientId1 = tokenDetails1.clientId;
-
-			/* authorize with force attribute */
-			TokenDetails tokenDetails2 = ably.auth.authorize(null,
-					new AuthOptions() {{
-						force = true;
-						key = ably.options.key;
-					}});
-			final String token2 = tokenDetails2.token;
-			final String clientId2 = tokenDetails2.clientId;
-
-			/* Verify that, new token was issued */
-			assertNotNull(tokenDetails1);
-			assertNotNull(tokenDetails2);
-			assertEquals(clientId1, clientId2);
-			assertNotEquals(token1, token2);
-
-			/* authorize with stored values */
-			TokenDetails tokenDetails3 = ably.auth.authorize(null, null);
-			final String token3 = tokenDetails3.token;
-			final String clientId3 = tokenDetails3.clientId;
-
-			/* Verify that, new token wasn't issued */
-			assertNotNull(tokenDetails3);
-			assertEquals(clientId2, clientId3);
-			assertEquals(token2, token3);
-		} catch (Exception e) {
-			e.printStackTrace();
-			fail("auth_stores_options_exception_force: Unexpected exception");
-		}
-	}
-
-	/**
 	 * Verify that {@link AuthOptions#queryTime} attribute don't stored/used for subsequent authorizations
 	 * <p>
 	 * Spec: RSA10g
@@ -255,7 +210,6 @@ public class RestAuthAttributeTest {
 			final String clientId1 = tokenDetails1.clientId;
 
 			/* force authorize with stored TokenParams values */
-			authOptions.force = true;
 			TokenDetails tokenDetails2 = ably.auth.authorize(null, authOptions);
 			final String token2 = tokenDetails2.token;
 			final String clientId2 = tokenDetails2.clientId;
@@ -282,7 +236,7 @@ public class RestAuthAttributeTest {
 	}
 
 	/**
-	 * Verify if {@link AuthOptions#force} is true
+	 * Verify
 	 * will to issue a new token even if an existing token exists.
 	 * <p>
 	 * Spec: RSA10d
@@ -295,7 +249,7 @@ public class RestAuthAttributeTest {
 			/* authorize with default options */
 			TokenDetails tokenDetails1 = ably.auth.authorize(null, null);
 
-			/* init custom AuthOptions with force value is true */
+			/* init custom AuthOptions */
 			final String custom_test_value = "test_forced_token";
 			AuthOptions authOptions = new AuthOptions() {{
 				authCallback = new TokenCallback() {
@@ -304,7 +258,6 @@ public class RestAuthAttributeTest {
 						return custom_test_value;
 					}
 				};
-				force = true;
 			}};
 
 			/* authorize with custom AuthOptions */


### PR DESCRIPTION
The public authorize() now always forces. We do not yet have 0.9
authorize in place, so for now this always forces a disconnect and
reconnect.