### PR TITLE
Preemptive HTTP authentication

### DIFF
--- a/lib/src/main/java/io/ably/lib/http/AsyncHttpPaginatedQuery.java
+++ b/lib/src/main/java/io/ably/lib/http/AsyncHttpPaginatedQuery.java
@@ -36,7 +36,7 @@ public class AsyncHttpPaginatedQuery implements ResponseHandler<AsyncHttpPaginat
 	}
 
 	public void exec(Param[] params, final AsyncHttpPaginatedResponse.Callback callback) {
-		http.exec(path, method, headers, params, requestBody, this, wrap(callback));
+		http.exec(path, method, headers, params, requestBody, this, true, wrap(callback));
 	}
 
 	/**

--- a/lib/src/main/java/io/ably/lib/http/AsyncPaginatedQuery.java
+++ b/lib/src/main/java/io/ably/lib/http/AsyncPaginatedQuery.java
@@ -61,7 +61,7 @@ public class AsyncPaginatedQuery<T> implements ResponseHandler<AsyncPaginatedRes
 	 * first page of results together with any available links to related results pages.
 	 */
 	public void get(Callback<AsyncPaginatedResult<T>> callback) {
-		http.get(path, headers, params, this, callback);
+		http.get(path, headers, params, this, true, callback);
 	}
 
 	/**
@@ -79,7 +79,7 @@ public class AsyncPaginatedQuery<T> implements ResponseHandler<AsyncPaginatedRes
 	 * first page of results together with any available links to related results pages.
 	 */
 	public void exec(String method, Param[] params, Callback<AsyncPaginatedResult<T>> callback) {
-		http.exec(path, method, headers, params, requestBody, this, callback);
+		http.exec(path, method, headers, params, requestBody, this, true, callback);
 	}
 
 	/**
@@ -138,7 +138,7 @@ public class AsyncPaginatedQuery<T> implements ResponseHandler<AsyncPaginatedRes
 					params[i] = new Param(split[0], URLDecoder.decode(split[1], "UTF-8"));
 				}
 			} catch(UnsupportedEncodingException uee) {}
-			http.get(path, headers, params, AsyncPaginatedQuery.this, callback);
+			http.get(path, headers, params, AsyncPaginatedQuery.this, true, callback);
 		}
 	
 		@Override

--- a/lib/src/main/java/io/ably/lib/http/HttpPaginatedQuery.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpPaginatedQuery.java
@@ -40,7 +40,7 @@ public class HttpPaginatedQuery implements ResponseHandler<HttpPaginatedResponse
 	 * @throws AblyException
 	 */
 	public HttpPaginatedResponse exec() throws AblyException {
-		return http.exec(path, method, requestHeaders, requestParams, requestBody, this);
+		return http.exec(path, method, requestHeaders, requestParams, requestBody, this, true);
 	}
 
 	/**
@@ -50,7 +50,7 @@ public class HttpPaginatedQuery implements ResponseHandler<HttpPaginatedResponse
 	 * @throws AblyException
 	 */
 	public HttpPaginatedResponse exec(Param[] params) throws AblyException {
-		return http.exec(path, method, requestHeaders, params, requestBody, this);
+		return http.exec(path, method, requestHeaders, params, requestBody, this, true);
 	}
 
 	@Override

