### PR TITLE
Omit TTL in TokenRequest as JSON if unset.

### DIFF
--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -288,6 +288,8 @@ public class Auth {
 		 * is successful, the TTL of the returned token will be less
 		 * than or equal to this value depending on application settings
 		 * and the attributes of the issuing key.
+		 *
+		 * 0 means Ably will set it to the default value.
 		 */
 		public long ttl;
 
@@ -433,7 +435,14 @@ public class Auth {
 		 * Convert a TokenParams into a JSON object.
 		 */
 		public JsonObject asJsonElement() {
-			return (JsonObject)Serialisation.gson.toJsonTree(this);
+			JsonObject o = (JsonObject)Serialisation.gson.toJsonTree(this);
+			if (this.ttl == 0) {
+				o.remove("ttl");
+			}
+			if (this.capability != null && this.capability.isEmpty()) {
+				o.remove("capability");
+			}
+			return o;
 		}
 
 		/**

--- a/lib/src/test/java/io/ably/lib/test/rest/RestAuthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestAuthTest.java
@@ -1691,6 +1691,32 @@ public class RestAuthTest extends ParameterizedTest {
 		}
 	}
 
+	/**
+	 * Verify TokenRequest as JSON TTL and capability are omitted if not explicitly set to nonzero.
+	 * Spec: RSA5, RSA6
+	 */
+	@Test
+	public void auth_token_request_json_omitted_defaults() {
+		AblyRest ably;
+		TokenRequest tokenRequest;
+		try {
+			for (String cap : new String[] {null, ""}) {
+				ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+				opts.clientId = "Test client id";
+				ably = new AblyRest(opts);
+				tokenRequest = ably.auth.createTokenRequest(new TokenParams() {{
+					capability = cap;
+				}}, null);
+				String serialisedTokenRequest = tokenRequest.asJson();
+				assertTrue("Verify token request has no ttl", !serialisedTokenRequest.contains("ttl"));
+				assertTrue("Verify token request has no capability", !serialisedTokenRequest.contains("capability"));
+			}
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("Unexpected exception");
+		}
+	}
+
 	private static TokenServer tokenServer;
 	private static SessionHandlerNanoHTTPD nanoHTTPD;
 


### PR DESCRIPTION
Fixes #349.