### PR TITLE
RSA10k; token expiration now takes client-server time delta into account

### DIFF
--- a/lib/src/main/java/io/ably/lib/http/TokenAuth.java
+++ b/lib/src/main/java/io/ably/lib/http/TokenAuth.java
@@ -61,7 +61,7 @@ public class TokenAuth {
 	}
 
 	private static boolean tokenValid(TokenDetails tokenDetails) {
-		return tokenDetails.expires > Auth.timestamp();
+		return tokenDetails.expires > Auth.serverTimestamp();
 	}
 
 	private Auth auth;

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -591,10 +591,17 @@ public class Auth {
 
 		/* timestamp */
 		if(request.timestamp == 0) {
-			if(options.queryTime)
-				request.timestamp = ably.time();
-			else
+			if(options.queryTime) {
+				if (timeDelta != Long.MAX_VALUE) {
+					request.timestamp = timestamp() + timeDelta;
+				} else {
+					request.timestamp = ably.time();
+					timeDelta = request.timestamp - timestamp();
+				}
+			}
+			else {
 				request.timestamp = timestamp();
+			}
 		}
 
 		/* nonce */
@@ -728,6 +735,15 @@ public class Auth {
 		} catch (GeneralSecurityException e) { Log.e("Auth.hmac", "Unexpected exception", e); return null; }
 	}
 
+	/**
+	 * Using time delta obtained before guess current server time
+	 */
+	public static long serverTimestamp() {
+		long clientTime = timestamp();
+		long delta = timeDelta;
+		return delta != Long.MAX_VALUE ? clientTime + timeDelta : clientTime;
+	}
+
 	private static final String TAG = Auth.class.getName();
 	private final AblyRest ably;
 	private final AuthMethod method;