--- a/lib/src/main/java/io/ably/lib/http/PaginatedQuery.java
+++ b/lib/src/main/java/io/ably/lib/http/PaginatedQuery.java
@@ -62,7 +62,7 @@ public class PaginatedQuery<T> implements ResponseHandler<PaginatedResult<T>> {
 	 * @throws AblyException
 	 */
 	public PaginatedResult<T> get() throws AblyException {
-		return http.get(path, requestHeaders, requestParams, this);
+		return http.get(path, requestHeaders, requestParams, this, true);
 	}
 
 	/**
@@ -72,7 +72,7 @@ public class PaginatedQuery<T> implements ResponseHandler<PaginatedResult<T>> {
 	 * @throws AblyException
 	 */
 	public PaginatedResult<T> exec(String method) throws AblyException {
-		return http.exec(path, method, requestHeaders, requestParams, requestBody, this);
+		return http.exec(path, method, requestHeaders, requestParams, requestBody, this, true);
 	}
 
 	/**
@@ -118,7 +118,7 @@ public class PaginatedQuery<T> implements ResponseHandler<PaginatedResult<T>> {
 						params[i] = new Param(split[0], URLDecoder.decode(split[1], "UTF-8"));
 					}
 				} catch(UnsupportedEncodingException uee) {}
-				return http.get(path, requestHeaders, params, PaginatedQuery.this);
+				return http.get(path, requestHeaders, params, PaginatedQuery.this, true);
 			}
 			throw AblyException.fromErrorInfo(new ErrorInfo("Unexpected link URL format", 500, 50000));
 		}

--- a/lib/src/main/java/io/ably/lib/rest/AblyRest.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyRest.java
@@ -126,7 +126,7 @@ public class AblyRest {
 					throw AblyException.fromErrorInfo(error);
 				}
 				return (Long)Serialisation.gson.fromJson(new String(response.body), Long[].class)[0];
-			}}).longValue();
+			}}, false).longValue();
 	}
 
 	/**
@@ -145,7 +145,7 @@ public class AblyRest {
 				}
 				return Serialisation.gson.fromJson(new String(response.body), Long[].class)[0];
 			}
-		}, callback);
+		}, false, callback);
 	}
 
 	/**

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -659,7 +659,7 @@ public class Auth {
 					throw AblyException.fromThrowable(e);
 				}
 			}
-		});
+		}, false);
 	}
 
 	/**

--- a/lib/src/main/java/io/ably/lib/rest/Channel.java
+++ b/lib/src/main/java/io/ably/lib/rest/Channel.java
@@ -53,7 +53,7 @@ public class Channel {
 		ably.auth.checkClientId(message, true, false);
 		message.encode(options);
 		RequestBody requestBody = ably.options.useBinaryProtocol ? MessageSerializer.asMsgpackRequest(message) : MessageSerializer.asJsonRequest(message);
-		ably.http.post(basePath + "/messages", HttpUtils.defaultAcceptHeaders(ably.options.useBinaryProtocol), null, requestBody, null);
+		ably.http.post(basePath + "/messages", HttpUtils.defaultAcceptHeaders(ably.options.useBinaryProtocol), null, requestBody, null, true);
 	}
 
 	/**
@@ -71,7 +71,7 @@ public class Channel {
 			message.encode(options);
 		}
 		RequestBody requestBody = ably.options.useBinaryProtocol ? MessageSerializer.asMsgpackRequest(messages) : MessageSerializer.asJsonRequest(messages);
-		ably.http.post(basePath + "/messages", HttpUtils.defaultAcceptHeaders(ably.options.useBinaryProtocol), null, requestBody, null);
+		ably.http.post(basePath + "/messages", HttpUtils.defaultAcceptHeaders(ably.options.useBinaryProtocol), null, requestBody, null, true);
 	}
 
 	/**
@@ -89,7 +89,7 @@ public class Channel {
 		}
 		RequestBody requestBody = ably.options.useBinaryProtocol ? MessageSerializer.asMsgpackRequest(messages) : MessageSerializer.asJsonRequest(messages);
 
-		ably.asyncHttp.post(basePath + "/messages", HttpUtils.defaultAcceptHeaders(ably.options.useBinaryProtocol), null, requestBody, null, new Callback<Void>() {
+		ably.asyncHttp.post(basePath + "/messages", HttpUtils.defaultAcceptHeaders(ably.options.useBinaryProtocol), null, requestBody, null, true, new Callback<Void>() {
 			@Override
 			public void onSuccess(Void result) { listener.onSuccess(); }
 			@Override

--- a/lib/src/test/java/io/ably/lib/test/common/Helpers.java
+++ b/lib/src/test/java/io/ably/lib/test/common/Helpers.java
@@ -1,6 +1,7 @@
 package io.ably.lib.test.common;
 
 import java.net.HttpURLConnection;
+import java.net.URL;
 import java.util.*;
 
 import com.google.gson.Gson;
@@ -682,6 +683,7 @@ public class Helpers {
 
 	public static class RawHttpRequest {
 		public String id;
+		public URL url;
 		public HttpURLConnection conn;
 		public String method;
 		public String authHeader;
@@ -708,6 +710,7 @@ public class Helpers {
 			}
 			RawHttpRequest req = new RawHttpRequest();
 			req.id = id;
+			req.url = conn.getURL();
 			req.conn = conn;
 			req.method = method;
 			req.authHeader = authHeader;

--- a/lib/src/test/java/io/ably/lib/test/common/Setup.java
+++ b/lib/src/test/java/io/ably/lib/test/common/Setup.java
@@ -210,7 +210,7 @@ public class Setup {
 						result.tlsPort = tlsPort;
 						result.tls = true;
 						return result;
-					}});
+					}}, false);
 			} catch (AblyException ae) {
 				System.err.println("Unable to create test app: " + ae);
 				ae.printStackTrace();
@@ -235,7 +235,7 @@ public class Setup {
 				opts.tlsPort = tlsPort;
 				opts.tls = true;
 				ably = new AblyRest(opts);
-				ably.http.del("/apps/" + testVars.appId, HttpUtils.defaultAcceptHeaders(false), null, null);
+				ably.http.del("/apps/" + testVars.appId, HttpUtils.defaultAcceptHeaders(false), null, null, false);
 			} catch (AblyException ae) {
 				System.err.println("Unable to delete test app: " + ae);
 				ae.printStackTrace();

--- a/lib/src/test/java/io/ably/lib/test/common/Setup.java
+++ b/lib/src/test/java/io/ably/lib/test/common/Setup.java
@@ -235,7 +235,7 @@ public class Setup {
 				opts.tlsPort = tlsPort;
 				opts.tls = true;
 				ably = new AblyRest(opts);
-				ably.http.del("/apps/" + testVars.appId, HttpUtils.defaultAcceptHeaders(false), null, null, false);
+				ably.http.del("/apps/" + testVars.appId, HttpUtils.defaultAcceptHeaders(false), null, null, true);
 			} catch (AblyException ae) {
 				System.err.println("Unable to delete test app: " + ae);
 				ae.printStackTrace();

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
@@ -597,7 +597,7 @@ public class RealtimeMessageTest extends ParameterizedTest {
 				/* subscribe */
 				MessageWaiter messageWaiter = new MessageWaiter(channel);
 
-				ably.http.post("/channels/" + channel.name + "/messages", null, null, new Http.JsonRequestBody(fixtureMessage), null);
+				ably.http.post("/channels/" + channel.name + "/messages", null, null, new Http.JsonRequestBody(fixtureMessage), null, true);
 
 				messageWaiter.waitFor(1);
 				channel.unsubscribe(messageWaiter);
@@ -618,7 +618,7 @@ public class RealtimeMessageTest extends ParameterizedTest {
 						}
 						return gson.fromJson(new String(response.body), MessagesEncodingDataItem[].class);
 					}
