### PR TITLE
Don't send authHeaders or authParams in calls to requestToken

### DIFF
--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -647,7 +647,7 @@ public class Auth {
 		}
 
 		String tokenPath = "/keys/" + signedTokenRequest.keyName + "/requestToken";
-		return ably.http.post(tokenPath, tokenOptions.authHeaders, tokenOptions.authParams, new Http.JsonRequestBody(signedTokenRequest.asJsonElement().toString()), new ResponseHandler<TokenDetails>() {
+		return ably.http.post(tokenPath, null, null, new Http.JsonRequestBody(signedTokenRequest.asJsonElement().toString()), new ResponseHandler<TokenDetails>() {
 			@Override
 			public TokenDetails handleResponse(Response response, ErrorInfo error) throws AblyException {
 				if(error != null) {


### PR DESCRIPTION
Fixes: https://github.com/ably/ably-java/issues/331