@@ -735,4 +751,9 @@ public class Auth {
 	private TokenParams tokenParams;
 	private String basicCredentials;
 	private TokenAuth tokenAuth;
+
+	/**
+	 * Time delta is server time minus client time, in milliseconds, MAX_VALUE if not obtained yet
+	 */
+	private static long timeDelta = Long.MAX_VALUE;
 }

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -771,4 +771,11 @@ public class Auth {
 	 * suggests device time/date has changed
 	 */
 	private static long nanoTimeDelta = System.currentTimeMillis() - System.nanoTime()/(1000*1000);
+
+	/**
+	 * For testing purposes we need method to clear cached timeDelta
+	 */
+	public static void clearCachedServerTime() {
+		timeDelta = Long.MAX_VALUE;
+	}
 }

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -592,8 +592,18 @@ public class Auth {
 		/* timestamp */
 		if(request.timestamp == 0) {
 			if(options.queryTime) {
+				long oldNanoTimeDelta = nanoTimeDelta;
+				long currentNanoTimeDelta = System.currentTimeMillis() - System.nanoTime()/(1000*1000);
+
+				if (timeDelta != Long.MAX_VALUE) {
+					/* system time changed by more than 500ms since last time? */
+					if(Math.abs(oldNanoTimeDelta - currentNanoTimeDelta) > 500)
+						timeDelta = Long.MAX_VALUE;
+				}
+
 				if (timeDelta != Long.MAX_VALUE) {
 					request.timestamp = timestamp() + timeDelta;
+					nanoTimeDelta = currentNanoTimeDelta;
 				} else {
 					request.timestamp = ably.time();
 					timeDelta = request.timestamp - timestamp();
@@ -756,4 +766,9 @@ public class Auth {
 	 * Time delta is server time minus client time, in milliseconds, MAX_VALUE if not obtained yet
 	 */
 	private static long timeDelta = Long.MAX_VALUE;
+	/**
+	 * Time delta between System.nanoTime() and System.currentTimeMillis. If it changes significantly it
+	 * suggests device time/date has changed
+	 */
+	private static long nanoTimeDelta = System.currentTimeMillis() - System.nanoTime()/(1000*1000);
 }

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
@@ -217,15 +217,12 @@ public class RealtimeConnectFailTest {
 			/* wait for connected state */
 			ConnectionWaiter connectionWaiter = new ConnectionWaiter(ably.connection);
 			connectionWaiter.waitFor(ConnectionState.connected);
-			//assertEquals("Verify connected state is reached", ConnectionState.connected, ably.connection.state);
 
 			/* wait for disconnected state (on token expiry), with timeout */
 			connectionWaiter.waitFor(ConnectionState.disconnected, 1, 30000L);
-			//assertEquals("Verify disconnected state is reached", ConnectionState.disconnected, ably.connection.state);
 
 			/* wait for connected state (on token renewal) */
 			connectionWaiter.waitFor(ConnectionState.connected, 2, 30000L);
-			//assertEquals("Verify connected state is reached", ConnectionState.connected, ably.connection.state);
 
 			/* verify that our token generator was called */
 			assertEquals("Expected token generator to be called", 1, authCallback.getCbCount());
@@ -233,7 +230,7 @@ public class RealtimeConnectFailTest {
 			/* end */
 			ably.close();
 			connectionWaiter.waitFor(ConnectionState.closed);
-			//assertEquals("Verify closed state is reached", ConnectionState.closed, ably.connection.state);
+			assertEquals("Verify closed state is reached", ConnectionState.closed, ably.connection.state);
 		} catch (AblyException e) {
 			e.printStackTrace();
 			fail("init0: Unexpected exception instantiating library");

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import io.ably.lib.rest.Auth;
 import io.ably.lib.realtime.ConnectionStateListener;
 import io.ably.lib.rest.Auth;
 import org.junit.AfterClass;
@@ -175,10 +176,14 @@ public class RealtimeConnectFailTest {
 	public void connect_token_expire_disconnected() {
 		try {
 			final Setup.TestVars optsTestVars = Setup.getTestVars();
-			ClientOptions optsForToken = optsTestVars.createOptions(optsTestVars.keys[0].keyStr);
-			//optsForToken.logLevel = Log.VERBOSE;
+			final ClientOptions optsForToken = optsTestVars.createOptions(optsTestVars.keys[0].keyStr);
+			optsForToken.logLevel = Log.VERBOSE;
 			final AblyRest ablyForToken = new AblyRest(optsForToken);
-			TokenDetails tokenDetails = ablyForToken.auth.requestToken(new TokenParams() {{ ttl = 8000L; }}, null);
+			Auth.AuthOptions restAuthOptions = new Auth.AuthOptions() {{
+				key = optsForToken.key;
+				queryTime = true;
+			}};
+			TokenDetails tokenDetails = ablyForToken.auth.requestToken(new TokenParams() {{ ttl = 8000L; }}, restAuthOptions);
 			assertNotNull("Expected token value", tokenDetails.token);
 
 			/* implement callback, using Ably instance with key */
@@ -199,7 +204,7 @@ public class RealtimeConnectFailTest {
 			ClientOptions opts = testVars.createOptions();
 			opts.tokenDetails = tokenDetails;
 			opts.authCallback = authCallback;
-			//opts.logLevel = Log.VERBOSE;
+			opts.logLevel = Log.VERBOSE;
 			AblyRealtime ably = new AblyRealtime(opts);
 
 			ably.connection.on(new ConnectionStateListener() {

--- a/lib/src/test/java/io/ably/lib/test/rest/RestAuthAttributeTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestAuthAttributeTest.java
@@ -1,5 +1,6 @@
 package io.ably.lib.test.rest;
 
+import io.ably.lib.rest.Auth;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -119,6 +120,7 @@ public class RestAuthAttributeTest {
 	public void auth_stores_options_exception_querytime() {
 		try {
 			setup();
+			Auth.clearCachedServerTime();
 			final long fakeServerTime = -1000;
 			final String expectedClientId = "testClientId";
 			Setup.TestVars testVars = Setup.getTestVars();


### PR DESCRIPTION
It's different from https://github.com/ably/ably-java/pull/158 in two aspects
1. Time offset is shared between all the connections.
2. Offset is used to calculate token expiration time if client time is off. This solves a lot of problems when client time is out of sync with server.