-				})[0];
+				}, true)[0];
 				assertEquals("Verify persisted message encoding", fixtureMessage.encoding, persistedMessage.encoding);
 				assertEquals("Verify persisted message data", fixtureMessage.data, persistedMessage.data);
 			}
@@ -666,7 +666,7 @@ public class RealtimeMessageTest extends ParameterizedTest {
 				for (MessagesEncodingDataItem fixtureMessage : fixtures.messages) {
 					MessageWaiter messageWaiter = new MessageWaiter(realtimeSubscribeChannel);
 
-					restPublishClient.http.post("/channels/" + realtimeSubscribeChannel.name + "/messages", null, null, new Http.JsonRequestBody(fixtureMessage), null);
+					restPublishClient.http.post("/channels/" + realtimeSubscribeChannel.name + "/messages", null, null, new Http.JsonRequestBody(fixtureMessage), null, true);
 
 					messageWaiter.waitFor(1);
 					realtimeSubscribeChannel.unsubscribe(messageWaiter);
@@ -710,7 +710,7 @@ public class RealtimeMessageTest extends ParameterizedTest {
 							}
 							return gson.fromJson(new String(response.body), MessagesEncodingDataItem[].class);
 						}
-					})[0];
+					}, true)[0];
 					assertEquals("Verify persisted message encoding", fixtureMessage.encoding, persistedMessage.encoding);
 					assertEquals("Verify persisted message data", fixtureMessage.data, persistedMessage.data);
 				}
