### PR TITLE
Request API support (RSC19)

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -10,4 +10,5 @@ dependencies {
   testCompile 'org.nanohttpd:nanohttpd-nanolets:2.2.0'
   testCompile 'org.nanohttpd:nanohttpd-websocket:2.2.0'
   testCompile 'org.mockito:mockito-core:1.10.19'
+  testCompile 'net.jodah:concurrentunit:0.4.2'
 }

--- a/lib/src/main/java/io/ably/lib/debug/DebugOptions.java
+++ b/lib/src/main/java/io/ably/lib/debug/DebugOptions.java
@@ -1,9 +1,29 @@
 package io.ably.lib.debug;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.List;
+import java.util.Map;
+
+import io.ably.lib.http.Http.RequestBody;
+import io.ably.lib.http.Http.Response;
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.ClientOptions;
+import io.ably.lib.types.ProtocolMessage;
 
 public class DebugOptions extends ClientOptions {
-	public RawProtocolListener protocolListener;
+	public interface RawProtocolListener {
+		public void onRawMessage(ProtocolMessage message);
+	}
+
+	public interface RawHttpListener {
+		public void onRawHttpRequest(String id, HttpURLConnection conn, String method, String authHeader, Map<String, List<String>> requestHeaders, RequestBody requestBody);
+		public void onRawHttpResponse(String id, Response response);
+		public void onRawHttpException(String id, Throwable t);
+	}
+
 	public DebugOptions(String key) throws AblyException { super(key); }
+
+	public RawProtocolListener protocolListener;
+	public RawHttpListener httpListener;
 }

--- a/lib/src/main/java/io/ably/lib/debug/RawProtocolListener.java
+++ b/lib/src/main/java/io/ably/lib/debug/RawProtocolListener.java
@@ -1,7 +1,0 @@
-package io.ably.lib.debug;
-
-import io.ably.lib.types.ProtocolMessage;
-
-public interface RawProtocolListener {
-	public void onRawMessage(ProtocolMessage message);
-}

--- a/lib/src/main/java/io/ably/lib/http/AsyncHttp.java
+++ b/lib/src/main/java/io/ably/lib/http/AsyncHttp.java
@@ -11,7 +11,6 @@ import java.util.concurrent.TimeoutException;
 
 import io.ably.lib.http.Http.RequestBody;
 import io.ably.lib.http.Http.ResponseHandler;
-import io.ably.lib.transport.Hosts;
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.Callback;
 import io.ably.lib.types.ErrorInfo;
