### PR TITLE
Crypto default 256 bit length like all other libraries

### DIFF
--- a/lib/src/main/java/io/ably/lib/util/Crypto.java
+++ b/lib/src/main/java/io/ably/lib/util/Crypto.java
@@ -20,7 +20,7 @@ import io.ably.lib.types.ErrorInfo;
 /**
  * Utility classes and interfaces for message payload encryption.
  *
- * This class supports AES/CBC/PKCS5 with a default key length of 128 bits
+ * This class supports AES/CBC/PKCS5 with a default key length of 256 bits
  * but supporting other key lengths. Other algorithms and chaining modes are
  * not supported directly, but supportable by extending/implementing the base
  * classes and interfaces here.
@@ -37,7 +37,7 @@ import io.ably.lib.types.ErrorInfo;
 public class Crypto {
 
 	public static final String DEFAULT_ALGORITHM = "aes";
-	public static final int DEFAULT_KEYLENGTH = 128; // bits
+	public static final int DEFAULT_KEYLENGTH = 256; // bits
 	public static final int DEFAULT_BLOCKLENGTH = 16; // bytes
 
 	/**

--- a/lib/src/main/java/io/ably/lib/util/Crypto.java
+++ b/lib/src/main/java/io/ably/lib/util/Crypto.java
@@ -37,7 +37,7 @@ import io.ably.lib.types.ErrorInfo;
 public class Crypto {
 
 	public static final String DEFAULT_ALGORITHM = "aes";
-	public static final int DEFAULT_KEYLENGTH = 256; // bits
+	public static final int DEFAULT_KEYLENGTH = is256BitsSupported() ? 256 : 128; // bits
 	public static final int DEFAULT_BLOCKLENGTH = 16; // bytes
 
 	/**
@@ -287,6 +287,19 @@ public class Crypto {
 			new byte[] {15,15,15,15,15,15,15,15,15,15,15,15,15,15,15},
 			new byte[] {16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16}
 		};
+	}
+
+	/**
+	 * Determine whether or not 256-bit AES is supported. (If this determines that
+	 * it is not supported, install the JCE unlimited strength JCE extensions).
+	 * @return
+	 */
+	private static boolean is256BitsSupported() {
+		try {
+			return Cipher.getMaxAllowedKeyLength(DEFAULT_ALGORITHM) >= 256;
+		} catch (NoSuchAlgorithmException e) {
+			return false;
+		}
 	}
 
 	/**


### PR DESCRIPTION
I am not sure I understand why Java is the only lib with a default key length different to the other libs, so I have changed this to 256 bits like the others and according to the spec.