@@ -763,7 +763,7 @@ public class RealtimeMessageTest extends ParameterizedTest {
 			testData.expectedType = "binary";
 			testData.expectedHexValue = "30313233343536373839";	/* hex for "0123456789" */
 
-			restPublishClient.http.post("/channels/" + realtimeSubscribeChannelJson.name + "/messages", null, null, new Http.JsonRequestBody(testData), null);
+			restPublishClient.http.post("/channels/" + realtimeSubscribeChannelJson.name + "/messages", null, null, new Http.JsonRequestBody(testData), null, true);
 
 			messageWaiter.waitFor(1);
 			realtimeSubscribeChannelJson.unsubscribe(messageWaiter);

--- a/lib/src/test/java/io/ably/lib/test/rest/HttpTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/HttpTest.java
@@ -146,7 +146,8 @@ public class HttpTest {
 					new Param[0], /* Ignore headers */
 					new Param[0], /* Ignore params */
 					null, /* Ignore requestBody */
-					null /* Ignore requestHandler */
+					null, /* Ignore requestHandler */
+					false /* Ignore requireAblyAuth */
 			);
 		} catch (AblyException e) {
 			/* Verify that,
@@ -207,7 +208,8 @@ public class HttpTest {
 					new Param[0], /* Ignore headers */
 					new Param[0], /* Ignore params */
 					null, /* Ignore requestBody */
-					null /* Ignore requestHandler */
+					null, /* Ignore requestHandler */
+					false /* Ignore requireAblyAuth */
 			);
 		} catch (AblyException.HostFailedException e) {
 			/* Verify that,
@@ -272,7 +274,8 @@ public class HttpTest {
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
 				mock(Http.RequestBody.class), /* Ignore */
-				mock(Http.ResponseHandler.class) /* Ignore */
+				mock(Http.ResponseHandler.class), /* Ignore */
+				false /* Ignore */
 		);
 
 		assertThat("Unexpected default primary host", url.getAllValues().get(0).getHost(), is(equalTo(Defaults.HOST_REST)));
@@ -285,7 +288,8 @@ public class HttpTest {
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
 				mock(Http.RequestBody.class), /* Ignore */
-				mock(Http.ResponseHandler.class) /* Ignore */
+				mock(Http.ResponseHandler.class), /* Ignore */
+				false /* Ignore */
 		);
 
 		/* Verify call causes captor to capture same arguments thrice.
@@ -354,7 +358,8 @@ public class HttpTest {
 					new Param[0], /* Ignore */
 					new Param[0], /* Ignore */
 					mock(Http.RequestBody.class), /* Ignore */
-					mock(Http.ResponseHandler.class) /* Ignore */
+					mock(Http.ResponseHandler.class), /* Ignore */
+					false /* Ignore */
 			);
 		} catch (AblyException e) {
 			/* Verify that,
@@ -373,7 +378,8 @@ public class HttpTest {
 					new Param[0], /* Ignore */
 					new Param[0], /* Ignore */
 					mock(Http.RequestBody.class), /* Ignore */
-					mock(Http.ResponseHandler.class) /* Ignore */
+					mock(Http.ResponseHandler.class), /* Ignore */
+					false /* Ignore */
 			);
 		} catch (AblyException e) {
 			/* Verify that,
@@ -447,7 +453,8 @@ public class HttpTest {
 					new Param[0], /* Ignore */
 					new Param[0], /* Ignore */
 					mock(Http.RequestBody.class), /* Ignore */
-					mock(Http.ResponseHandler.class) /* Ignore */
+					mock(Http.ResponseHandler.class), /* Ignore */
+					false /* Ignore */
 			);
 		} catch (AblyException e) {
 			/* Verify that,
@@ -524,7 +531,8 @@ public class HttpTest {
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
 				mock(Http.RequestBody.class), /* Ignore */
-				mock(Http.ResponseHandler.class) /* Ignore */
+				mock(Http.ResponseHandler.class), /* Ignore */
+				false /* Ignore */
 		);
 
 		/* Verify {code Http#httpExecute} have been called (httpMaxRetryCount + 1) times */