@@ -30,6 +29,19 @@ public class AsyncHttp extends ThreadPoolExecutor {
 	 */
 	public <T> Future<T> get(String path, Param[] headers, Param[] params, ResponseHandler<T> responseHandler, Callback<T> callback) {
 		return ablyHttpExecuteWithFallback(path, Http.GET, headers, params, null, responseHandler, callback);
+	}
+
+	/**
+	 * Async HTTP PUT for Ably host, with fallbacks
+	 * @param path
+	 * @param headers
+	 * @param params
+	 * @param requestBody
+	 * @param responseHandler
+	 * @param callback
+	 */
+	public <T> Future<T> put(String path, Param[] headers, Param[] params, RequestBody requestBody, ResponseHandler<T> responseHandler, Callback<T> callback) {
+		return ablyHttpExecuteWithFallback(path, Http.PUT, headers, params, requestBody, responseHandler, callback);
 	}
 
 	/**
@@ -55,6 +67,20 @@ public class AsyncHttp extends ThreadPoolExecutor {
 	 */
 	public <T> Future<T> del(String path, Param[] headers, Param[] params, ResponseHandler<T> responseHandler, Callback<T> callback) {
 		return ablyHttpExecuteWithFallback(path, Http.DELETE, headers, params, null, responseHandler, callback);
+	}
+
+	/**
+	 * Async HTTP request for Ably host, with fallbacks
+	 * @param path
+	 * @param method
+	 * @param headers
+	 * @param params
+	 * @param requestBody
+	 * @param responseHandler
+	 * @param callback
+	 */
+	public <T> Future<T> exec(String path, String method, Param[] headers, Param[] params, RequestBody requestBody, ResponseHandler<T> responseHandler, Callback<T> callback) {
+		return ablyHttpExecuteWithFallback(path, method, headers, params, requestBody, responseHandler, callback);
 	}
 
 	/**************************
@@ -352,7 +378,7 @@ public class AsyncHttp extends ThreadPoolExecutor {
 			final ResponseHandler<T> responseHandler,
 			final Callback<T> callback) {
 
-		AblyRequestWithFallback<T> request = new AblyRequestWithFallback<>(path, method, headers, null, requestBody, responseHandler, callback);
+		AblyRequestWithFallback<T> request = new AblyRequestWithFallback<>(path, method, headers, params, requestBody, responseHandler, callback);
 		execute(request);
 		return request;
 	}
@@ -379,7 +405,7 @@ public class AsyncHttp extends ThreadPoolExecutor {
 			final ResponseHandler<T> responseHandler,
 			final Callback<T> callback) {
 
-		AblyRequestWithRetry<T> request = new AblyRequestWithRetry<>(host, path, method, headers, null, requestBody, responseHandler, callback);
+		AblyRequestWithRetry<T> request = new AblyRequestWithRetry<>(host, path, method, headers, params, requestBody, responseHandler, callback);
 		execute(request);
 		return request;
 	}

--- a/lib/src/main/java/io/ably/lib/http/AsyncPaginatedQuery.java
+++ b/lib/src/main/java/io/ably/lib/http/AsyncPaginatedQuery.java
@@ -9,6 +9,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import io.ably.lib.http.Http.BodyHandler;
+import io.ably.lib.http.Http.RequestBody;
 import io.ably.lib.http.Http.ResponseHandler;
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.AsyncPaginatedResult;
@@ -25,7 +26,7 @@ public class AsyncPaginatedQuery<T> implements ResponseHandler<AsyncPaginatedRes
 
 	/**
 	 * Construct a PaginatedQuery
-	 * 
+	 *
 	 * @param http. the http instance
 	 * @param path. the path of the resource being queried
 	 * @param headers. headers to pass into the first and all relative queries
@@ -33,10 +34,24 @@ public class AsyncPaginatedQuery<T> implements ResponseHandler<AsyncPaginatedRes
 	 * @param bodyHandler. handler to parse response bodies for first and all relative queries
 	 */
 	public AsyncPaginatedQuery(AsyncHttp http, String path, Param[] headers, Param[] params, BodyHandler<T> bodyHandler) {
+		this(http, path, headers, params, null, bodyHandler);
+	}
+
+	/**
+	 * Construct a PaginatedQuery
+	 *
+	 * @param http. the http instance
+	 * @param path. the path of the resource being queried
+	 * @param headers. headers to pass into the first and all relative queries
+	 * @param params. params to pass into the initial query
+	 * @param bodyHandler. handler to parse response bodies for first and all relative queries
+	 */
+	public AsyncPaginatedQuery(AsyncHttp http, String path, Param[] headers, Param[] params, RequestBody requestBody, BodyHandler<T> bodyHandler) {
 		this.http = http;
 		this.path = path;
 		this.headers = headers;
 		this.params = params;
+		this.requestBody = requestBody;
 		this.bodyHandler = bodyHandler;
 	}
 
@@ -47,6 +62,15 @@ public class AsyncPaginatedQuery<T> implements ResponseHandler<AsyncPaginatedRes
 	 */
 	public void get(Callback<AsyncPaginatedResult<T>> callback) {
 		http.get(path, headers, params, this, callback);
+	}
+
+	/**
+	 * Get the result of the first query
+	 * @param callback. On success returns A PaginatedResult<T> giving the
+	 * first page of results together with any available links to related results pages.
+	 */
+	public void exec(String method, Callback<AsyncPaginatedResult<T>> callback) {
+		http.exec(path, method, headers, params, requestBody, this, callback);
 	}
 
 	/**
@@ -151,5 +175,6 @@ public class AsyncPaginatedQuery<T> implements ResponseHandler<AsyncPaginatedRes
 	private String path;
 	private Param[] headers;
 	private Param[] params;
+	private RequestBody requestBody;
 	private BodyHandler<T> bodyHandler;
 }

--- a/lib/src/main/java/io/ably/lib/http/Http.java
+++ b/lib/src/main/java/io/ably/lib/http/Http.java
@@ -42,6 +42,7 @@ import io.ably.lib.util.Serialisation;
  */
 public class Http {
 	public static final String GET    = "GET";
+	public static final String PUT    = "PUT";
 	public static final String POST   = "POST";
 	public static final String DELETE = "DELETE";
 
@@ -245,6 +246,20 @@ public class Http {
 	}
 
 	/**
+	 * HTTP PUT for Ably host, with fallbacks
+	 * @param path
+	 * @param headers
+	 * @param params
+	 * @param requestBody
+	 * @param responseHandler
+	 * @return
+	 * @throws AblyException
+	 */
+	public <T> T put(String path, Param[] headers, Param[] params, RequestBody requestBody, ResponseHandler<T> responseHandler) throws AblyException {
+		return ablyHttpExecute(path, PUT, headers, params, requestBody, responseHandler);
+	}
+
+	/**
 	 * HTTP POST for Ably host, with fallbacks
 	 * @param path
 	 * @param headers
@@ -269,6 +284,21 @@ public class Http {
 	 */
 	public <T> T del(String path, Param[] headers, Param[] params, ResponseHandler<T> responseHandler) throws AblyException {
 		return ablyHttpExecute(path, DELETE, headers, params, null, responseHandler);
+	}
+
+	/**
+	 * HTTP request for Ably host, with fallbacks
+	 * @param path
+	 * @param method
+	 * @param headers
+	 * @param params
+	 * @param requestBody
+	 * @param responseHandler
+	 * @return
+	 * @throws AblyException
+	 */
+	public <T> T exec(String path, String method, Param[] headers, Param[] params, RequestBody requestBody, ResponseHandler<T> responseHandler) throws AblyException {
+		return ablyHttpExecute(path, method, headers, params, requestBody, responseHandler);
 	}
 
 	/**************************

--- a/lib/src/main/java/io/ably/lib/http/HttpUtils.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpUtils.java
@@ -3,7 +3,6 @@ package io.ably.lib.http;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -12,7 +11,6 @@ import com.google.gson.JsonElement;
 
 import io.ably.lib.BuildConfig;
 import io.ably.lib.http.Http.BodyHandler;
-import io.ably.lib.http.Http.ResponseHandler;
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.Param;
 import io.ably.lib.util.Serialisation;
@@ -97,26 +95,16 @@ public class HttpUtils {
 			if(!"application/json".equals(contentType)) {
 				return null;
 			}
-			JsonElement jsonItems = Serialisation.gsonParser.parse(new String(body, StandardCharsets.UTF_8));
-			if(!jsonItems.isJsonArray()) {
-				return null;
+			JsonElement jsonBody = Serialisation.gsonParser.parse(new String(body, StandardCharsets.UTF_8));
+			if(!jsonBody.isJsonArray()) {
+				return new JsonElement[] { jsonBody };
 			}
-			JsonArray jsonArray = jsonItems.getAsJsonArray();
+			JsonArray jsonArray = jsonBody.getAsJsonArray();
 			JsonElement[] items = new JsonElement[jsonArray.size()];
 			for(int i = 0; i < items.length; i++) {
 				items[i] = jsonArray.get(i);
 			}
 			return items;
-		}
-	};
-
-	public static ResponseHandler<JsonElement> jsonResponseHandler = new ResponseHandler<JsonElement>() {
-		@Override
-		public JsonElement handleResponse(int statusCode, String contentType, Collection<String> linkHeaders, byte[] body) throws AblyException {
-			if(!"application/json".equals(contentType)) {
-				return null;
-			}
-			return Serialisation.gsonParser.parse(new String(body, StandardCharsets.UTF_8));
 		}
 	};
 

--- a/lib/src/main/java/io/ably/lib/http/HttpUtils.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpUtils.java
@@ -1,6 +1,7 @@
 package io.ably.lib.http;
 
 import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -72,6 +73,26 @@ public class HttpUtils {
 			}
 		}
 		return builder.toString();
+	}
+
+	public static Map<String, String> decodeParams(String query) {
+	    Map<String, String> params = new HashMap<String, String>();
+	    String[] pairs = query.split("&");
+        try {
+		    for (String pair : pairs) {
+		        int idx = pair.indexOf('=');
+				params.put(URLDecoder.decode(pair.substring(0, idx), "UTF-8"), URLDecoder.decode(pair.substring(idx + 1), "UTF-8"));
+			}
+        } catch (UnsupportedEncodingException e) {}
+	    return params;
+	}
+
+	public static Map<String, String> indexParams(Param[] paramArray) {
+	    Map<String, String> params = new HashMap<String, String>();
+	    for (Param param : paramArray) {
+			params.put(param.key, param.value);
+		}
+	    return params;
 	}
 
 	public static String encodeURIComponent(String input) {

--- a/lib/src/main/java/io/ably/lib/http/PaginatedQuery.java
+++ b/lib/src/main/java/io/ably/lib/http/PaginatedQuery.java
@@ -1,6 +1,7 @@
 package io.ably.lib.http;
 
 import io.ably.lib.http.Http.BodyHandler;
+import io.ably.lib.http.Http.RequestBody;
 import io.ably.lib.http.Http.ResponseHandler;
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.ErrorInfo;
@@ -24,7 +25,7 @@ public class PaginatedQuery<T> implements ResponseHandler<PaginatedResult<T>> {
 
 	/**
 	 * Construct a PaginatedQuery
-	 * 
+	 *
 	 * @param http. the http instance
 	 * @param path. the path of the resource being queried
 	 * @param headers. headers to pass into the first and all relative queries
@@ -32,10 +33,24 @@ public class PaginatedQuery<T> implements ResponseHandler<PaginatedResult<T>> {
 	 * @param bodyHandler. handler to parse response bodies for first and all relative queries
 	 */
 	public PaginatedQuery(Http http, String path, Param[] headers, Param[] params, BodyHandler<T> bodyHandler) {
+		this(http, path, headers, params, null, bodyHandler);
+	}
+
+	/**
+	 * Construct a PaginatedQuery
+	 *
+	 * @param http. the http instance
+	 * @param path. the path of the resource being queried
+	 * @param headers. headers to pass into the first and all relative queries
+	 * @param params. params to pass into the initial query
+	 * @param bodyHandler. handler to parse response bodies for first and all relative queries
+	 */
+	public PaginatedQuery(Http http, String path, Param[] headers, Param[] params, RequestBody requestBody, BodyHandler<T> bodyHandler) {
 		this.http = http;
 		this.path = path;
 		this.headers = headers;
 		this.params = params;
+		this.requestBody = requestBody;
 		this.bodyHandler = bodyHandler;
 	}
 
@@ -47,6 +62,16 @@ public class PaginatedQuery<T> implements ResponseHandler<PaginatedResult<T>> {
 	 */
 	public PaginatedResult<T> get() throws AblyException {
 		return http.get(path, headers, params, this);
+	}
+
+	/**
+	 * Get the result of the first query
+	 * @return A PaginatedResult<T> giving the first page of results
+	 * together with any available links to related results pages.
+	 * @throws AblyException
+	 */
+	public PaginatedResult<T> exec(String method) throws AblyException {
+		return http.exec(path, method, headers, params, requestBody, this);
 	}
 
 	/**
@@ -145,5 +170,6 @@ public class PaginatedQuery<T> implements ResponseHandler<PaginatedResult<T>> {
 	private String path;
 	private Param[] headers;
 	private Param[] params;
+	private RequestBody requestBody;
 	private BodyHandler<T> bodyHandler;
 }

--- a/lib/src/main/java/io/ably/lib/rest/AblyRest.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyRest.java
@@ -152,48 +152,34 @@ public class AblyRest {
 	}
 
 	/**
-	 * Make a generic HTTP request for a collection of the given type
-	 * @param params query options: see Ably REST API documentation
-	 * for available options
-	 * @return a PaginatedResult of Stats records for the requested params
-	 * @throws AblyException
+	 * Make a generic HTTP request against an endpoint representing a collection
+	 * of some type; this is to provide a forward compatibility path for new APIs.
+	 * @param method: the HTTP method to use (see constants in io.ably.lib.http.Http)
+	 * @param path: the path component of the resource URI
+	 * @param params (optional; may be null): any parameters to send with the request; see API-specific documentation
+	 * @param body (optional; may be null): an instance of RequestBody; either a JSONRequestBody or ByteArrayRequestBody
+	 * @param headers (optional; may be null): any additional headers to send; see API-specific documentation
+	 * @return a page of results, each represented as a JsonElement
+	 * @throws AblyException if it was not possible to complete the request, or an error response was received
 	 */
-	public PaginatedResult<JsonElement> paginatedRequest(String method, String path, Param[] params, RequestBody body, Param[] headers) throws AblyException {
+	public PaginatedResult<JsonElement> request(String method, String path, Param[] params, RequestBody body, Param[] headers) throws AblyException {
 		headers = HttpUtils.mergeHeaders(HttpUtils.defaultAcceptHeaders(false), headers);
 		return new PaginatedQuery<JsonElement>(http, path, headers, params, body, HttpUtils.jsonArrayResponseHandler).exec(method);
 	}
 
 	/**
-	 * Asynchronously obtain usage statistics for this application using the REST API.
-	 * @param params: the request params. See the Ably REST API
-	 * @param callback
-	 * @return
+	 * Make an async generic HTTP request against an endpoint representing a collection
+	 * of some type; this is to provide a forward compatibility path for new APIs.
+	 * @param method: the HTTP method to use (see constants in io.ably.lib.http.Http)
+	 * @param path: the path component of the resource URI
+	 * @param params (optional; may be null): any parameters to send with the request; see API-specific documentation
+	 * @param body (optional; may be null): an instance of RequestBody; either a JSONRequestBody or ByteArrayRequestBody
+	 * @param headers (optional; may be null): any additional headers to send; see API-specific documentation
+	 * @param callback: called with the asynchronous result
 	 */
-	public void paginatedRequestAsync(String method, String path, Param[] params, RequestBody body, Param[] headers, Callback<AsyncPaginatedResult<JsonElement>> callback)  {
+	public void requestAsync(String method, String path, Param[] params, RequestBody body, Param[] headers, Callback<AsyncPaginatedResult<JsonElement>> callback)  {
 		headers = HttpUtils.mergeHeaders(HttpUtils.defaultAcceptHeaders(false), headers);
 		(new AsyncPaginatedQuery<JsonElement>(asyncHttp, path, headers, params, body, HttpUtils.jsonArrayResponseHandler)).exec(method, callback);
-	}
-
-	/**
-	 * Make a generic HTTP request for a collection of JsonElements
-	 * @param params query options: see Ably REST API documentation
-	 * for available options
-	 * @return a PaginatedResult of JsonElement records for the requested params
-	 * @throws AblyException
-	 */
-	public JsonElement request(String method, String path, Param[] params, RequestBody body, Param[] headers) throws AblyException {
-		headers = HttpUtils.mergeHeaders(HttpUtils.defaultAcceptHeaders(false), headers);
-		return http.exec(path, method, headers, params, body, HttpUtils.jsonResponseHandler);
-	}
-
-	/**
-	 * Asynchronously make a generic HTTP request for a JsonElement
-	 * @param params: the request params. See the Ably REST API
-	 * @param callback
-	 */
-	public void requestAsync(String method, String path, Param[] params, RequestBody requestBody, Param[] headers, Callback<JsonElement> callback)  {
-		headers = HttpUtils.mergeHeaders(HttpUtils.defaultAcceptHeaders(false), headers);
-		asyncHttp.exec(path, method, headers, params, requestBody, HttpUtils.jsonResponseHandler, callback);
 	}
 
 	/**

--- a/lib/src/main/java/io/ably/lib/rest/AblyRest.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyRest.java
@@ -160,7 +160,7 @@ public class AblyRest {
 	 */
 	public PaginatedResult<JsonElement> paginatedRequest(String method, String path, Param[] params, RequestBody body, Param[] headers) throws AblyException {
 		headers = HttpUtils.mergeHeaders(HttpUtils.defaultAcceptHeaders(false), headers);
-		return new PaginatedQuery<JsonElement>(http, path, headers, params, HttpUtils.jsonArrayResponseHandler).exec(method);
+		return new PaginatedQuery<JsonElement>(http, path, headers, params, body, HttpUtils.jsonArrayResponseHandler).exec(method);
 	}
 
 	/**
@@ -171,7 +171,7 @@ public class AblyRest {
 	 */
 	public void paginatedRequestAsync(String method, String path, Param[] params, RequestBody body, Param[] headers, Callback<AsyncPaginatedResult<JsonElement>> callback)  {
 		headers = HttpUtils.mergeHeaders(HttpUtils.defaultAcceptHeaders(false), headers);
-		(new AsyncPaginatedQuery<JsonElement>(asyncHttp, path, headers, params, HttpUtils.jsonArrayResponseHandler)).exec(method, callback);
+		(new AsyncPaginatedQuery<JsonElement>(asyncHttp, path, headers, params, body, HttpUtils.jsonArrayResponseHandler)).exec(method, callback);
 	}
 
 	/**

--- a/lib/src/main/java/io/ably/lib/rest/AblyRest.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyRest.java
@@ -3,9 +3,12 @@ package io.ably.lib.rest;
 import java.util.Collection;
 import java.util.HashMap;
 
+import com.google.gson.JsonElement;
+
 import io.ably.lib.http.AsyncHttp;
 import io.ably.lib.http.AsyncPaginatedQuery;
 import io.ably.lib.http.Http;
+import io.ably.lib.http.Http.RequestBody;
 import io.ably.lib.http.Http.ResponseHandler;
 import io.ably.lib.http.HttpUtils;
 import io.ably.lib.http.PaginatedQuery;
@@ -146,6 +149,51 @@ public class AblyRest {
 	 */
 	public void statsAsync(Param[] params, Callback<AsyncPaginatedResult<Stats>> callback)  {
 		(new AsyncPaginatedQuery<Stats>(asyncHttp, "/stats", HttpUtils.defaultAcceptHeaders(false), params, StatsReader.statsResponseHandler)).get(callback);
+	}
+
+	/**
+	 * Make a generic HTTP request for a collection of the given type
+	 * @param params query options: see Ably REST API documentation
+	 * for available options
+	 * @return a PaginatedResult of Stats records for the requested params
+	 * @throws AblyException
+	 */
+	public PaginatedResult<JsonElement> paginatedRequest(String method, String path, Param[] params, RequestBody body, Param[] headers) throws AblyException {
+		headers = HttpUtils.mergeHeaders(HttpUtils.defaultAcceptHeaders(false), headers);
+		return new PaginatedQuery<JsonElement>(http, path, headers, params, HttpUtils.jsonArrayResponseHandler).exec(method);
+	}
+
+	/**
+	 * Asynchronously obtain usage statistics for this application using the REST API.
+	 * @param params: the request params. See the Ably REST API
+	 * @param callback
+	 * @return
+	 */
+	public void paginatedRequestAsync(String method, String path, Param[] params, RequestBody body, Param[] headers, Callback<AsyncPaginatedResult<JsonElement>> callback)  {
+		headers = HttpUtils.mergeHeaders(HttpUtils.defaultAcceptHeaders(false), headers);
+		(new AsyncPaginatedQuery<JsonElement>(asyncHttp, path, headers, params, HttpUtils.jsonArrayResponseHandler)).exec(method, callback);
+	}
+
+	/**
+	 * Make a generic HTTP request for a collection of JsonElements
+	 * @param params query options: see Ably REST API documentation
+	 * for available options
+	 * @return a PaginatedResult of JsonElement records for the requested params
+	 * @throws AblyException
+	 */
+	public JsonElement request(String method, String path, Param[] params, RequestBody body, Param[] headers) throws AblyException {
+		headers = HttpUtils.mergeHeaders(HttpUtils.defaultAcceptHeaders(false), headers);
+		return http.exec(path, method, headers, params, body, HttpUtils.jsonResponseHandler);
+	}
+
+	/**
+	 * Asynchronously make a generic HTTP request for a JsonElement
+	 * @param params: the request params. See the Ably REST API
+	 * @param callback
+	 */
+	public void requestAsync(String method, String path, Param[] params, RequestBody requestBody, Param[] headers, Callback<JsonElement> callback)  {
+		headers = HttpUtils.mergeHeaders(HttpUtils.defaultAcceptHeaders(false), headers);
+		asyncHttp.exec(path, method, headers, params, requestBody, HttpUtils.jsonResponseHandler, callback);
 	}
 
 	/**

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1,8 +1,7 @@
 package io.ably.lib.transport;
 
 import io.ably.lib.debug.DebugOptions;
-import io.ably.lib.debug.RawProtocolListener;
-import io.ably.lib.http.TokenAuth;
+import io.ably.lib.debug.DebugOptions.RawProtocolListener;
 import io.ably.lib.realtime.*;
 import io.ably.lib.transport.ITransport.ConnectListener;
 import io.ably.lib.transport.ITransport.TransportParams;

--- a/lib/src/test/java/io/ably/lib/test/common/Helpers.java
+++ b/lib/src/test/java/io/ably/lib/test/common/Helpers.java
@@ -1,5 +1,6 @@
 package io.ably.lib.test.common;
 
+import java.net.HttpURLConnection;
 import java.util.*;
 
 import com.google.gson.Gson;
@@ -7,7 +8,11 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
-import io.ably.lib.debug.RawProtocolListener;
+import io.ably.lib.debug.DebugOptions.RawHttpListener;
+import io.ably.lib.debug.DebugOptions.RawProtocolListener;
+import io.ably.lib.http.Http.RequestBody;
+import io.ably.lib.http.Http.Response;
+import io.ably.lib.http.HttpUtils;
 import io.ably.lib.realtime.Channel;
 import io.ably.lib.realtime.Channel.MessageListener;
 import io.ably.lib.realtime.ChannelState;
@@ -631,6 +636,119 @@ public class Helpers {
 
 	public static boolean equalNullableStrings(String one, String two) {
 		return (one == null) ? (two == null) : one.equals(two);
+	}
+
+	public static class RawHttpRequest {
+		public String id;
+		public HttpURLConnection conn;
+		public String method;
+		public String authHeader;
+		public Map<String, List<String>> requestHeaders;
+		public RequestBody requestBody;
+		public Response response;
+		public Throwable error;
+	}
+
+	public static class RawHttpTracker extends LinkedHashMap<String, RawHttpRequest> implements RawHttpListener {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public void onRawHttpRequest(String id, HttpURLConnection conn, String method, String authHeader, Map<String, List<String>> requestHeaders,
+				RequestBody requestBody) {
+
+			/* duplicating if necessary, ensure lower-case versions of header names are present */
+			Map<String, List<String>> normalisedHeaders = new HashMap<String, List<String>>();
+			if(requestHeaders != null) {
+				normalisedHeaders.putAll(requestHeaders);
+				for(String header : requestHeaders.keySet()) {
+					normalisedHeaders.put(header.toLowerCase(), requestHeaders.get(header));
+				}
+			}
+			RawHttpRequest req = new RawHttpRequest();
+			req.id = id;
+			req.conn = conn;
+			req.method = method;
+			req.authHeader = authHeader;
+			req.requestHeaders = normalisedHeaders;
+			req.requestBody = requestBody;
+			put(id, req);
+		}
+
+		@Override
+		public void onRawHttpResponse(String id, Response response) {
+			/* duplicating if necessary, ensure lower-case versions of header names are present */
+			Map<String, List<String>> headers = response.headers;
+			Map<String, List<String>> normalisedHeaders = new HashMap<String, List<String>>();
+			if(headers != null) {
+				normalisedHeaders.putAll(headers);
+				for(String header : headers.keySet()) {
+					normalisedHeaders.put(header.toLowerCase(), headers.get(header));
+				}
+				response.headers = normalisedHeaders;
+			}
+
+			RawHttpRequest req = get(id);
+			if(req != null) {
+				req.response = response;
+			}
+		}
+
+		@Override
+		public void onRawHttpException(String id, Throwable t) {
+			RawHttpRequest req = get(id);
+			if(req != null) {
+				req.error = t;
+			}
+		}
+
+		public RawHttpRequest getFirstRequest() {
+			Collection<RawHttpRequest> reqs = values();
+			return (RawHttpRequest) reqs.toArray()[0];
+		}
+
+		public RawHttpRequest getLastRequest() {
+			Collection<RawHttpRequest> reqs = values();
+			return (RawHttpRequest) reqs.toArray()[reqs.size() - 1];
+		}
+
+		public String getRequestParam(String id, String param) {
+			String result = null;
+			RawHttpRequest req = get(id);
+			if(req != null) {
+				String query = req.conn.getURL().getQuery();
+				if(query != null && !query.isEmpty()) {
+					result = HttpUtils.decodeParams(query).get(param);
+				}
+			}
+			return result;
+		}
+
+		public List<String> getRequestHeader(String id, String header) {
+			List<String> result = null;
+			RawHttpRequest req = get(id);
+			if(req != null) {
+				header = header.toLowerCase();
+				if(header.equalsIgnoreCase("authorization")) {
+					result = Collections.singletonList(req.authHeader);
+				} else {
+					result = req.requestHeaders.get(header);
+				}
+			}
+			return result;
+		}
+
+		public List<String> getResponseHeader(String id, String header) {
+			List<String> result = null;
+			RawHttpRequest req = get(id);
+			if(req != null) {
+				header = header.toLowerCase();
+				List<String>headers = req.response.headers.get(header);
+				if(headers != null && headers.size() > 0) {
+					result = headers;
+				}
+			}
+			return result;
+		}
 	}
 
 	public static class RandomGenerator {

--- a/lib/src/test/java/io/ably/lib/test/rest/RestRequestTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestRequestTest.java
@@ -1,0 +1,287 @@
+package io.ably.lib.test.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.gson.JsonElement;
+
+import io.ably.lib.http.Http;
+import io.ably.lib.http.Http.JSONRequestBody;
+import io.ably.lib.rest.AblyRest;
+import io.ably.lib.rest.Channel;
+import io.ably.lib.test.common.ParameterizedTest;
+import io.ably.lib.types.AblyException;
+import io.ably.lib.types.AsyncPaginatedResult;
+import io.ably.lib.types.Callback;
+import io.ably.lib.types.ClientOptions;
+import io.ably.lib.types.ErrorInfo;
+import io.ably.lib.types.Message;
+import io.ably.lib.types.PaginatedResult;
+import io.ably.lib.types.Param;
+
+public class RestRequestTest extends ParameterizedTest {
+
+	private AblyRest ably;
+	private String channelName;
+	private String channelAltName;
+	private String channelNamePrefix;
+	private String channelPath;
+	private String channelsPath;
+	private String channelMessagesPath;
+
+	@Before
+	public void setUpBefore() throws Exception {
+		ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+		ably = new AblyRest(opts);
+		channelNamePrefix = "persisted:rest_request_";
+		channelName = "persisted:rest_request_test_" + testParams.name;
+		channelAltName = "persisted:rest_request_alt_" + testParams.name;
+		channelsPath = "/channels";
+		channelPath = channelsPath + "/" + channelName;
+		channelMessagesPath = channelPath + "/messages";
+
+		/* publish events */
+		Channel channel = ably.channels.get(channelName);
+		for(int i = 0; i < 4; i++) {
+			channel.publish("Test event", "Test data " + i);
+		}
+		Channel altChannel = ably.channels.get(channelAltName);
+		for(int i = 0; i < 4; i++) {
+			altChannel.publish("Test event", "Test alt data " + i);
+		}
+
+		/* wait to persist */
+		try { Thread.sleep(1000L); } catch(InterruptedException ie) {}
+	}
+
+	/**
+	 * Get channel details using the request() API
+	 */
+	@Test
+	public void request_simple() {
+		try {
+			JsonElement channelDetails = ably.request(Http.GET, channelPath, null, null, null);
+			/* check it looks like a ChannelDetails */
+			assertNotNull("Verify a result is returned", channelDetails);
+			assertTrue("Verify an object is returned", channelDetails.isJsonObject());
+			assertTrue("Verify id member is present", channelDetails.getAsJsonObject().has("id"));
+			assertEquals("Verify id member is channelName", channelName, channelDetails.getAsJsonObject().get("id").getAsString());
+		} catch(AblyException e) {
+			e.printStackTrace();
+			fail("request_simple: Unexpected exception");
+			return;
+		}
+	}
+
+	/**
+	 * Get channel details using the requestAsync() API
+	 */
+	@Test
+	public void request_simple_async() {
+		ably.requestAsync(Http.GET, channelPath, null, null, null, new Callback<JsonElement>() {
+			@Override
+			public void onSuccess(JsonElement channelDetails) {
+				/* check it looks like a ChannelDetails */
+				assertNotNull("Verify a result is returned", channelDetails);
+				assertTrue("Verify an object is returned", channelDetails.isJsonObject());
+				assertTrue("Verify id member is present", channelDetails.getAsJsonObject().has("id"));
+				assertEquals("Verify id member is channelName", channelName, channelDetails.getAsJsonObject().get("id").getAsString());
+			}
+			@Override
+			public void onError(ErrorInfo reason) {
+				fail("request_simple_async: Unexpected exception");
+			}
+		});
+	}
+
+	/**
+	 * Get channel details using the paginatedRequest() API
+	 */
+	@Test
+	public void request_paginated() {
+		try {
+			Param[] params = new Param[] { new Param("prefix", channelNamePrefix) };
+			PaginatedResult<JsonElement> channels = ably.paginatedRequest(Http.GET, channelsPath, params, null, null);
+			/* check it looks like an array of ChannelDetails */
+			assertNotNull("Verify a result is returned", channels);
+			JsonElement[] items = channels.items();
+			assertTrue("Verify at least two channels are returned", items.length >= 2);
+			for(int i = 0; i < items.length; i++) {
+				assertTrue("Verify id member is a matching channelName", items[i].getAsJsonObject().get("id").getAsString().startsWith(channelNamePrefix));
+			}
+		} catch(AblyException e) {
+			e.printStackTrace();
+			fail("request_simple: Unexpected exception");
+			return;
+		}
+	}
+
+	/**
+	 * Get channel details using the paginatedRequestAsync() API
+	 */
+	@Test
+	public void request_paginated_async() {
+		Param[] params = new Param[] { new Param("prefix", channelNamePrefix) };
+		ably.paginatedRequestAsync(Http.GET, channelsPath, params, null, null, new Callback<AsyncPaginatedResult<JsonElement>>() {
+			@Override
+			public void onSuccess(AsyncPaginatedResult<JsonElement> result) {
+				/* check it looks like an array of ChannelDetails */
+				assertNotNull("Verify a result is returned", result);
+				JsonElement[] items = result.items();
+				assertTrue("Verify at least two channels are returned", items.length >= 2);
+				for(int i = 0; i < items.length; i++) {
+					assertTrue("Verify id member is a matching channelName", items[i].getAsJsonObject().get("id").getAsString().startsWith(channelNamePrefix));
+				}
+			}
+			@Override
+			public void onError(ErrorInfo reason) {
+				fail("request_paginated_async: Unexpected exception");
+			}
+		});
+	}
+
+	/**
+	 * Get channel details using the paginatedRequest() API with a specified limit,
+	 * checking pagination links
+	 */
+	@Test
+	public void request_paginated_limit() {
+		try {
+			Param[] params = new Param[] { new Param("prefix", channelNamePrefix), new Param("limit", "1") };
+			PaginatedResult<JsonElement> channels = ably.paginatedRequest(Http.GET, channelsPath, params, null, null);
+			/* check it looks like an array of ChannelDetails */
+			assertNotNull("Verify a result is returned", channels);
+			JsonElement[] items = channels.items();
+			assertTrue("Verify one channel is returned", items.length == 1);
+			for(int i = 0; i < items.length; i++) {
+				assertTrue("Verify id member is a matching channelName", items[i].getAsJsonObject().get("id").getAsString().startsWith(channelNamePrefix));
+			}
+			/* get next page */
+			channels = channels.next();
+			assertNotNull("Verify a result is returned", channels);
+			items = channels.items();
+			assertTrue("Verify one channels is returned", items.length == 1);
+			for(int i = 0; i < items.length; i++) {
+				assertTrue("Verify id member is a matching channelName", items[i].getAsJsonObject().get("id").getAsString().startsWith(channelNamePrefix));
+			}
+		} catch(AblyException e) {
+			e.printStackTrace();
+			fail("request_simple: Unexpected exception");
+			return;
+		}
+	}
+
+	/**
+	 * Get channel details using the paginatedRequestAsync() API with a specified limit,
+	 * checking pagination links
+	 */
+	@Test
+	public void request_paginated_async_limit() {
+		Param[] params = new Param[] { new Param("prefix", channelNamePrefix), new Param("limit", "1") };
+		ably.paginatedRequestAsync(Http.GET, channelsPath, params, null, null, new Callback<AsyncPaginatedResult<JsonElement>>() {
+			@Override
+			public void onSuccess(AsyncPaginatedResult<JsonElement> result) {
+				/* check it looks like an array of ChannelDetails */
+				assertNotNull("Verify a result is returned", result);
+				JsonElement[] items = result.items();
+				assertTrue("Verify one channel is returned", items.length == 1);
+				for(int i = 0; i < items.length; i++) {
+					assertTrue("Verify id member is a matching channelName", items[i].getAsJsonObject().get("id").getAsString().startsWith(channelNamePrefix));
+				}
+				result.next(new Callback<AsyncPaginatedResult<JsonElement>>() {
+					@Override
+					public void onSuccess(AsyncPaginatedResult<JsonElement> result) {
+						/* check it looks like an array of ChannelDetails */
+						assertNotNull("Verify a result is returned", result);
+						JsonElement[] items = result.items();
+						assertTrue("Verify one channel is returned", items.length == 1);
+						for(int i = 0; i < items.length; i++) {
+							assertTrue("Verify id member is a matching channelName", items[i].getAsJsonObject().get("id").getAsString().startsWith(channelNamePrefix));
+						}
+					}
+					@Override
+					public void onError(ErrorInfo reason) {
+						fail("request_paginated_async: Unexpected exception");
+					}					
+				});
+			}
+			@Override
+			public void onError(ErrorInfo reason) {
+				fail("request_paginated_async: Unexpected exception");
+			}
+		});
+	}
+
+	/**
+	 * Publish a message using the request() API
+	 */
+	@Test
+	public void request_post() {
+		final String messageData = "Test data (request_post)";
+		try {
+			/* publish a message */
+			Message message = new Message("Test event", messageData);
+			JSONRequestBody requestBody = new JSONRequestBody(message);
+			ably.request(Http.POST, channelMessagesPath, null, requestBody, null);
+
+			/* wait to persist */
+			try { Thread.sleep(1000L); } catch(InterruptedException ie) {}
+
+			/* get the history */
+			Param[] params = new Param[] { new Param("limit", "1") };
+			PaginatedResult<Message> resultPage = ably.channels.get(channelName).history(params);
+
+			/* check it looks like a result page */
+			assertNotNull("Verify a result is returned", resultPage);
+			assertTrue("Verify an single message is returned", resultPage.items().length == 1);
+			assertEquals("Verify returned message was the one posted", messageData, resultPage.items()[0].data);
+		} catch(AblyException e) {
+			e.printStackTrace();
+			fail("request_post: Unexpected exception");
+			return;
+		}
+	}
+
+	/**
+	 * Publish a message using the requestAsync() API
+	 */
+	@Test
+	public void request_post_async() {
+		final String messageData = "Test data (request_post_async)";
+		/* publish a message */
+		Message message = new Message("Test event", messageData);
+		JSONRequestBody requestBody = new JSONRequestBody(message);
+		ably.requestAsync(Http.POST, channelMessagesPath, null, requestBody, null, new Callback<JsonElement>() {
+			@Override
+			public void onSuccess(JsonElement result) {
+				/* wait to persist */
+				try { Thread.sleep(1000L); } catch(InterruptedException ie) {}
+
+				/* get the history */
+				Param[] params = new Param[] { new Param("limit", "1") };
+				PaginatedResult<Message> resultPage;
+				try {
+					resultPage = ably.channels.get(channelName).history(params);
+
+					/* check it looks like a result page */
+					assertNotNull("Verify a result is returned", resultPage);
+					assertTrue("Verify an single message is returned", resultPage.items().length == 1);
+					assertEquals("Verify returned message was the one posted", messageData, resultPage.items()[0].data);
+				} catch (AblyException e) {
+					e.printStackTrace();
+					fail("request_post_async: Unexpected exception");
+				}
+			}
+			@Override
+			public void onError(ErrorInfo reason) {
+				fail("request_post_async: Unexpected exception");
+			}				
+		});
+	}
+
+}

--- a/lib/src/test/java/io/ably/lib/test/rest/RestRequestTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestRequestTest.java
@@ -65,9 +65,12 @@ public class RestRequestTest extends ParameterizedTest {
 	@Test
 	public void request_simple() {
 		try {
-			JsonElement channelDetails = ably.request(Http.GET, channelPath, null, null, null);
+			PaginatedResult<JsonElement> channelResponse = ably.request(Http.GET, channelPath, null, null, null);
 			/* check it looks like a ChannelDetails */
-			assertNotNull("Verify a result is returned", channelDetails);
+			assertNotNull("Verify a result is returned", channelResponse);
+			JsonElement[] items = channelResponse.items();
+			assertEquals("Verify a single items is returned", items.length, 1);
+			JsonElement channelDetails = items[0];
 			assertTrue("Verify an object is returned", channelDetails.isJsonObject());
 			assertTrue("Verify id member is present", channelDetails.getAsJsonObject().has("id"));
 			assertEquals("Verify id member is channelName", channelName, channelDetails.getAsJsonObject().get("id").getAsString());
@@ -83,11 +86,14 @@ public class RestRequestTest extends ParameterizedTest {
 	 */
 	@Test
 	public void request_simple_async() {
-		ably.requestAsync(Http.GET, channelPath, null, null, null, new Callback<JsonElement>() {
+		ably.requestAsync(Http.GET, channelPath, null, null, null, new Callback<AsyncPaginatedResult<JsonElement>>() {
 			@Override
-			public void onSuccess(JsonElement channelDetails) {
+			public void onSuccess(AsyncPaginatedResult<JsonElement> result) {
 				/* check it looks like a ChannelDetails */
-				assertNotNull("Verify a result is returned", channelDetails);
+				assertNotNull("Verify a result is returned", result);
+				JsonElement[] items = result.items();
+				assertEquals("Verify a single items is returned", items.length, 1);
+				JsonElement channelDetails = items[0];
 				assertTrue("Verify an object is returned", channelDetails.isJsonObject());
 				assertTrue("Verify id member is present", channelDetails.getAsJsonObject().has("id"));
 				assertEquals("Verify id member is channelName", channelName, channelDetails.getAsJsonObject().get("id").getAsString());
@@ -106,7 +112,7 @@ public class RestRequestTest extends ParameterizedTest {
 	public void request_paginated() {
 		try {
 			Param[] params = new Param[] { new Param("prefix", channelNamePrefix) };
-			PaginatedResult<JsonElement> channels = ably.paginatedRequest(Http.GET, channelsPath, params, null, null);
+			PaginatedResult<JsonElement> channels = ably.request(Http.GET, channelsPath, params, null, null);
 			/* check it looks like an array of ChannelDetails */
 			assertNotNull("Verify a result is returned", channels);
 			JsonElement[] items = channels.items();
@@ -127,7 +133,7 @@ public class RestRequestTest extends ParameterizedTest {
 	@Test
 	public void request_paginated_async() {
 		Param[] params = new Param[] { new Param("prefix", channelNamePrefix) };
-		ably.paginatedRequestAsync(Http.GET, channelsPath, params, null, null, new Callback<AsyncPaginatedResult<JsonElement>>() {
+		ably.requestAsync(Http.GET, channelsPath, params, null, null, new Callback<AsyncPaginatedResult<JsonElement>>() {
 			@Override
 			public void onSuccess(AsyncPaginatedResult<JsonElement> result) {
 				/* check it looks like an array of ChannelDetails */
@@ -153,7 +159,7 @@ public class RestRequestTest extends ParameterizedTest {
 	public void request_paginated_limit() {
 		try {
 			Param[] params = new Param[] { new Param("prefix", channelNamePrefix), new Param("limit", "1") };
-			PaginatedResult<JsonElement> channels = ably.paginatedRequest(Http.GET, channelsPath, params, null, null);
+			PaginatedResult<JsonElement> channels = ably.request(Http.GET, channelsPath, params, null, null);
 			/* check it looks like an array of ChannelDetails */
 			assertNotNull("Verify a result is returned", channels);
 			JsonElement[] items = channels.items();
@@ -183,7 +189,7 @@ public class RestRequestTest extends ParameterizedTest {
 	@Test
 	public void request_paginated_async_limit() {
 		Param[] params = new Param[] { new Param("prefix", channelNamePrefix), new Param("limit", "1") };
-		ably.paginatedRequestAsync(Http.GET, channelsPath, params, null, null, new Callback<AsyncPaginatedResult<JsonElement>>() {
+		ably.requestAsync(Http.GET, channelsPath, params, null, null, new Callback<AsyncPaginatedResult<JsonElement>>() {
 			@Override
 			public void onSuccess(AsyncPaginatedResult<JsonElement> result) {
 				/* check it looks like an array of ChannelDetails */
@@ -256,9 +262,9 @@ public class RestRequestTest extends ParameterizedTest {
 		/* publish a message */
 		Message message = new Message("Test event", messageData);
 		JSONRequestBody requestBody = new JSONRequestBody(message);
-		ably.requestAsync(Http.POST, channelMessagesPath, null, requestBody, null, new Callback<JsonElement>() {
+		ably.requestAsync(Http.POST, channelMessagesPath, null, requestBody, null, new Callback<AsyncPaginatedResult<JsonElement>>() {
 			@Override
-			public void onSuccess(JsonElement result) {
+			public void onSuccess(AsyncPaginatedResult<JsonElement> result) {
 				/* wait to persist */
 				try { Thread.sleep(1000L); } catch(InterruptedException ie) {}
 
@@ -280,7 +286,7 @@ public class RestRequestTest extends ParameterizedTest {
 			@Override
 			public void onError(ErrorInfo reason) {
 				fail("request_post_async: Unexpected exception");
-			}				
+			}
 		});
 	}
 

--- a/lib/src/test/java/io/ably/lib/test/rest/RestRequestTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestRequestTest.java
@@ -14,7 +14,7 @@ import com.google.gson.JsonElement;
 
 import io.ably.lib.debug.DebugOptions;
 import io.ably.lib.http.Http;
-import io.ably.lib.http.Http.JSONRequestBody;
+import io.ably.lib.http.Http.JsonRequestBody;
 import io.ably.lib.rest.AblyRest;
 import io.ably.lib.rest.Channel;
 import io.ably.lib.test.common.Helpers.RawHttpRequest;
@@ -350,7 +350,7 @@ public class RestRequestTest extends ParameterizedTest {
 
 			/* publish a message */
 			Message message = new Message("Test event", messageData);
-			JSONRequestBody requestBody = new JSONRequestBody(message);
+			JsonRequestBody requestBody = new JsonRequestBody(message);
 			ably.request(Http.POST, channelMessagesPath, null, requestBody, null);
 			RawHttpRequest req = httpListener.getLastRequest();
 
@@ -397,7 +397,7 @@ public class RestRequestTest extends ParameterizedTest {
 
 			/* publish a message */
 			Message message = new Message("Test event", messageData);
-			JSONRequestBody requestBody = new JSONRequestBody(message);
+			JsonRequestBody requestBody = new JsonRequestBody(message);
 			ably.requestAsync(Http.POST, channelMessagesPath, null, requestBody, null, new Callback<AsyncPaginatedResult<JsonElement>>() {
 				@Override
 				public void onSuccess(AsyncPaginatedResult<JsonElement> result) {

--- a/lib/src/test/java/io/ably/lib/test/rest/RestSuite.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestSuite.java
@@ -15,6 +15,7 @@ import io.ably.lib.test.common.Setup;
 @SuiteClasses({
 	HttpTest.class,
 	HttpHeaderTest.class,
+	RestRequestTest.class,
 	RestAppStatsTest.class,
 	RestInitTest.class,
 	RestTimeTest.class,


### PR DESCRIPTION
This is an initial implementation and tests for the generic request API.

There are issues with the API in Java that are not evident in dynamic languages, and also implementation issues in Java.

Firstly, our `PaginatedQuery<T>` primitive is parameterised by the type `T` of the members of a collection that are the subject of the request. That is, the request returns instances of `PaginatedResult<T>` that wraps arrays of type `T`. So for the `stats()` API, for example, we use a `PaginatedQuery<Stats>`, and we get back a page of results containing a `Stats[] items`.

This means that the current API is hard-wired to return arrays of results rather than single objects. To change that we would either have to have an `items` that is essentially untyped (ie it might be an array or an object, which is very unfriendly for the majority use-case) or we allow a result page to have both `T item` and `T[] items` members, with one or other being populated, which is also a bit ugly.

In this implementation I've opted instead for different methods on the `Rest` object: a `request()` method, which returns single objects, and a `paginatedRequest()`, which returns paginated responses, with arrays of members.

There are `Async` variants of each method.

The other implementation issue we have is that you can't get the msgpack library to return a `JsonElement`; and in fact the subset of the msgpack library that we include doesn't do reflection-based construction of types for deserialisation - so in fact there is no generic way to return an untyped and navigable structure for msgpack responses as there is for JSON. This implementation does not include support for msgpack; and the API is hard-coded to return `JsonElement`s; and it uses JSON even if `useBinaryProtocol=true`.

There are no tests for the `DELETE` method because there's nothing currently in the REST API that we can call.

