### PR TITLE
Add log message if a client's listener throws an exception whilst handling a message

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/Channel.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Channel.java
@@ -627,7 +627,9 @@ public class Channel extends EventEmitter<ChannelEvent, ChannelStateListener> {
 			for(MessageListener member : members)
 				try {
 					member.onMessage(message);
-				} catch(Throwable t) {}
+				} catch (Throwable t) {
+					Log.e(TAG, "Unexpected exception calling listener", t);
+				}
 		}
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/ably/ably-java/issues/314