@@ -594,7 +602,8 @@ public class HttpTest {
 					new Param[0], /* Ignore headers */
 					new Param[0], /* Ignore params */
 					null, /* Ignore requestBody */
-					null /* Ignore requestHandler */
+					null, /* Ignore requestHandler */
+					false /* Ignore requireAblyAuth */
 			);
 		} catch (AblyException.HostFailedException e) {
 			/* Verify that,
@@ -653,7 +662,8 @@ public class HttpTest {
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
 				mock(Http.RequestBody.class), /* Ignore */
-				mock(Http.ResponseHandler.class) /* Ignore */
+				mock(Http.ResponseHandler.class), /* Ignore */
+				false /* Ignore */
 		);
 
 
@@ -722,7 +732,8 @@ public class HttpTest {
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
 				mock(Http.RequestBody.class), /* Ignore */
-				mock(Http.ResponseHandler.class) /* Ignore */
+				mock(Http.ResponseHandler.class), /* Ignore */
+				false /* Ignore */
 		);
 
 
@@ -791,7 +802,8 @@ public class HttpTest {
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
 				mock(Http.RequestBody.class), /* Ignore */
-				mock(Http.ResponseHandler.class) /* Ignore */
+				mock(Http.ResponseHandler.class), /* Ignore */
+				false /* Ignore */
 		);
 
 
@@ -866,7 +878,8 @@ public class HttpTest {
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
 				mock(Http.RequestBody.class), /* Ignore */
-				mock(Http.ResponseHandler.class) /* Ignore */
+				mock(Http.ResponseHandler.class), /* Ignore */
+				false /* Ignore */
 		);
 
         /* Verify there was a fallback with first call */
@@ -892,7 +905,8 @@ public class HttpTest {
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
 				mock(Http.RequestBody.class), /* Ignore */
-				mock(Http.ResponseHandler.class) /* Ignore */
+				mock(Http.ResponseHandler.class), /* Ignore */
+				false /* Ignore */
 		);
 
         /* Verify second call was called with http host */
@@ -950,7 +964,8 @@ public class HttpTest {
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
 				mock(Http.RequestBody.class), /* Ignore */
-				mock(Http.ResponseHandler.class) /* Ignore */
+				mock(Http.ResponseHandler.class), /* Ignore */
+				false /* Ignore */
 		);
 	}
 

--- a/lib/src/test/java/io/ably/lib/test/rest/RestAppStatsTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestAppStatsTest.java
@@ -20,9 +20,7 @@ import java.util.Date;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 @SuppressWarnings("deprecation")
 public class RestAppStatsTest extends ParameterizedTest {
@@ -78,7 +76,7 @@ public class RestAppStatsTest extends ParameterizedTest {
 					+ ']'
 				);
 
-			ably.http.post("/stats", HttpUtils.defaultAcceptHeaders(false), null, StatsWriter.asJsonRequest(testStats), null);
+			ably.http.post("/stats", HttpUtils.defaultAcceptHeaders(false), null, StatsWriter.asJsonRequest(testStats), null, true);
 		} catch (AblyException e) {}
 	}
 


### PR DESCRIPTION
Expose an argument to http ops indicating whether or not auth will be required for an Ably endpoint; use this to ensure that all relevant requests are preemptively authenticated