### PR TITLE
Remove proguard warnings for missing dependencies of msgpack library

### DIFF
--- a/android/proguard.txt
+++ b/android/proguard.txt
@@ -1,3 +1,4 @@
 -keep public class io.ably.lib.transport.WebSocketTransport$Factory {*;}
 -keep class io.ably.lib.types.** {*;}
 -keep class org.msgpack.core.** {*;}
+-dontwarn org.msgpack.core.buffer.**


### PR DESCRIPTION
Fixes: https://github.com/ably/ably-java/issues/279