### PR TITLE
Add connectionStateTtl

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@
 
 A Java Realtime and REST client library for [Ably Realtime](https://www.ably.io), the realtime messaging and data delivery service.
 
+## Supported Platforms
+
+This SDK supports the following platforms:
+
+**Java:** Java 7+
+
+**Android:** android-19 or newer as a target SDK, android-16 or newer as a target platform
+
+We regression-test the library against a selection of Java and Android platforms (which will change over time, but usually consists of the versions that are supported upstream). Please refer to [.travis.yml](./.travis.yml) for the set of versions that currently undergo CI testing..
+
+We'll happily support (and investigate reported problems with) any reasonably-widely-used platform, Java or Android.
+If you find any compatibility issues, please [do raise an issue](https://github.com/ably/ably-java/issues/new) in this repository or [contact Ably customer support](https://support.ably.io/) for advice.
+
 ## Documentation
 
 Visit https://www.ably.io/documentation for a complete API reference and more examples.

--- a/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
+++ b/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
@@ -159,10 +159,10 @@ public class AblyRealtime extends AblyRest {
 			channel.onChannelMessage(msg);
 		}
 
-		public void suspendAll(ErrorInfo error) {
+		public void suspendAll(ErrorInfo error, boolean notifyStateChange) {
 			for(Iterator<Map.Entry<String, Channel>> it = entrySet().iterator(); it.hasNext(); ) {
 				Map.Entry<String, Channel> entry = it.next();
-				entry.getValue().setSuspended(error);
+				entry.getValue().setSuspended(error, notifyStateChange);
 			}
 		}
 	}

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -584,7 +584,7 @@ public class Auth {
 				if(authCallbackResponse instanceof TokenRequest)
 					signedTokenRequest = (TokenRequest)authCallbackResponse;
 				else
-					throw AblyException.fromErrorInfo(new ErrorInfo("Invalid authCallback response", 40000, 400));
+					throw AblyException.fromErrorInfo(new ErrorInfo("Invalid authCallback response", 400, 40000));
 			} catch(AblyException e) {
 				throw AblyException.fromErrorInfo(e, new ErrorInfo("authCallback failed with an exception", 401, 80019));
 			}

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -151,7 +151,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 		put(ConnectionState.failed, new StateInfo(ConnectionState.failed, false, false, true, false, 0, REASON_FAILED));
 	}};
 
-	long maxIdleInterval;
+	long maxIdleInterval = Defaults.maxIdleInterval;
 	long connectionStateTtl = Defaults.connectionStateTtl;
 	private long failedAuthAttempts = 0;
 
@@ -1188,6 +1188,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 		if(err.code != 0) {
 			/* token errors are assumed to be recoverable */
 			if((err.code >= 40140) && (err.code < 40150)) {
+				/* unless one auth attempt has already been made and has failed */
 				if (failedAuthAttempts >= 1) {
 					return true;
 				}

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -205,6 +205,19 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	 *********************/
 
 	public void connect() {
+
+		if (transport != null) {
+			long intervalSinceLastActivity = System.currentTimeMillis() - transport.getLastActivity();
+			if (intervalSinceLastActivity > (maxIdleInterval + connectionStateTtl)) {
+				connection.id = null;
+				connection.key = null;
+				connection.recoveryKey = null;
+				startThread();
+				requestState(ConnectionState.connecting);
+				return;
+			}
+		}
+
 		boolean connectionExist = state.state == ConnectionState.connected;
 		boolean connectionAttemptInProgress = (requestedState != null && requestedState.state == ConnectionState.connecting) ||
 				state.state == ConnectionState.connecting;

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -153,7 +153,6 @@ public class ConnectionManager implements Runnable, ConnectListener {
 
 	long maxIdleInterval = Defaults.maxIdleInterval;
 	long connectionStateTtl = Defaults.connectionStateTtl;
-	private long failedAuthAttempts = 0;
 
 	public ErrorInfo getStateErrorInfo() {
 		return state.defaultErrorInfo;
@@ -582,9 +581,6 @@ public class ConnectionManager implements Runnable, ConnectListener {
 
 	private synchronized void onError(ProtocolMessage message) {
 		connection.key = null;
-		if((message.error.code >= 40140) && (message.error.code < 40150)) {
-			failedAuthAttempts += 1;
-		}
 		ConnectionState destinationState = isFatalError(message.error) ? ConnectionState.failed : ConnectionState.disconnected;
 		notifyState(transport, new StateIndication(destinationState, message.error));
 	}
@@ -1187,13 +1183,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	private boolean isFatalError(ErrorInfo err) {
 		if(err.code != 0) {
 			/* token errors are assumed to be recoverable */
-			if((err.code >= 40140) && (err.code < 40150)) {
-				/* unless one auth attempt has already been made and has failed */
-				if (failedAuthAttempts >= 1) {
-					return true;
-				}
-				return false;
-			}
+			if((err.code >= 40140) && (err.code < 40150)) { return false; }
 			/* 400 codes assumed to be fatal */
 			if((err.code >= 40000) && (err.code < 50000)) { return true; }
 		}

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -679,6 +679,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 		if(intervalSinceLastActivity > (maxIdleInterval + connectionStateTtl)) {
 			/* RTN15g1, RTN15g2 Force a new connection if the previous one is stale */
 			if(connection.id != null) {
+				Log.v(TAG, "Clearing the old stale connection");
 				connection.id = null;
 				connection.key = null;
 				connection.recoveryKey = null;

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -451,7 +451,6 @@ public class ConnectionManager implements Runnable, ConnectListener {
 		if (Log.level <= Log.VERBOSE)
 			Log.v(TAG, "onMessage(): " + message.action + ": " + new String(ProtocolSerializer.writeJSON(message)));
 		try {
-			lastActivity = System.currentTimeMillis();
 			if(protocolListener != null)
 				protocolListener.onRawMessageRecv(message);
 			switch(message.action) {
@@ -993,6 +992,10 @@ public class ConnectionManager implements Runnable, ConnectListener {
 		} catch(AblyException e) {
 			return false;
 		}
+	}
+
+	protected void setLastActivity(long lastActivityTime) {
+		this.lastActivity = lastActivityTime;
 	}
 
 	/******************

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -205,7 +205,6 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	 *********************/
 
 	public void connect() {
-
 		boolean connectionExist = state.state == ConnectionState.connected;
 		boolean connectionAttemptInProgress = (requestedState != null && requestedState.state == ConnectionState.connecting) ||
 				state.state == ConnectionState.connecting;
@@ -674,7 +673,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	private boolean checkConnectionStale() {
 	    if(lastActivity == 0) {
 	        return false;
-        }
+	    }
 		long now = System.currentTimeMillis();
 		long intervalSinceLastActivity = now - lastActivity;
 		if(intervalSinceLastActivity > (maxIdleInterval + connectionStateTtl)) {

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -145,14 +145,14 @@ public class ConnectionManager implements Runnable, ConnectListener {
 		put(ConnectionState.connecting, new StateInfo(ConnectionState.connecting, true, false, false, false, Defaults.TIMEOUT_CONNECT, null));
 		put(ConnectionState.connected, new StateInfo(ConnectionState.connected, false, true, false, false, 0, null));
 		put(ConnectionState.disconnected, new StateInfo(ConnectionState.disconnected, true, false, false, true, Defaults.TIMEOUT_DISCONNECT, REASON_DISCONNECTED));
-		put(ConnectionState.suspended, new StateInfo(ConnectionState.suspended, false, false, false, true, Defaults.TIMEOUT_SUSPEND, REASON_SUSPENDED));
+		put(ConnectionState.suspended, new StateInfo(ConnectionState.suspended, false, false, false, true, Defaults.connectionStateTtl, REASON_SUSPENDED));
 		put(ConnectionState.closing, new StateInfo(ConnectionState.closing, false, false, false, false, Defaults.TIMEOUT_CONNECT, REASON_CLOSED));
 		put(ConnectionState.closed, new StateInfo(ConnectionState.closed, false, false, true, false, 0, REASON_CLOSED));
 		put(ConnectionState.failed, new StateInfo(ConnectionState.failed, false, false, true, false, 0, REASON_FAILED));
 	}};
 
 	long maxIdleInterval;
-	long connectionStateTtl;
+	long connectionStateTtl = Defaults.connectionStateTtl;
 
 	public ErrorInfo getStateErrorInfo() {
 		return state.defaultErrorInfo;
@@ -716,7 +716,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	}
 
 	private void setSuspendTime() {
-		suspendTime = (System.currentTimeMillis() + Defaults.TIMEOUT_SUSPEND);
+		suspendTime = (System.currentTimeMillis() + connectionStateTtl);
 	}
 
 	private StateIndication checkSuspend(StateIndication stateChange) {

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -152,6 +152,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	}};
 
 	long maxIdleInterval;
+	long connectionStateTtl;
 
 	public ErrorInfo getStateErrorInfo() {
 		return state.defaultErrorInfo;
@@ -550,6 +551,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 
 		/* Get any parameters from connectionDetails. */
 		maxIdleInterval = connectionDetails.maxIdleInterval;
+		connectionStateTtl = connectionDetails.connectionStateTtl;
 
 		/* set the clientId resolved from token, if any */
 		String clientId = connectionDetails.clientId;

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -276,7 +276,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 						/* (RTL3c) If the connection state enters the SUSPENDED
 						 * state, then an ATTACHING or ATTACHED channel state
 						 * will transition to SUSPENDED. */
-						channel.setSuspended(state.defaultErrorInfo);
+						channel.setSuspended(state.defaultErrorInfo, true);
 						break;
 				}
 			}
@@ -526,10 +526,12 @@ public class ConnectionManager implements Runnable, ConnectListener {
 
 		/* if there was a (non-fatal) connection error
 		 * that invalidates an existing connection id, then
-		 * remove all channels attached to the previous id */
+		 * suspend all channels attached to the previous id;
+		 * this will be reattached in setConnection() */
 		ErrorInfo error = message.error;
-		if(error != null && !message.connectionId.equals(connection.id))
-			ably.channels.suspendAll(error);
+		if(error != null && !message.connectionId.equals(connection.id)) {
+			ably.channels.suspendAll(error, false);
+		}
 
 		/* set the new connection id */
 		ConnectionDetails connectionDetails = message.connectionDetails;
@@ -715,9 +717,11 @@ public class ConnectionManager implements Runnable, ConnectListener {
 				stateChange = null;
 				break;
 			case connected:
-				/* we were connected, so retry immediately */
 				setSuspendTime();
-				requestState(ConnectionState.connecting);
+				/* we were connected, so retry immediately */
+				if(!suppressRetry) {
+					requestState(ConnectionState.connecting);
+				}
 				break;
 			case suspended:
 				/* Don't allow a second disconnected to make the state come out of suspended. */
@@ -823,7 +827,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 					}
 
 					/* if our state wants us to retry on timer expiry, do that */
-					if(state.retry) {
+					if(state.retry && !suppressRetry) {
 						requestState(ConnectionState.connecting);
 						continue;
 					}
@@ -1205,6 +1209,15 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	}
 
 	/*******************
+	 * for tests only
+	 ******************/
+
+	void disconnectAndSuppressRetries() {
+		requestState(ConnectionState.disconnected);
+		suppressRetry = true;
+	}
+
+	/*******************
 	 * internal
 	 ******************/
 
@@ -1238,6 +1251,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	private StateIndication indicatedState, requestedState;
 	private ConnectParams pendingConnect;
 	private boolean pendingReauth;
+	private boolean suppressRetry; /* for tests only; modified via reflection */
 	private ITransport transport;
 	private long suspendTime;
 	private long msgSerial;

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -207,7 +207,8 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	public void connect() {
 
 		if (transport != null) {
-			long intervalSinceLastActivity = System.currentTimeMillis() - transport.getLastActivity();
+			long now = System.currentTimeMillis();
+			long intervalSinceLastActivity = now - lastActivity;
 			if (intervalSinceLastActivity > (maxIdleInterval + connectionStateTtl)) {
 				connection.id = null;
 				connection.key = null;
@@ -464,6 +465,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 		if (Log.level <= Log.VERBOSE)
 			Log.v(TAG, "onMessage(): " + message.action + ": " + new String(ProtocolSerializer.writeJSON(message)));
 		try {
+			lastActivity = System.currentTimeMillis();
 			if(protocolListener != null)
 				protocolListener.onRawMessageRecv(message);
 			switch(message.action) {
@@ -1226,6 +1228,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	private ITransport transport;
 	private long suspendTime;
 	private long msgSerial;
+	private long lastActivity;
 
 	/* for debug/test only */
 	private RawProtocolListener protocolListener;

--- a/lib/src/main/java/io/ably/lib/transport/Defaults.java
+++ b/lib/src/main/java/io/ably/lib/transport/Defaults.java
@@ -26,7 +26,6 @@ public class Defaults {
 	/* Timeouts */
 	public static int TIMEOUT_CONNECT               = 15000;
 	public static int TIMEOUT_DISCONNECT            = 30000;
-	public static int TIMEOUT_SUSPEND               = 120000;
 	public static int TIMEOUT_CHANNEL_RETRY			= 15000;
 
 	/* TO313 */

--- a/lib/src/main/java/io/ably/lib/transport/Defaults.java
+++ b/lib/src/main/java/io/ably/lib/transport/Defaults.java
@@ -37,6 +37,8 @@ public class Defaults {
 	public static long realtimeRequestTimeout = 10000L;
 	/* CD2h (but no default in the spec) */
 	public static long maxIdleInterval = 20000L;
+	/* DF1a */
+	public static long connectionStateTtl = 60000L;
 
 	public static final String[] TRANSPORTS         = new String[]{"web_socket"};
 	public static String TRANSPORT = "io.ably.lib.transport.WebSocketTransport$Factory";

--- a/lib/src/main/java/io/ably/lib/transport/ITransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/ITransport.java
@@ -117,4 +117,7 @@ public interface ITransport {
 	public String getURL();
 
 	public String getHost();
+
+	public long getLastActivity();
+
 }

--- a/lib/src/main/java/io/ably/lib/transport/ITransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/ITransport.java
@@ -118,6 +118,4 @@ public interface ITransport {
 
 	public String getHost();
 
-	public long getLastActivity();
-
 }

--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -139,6 +139,14 @@ public class WebSocketTransport implements ITransport {
 		return params.host;
 	}
 
+	@Override
+	public long getLastActivity() {
+		if (wsConnection != null) {
+			return wsConnection.lastActivityTime;
+		}
+		return 0;
+	}
+
 	/**************************
 	 * WebSocketHandler methods
 	 **************************/

--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -258,6 +258,7 @@ public class WebSocketTransport implements ITransport {
 
 		private void flagActivity() {
 			lastActivityTime = System.currentTimeMillis();
+			connectionManager.setLastActivity(lastActivityTime);
 			if (timer == null && connectionManager.maxIdleInterval != 0) {
 				/* No timer currently running because previously there was no
 				 * maxIdleInterval configured, but now there is a

--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -139,14 +139,6 @@ public class WebSocketTransport implements ITransport {
 		return params.host;
 	}
 
-	@Override
-	public long getLastActivity() {
-		if (wsConnection != null) {
-			return wsConnection.lastActivityTime;
-		}
-		return 0;
-	}
-
 	/**************************
 	 * WebSocketHandler methods
 	 **************************/

--- a/lib/src/main/java/io/ably/lib/types/BaseMessage.java
+++ b/lib/src/main/java/io/ably/lib/types/BaseMessage.java
@@ -131,6 +131,7 @@ public class BaseMessage implements Cloneable {
 					encoding = ((encoding == null) ? "" : encoding + "/") + "utf-8";
 				}
 			} else if(!(data instanceof byte[])) {
+				Log.d(TAG, "Message data must be either `byte[]`, `String` or `JSONElement`; implicit coercion of other types to String is deprecated");
 				throw AblyException.fromErrorInfo(new ErrorInfo("Invalid message data or encoding", 400, 40013));
 			}
 		}

--- a/lib/src/main/java/io/ably/lib/types/BaseMessage.java
+++ b/lib/src/main/java/io/ably/lib/types/BaseMessage.java
@@ -131,11 +131,7 @@ public class BaseMessage implements Cloneable {
 					encoding = ((encoding == null) ? "" : encoding + "/") + "utf-8";
 				}
 			} else if(!(data instanceof byte[])) {
-				if (opts != null && opts.encrypted) {
-					throw AblyException.fromErrorInfo(new ErrorInfo("Invalid message data or encoding", 400, 40013));
-				} else {
-					Log.e(TAG, "Message data must be either `byte[]`, `String` or `JSONElement`; implicit coercion of other types to String is deprecated and throws from v.0.9 on.\nPlease check the documentation (https://www.ably.io/documentation/realtime/types#message).");
-				}
+				throw AblyException.fromErrorInfo(new ErrorInfo("Invalid message data or encoding", 400, 40013));
 			}
 		}
 		if (opts != null && opts.encrypted) {

--- a/lib/src/main/java/io/ably/lib/types/ConnectionDetails.java
+++ b/lib/src/main/java/io/ably/lib/types/ConnectionDetails.java
@@ -20,6 +20,7 @@ public class ConnectionDetails {
 
 	ConnectionDetails() {
 		maxIdleInterval = Defaults.maxIdleInterval;
+		connectionStateTtl = Defaults.connectionStateTtl;
 	}
 
 	ConnectionDetails readMsgpack(MessageUnpacker unpacker) throws IOException {

--- a/lib/src/main/java/io/ably/lib/types/ConnectionDetails.java
+++ b/lib/src/main/java/io/ably/lib/types/ConnectionDetails.java
@@ -16,6 +16,7 @@ public class ConnectionDetails {
 	public Long maxInboundRate;
 	public Long maxFrameSize;
 	public Long maxIdleInterval;
+	public Long connectionStateTtl;
 
 	ConnectionDetails() {
 		maxIdleInterval = Defaults.maxIdleInterval;
@@ -49,6 +50,9 @@ public class ConnectionDetails {
 					break;
 				case "maxIdleInterval":
 					maxIdleInterval = unpacker.unpackLong();
+					break;
+				case "connectionStateTtl":
+					connectionStateTtl = unpacker.unpackLong();
 					break;
 				default:
 					Log.v(TAG, "Unexpected field: " + fieldName);

--- a/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.lang.reflect.Field;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -383,6 +384,34 @@ public class ConnectionManagerTest extends ParameterizedTest {
 				}
 			});
 
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("init0: Unexpected exception instantiating library");
+		}
+	}
+
+	/**
+	 * Connect and then verify that the connection manager has the default value for connectionStateTtl;
+	 */
+	@Test
+	public void connection_details_has_ttl() {
+		try {
+			ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+			final AblyRealtime ably = new AblyRealtime(opts);
+			ably.connection.on(ConnectionEvent.connected, new ConnectionStateListener() {
+				@Override
+				public void onConnectionStateChanged(ConnectionStateChange state) {
+					assertEquals(1, 1);
+					try {
+						Field field = ably.connection.connectionManager.getClass().getDeclaredField("connectionStateTtl");
+						field.setAccessible(true);
+						assertEquals("Verify connectionStateTtl has the default value", field.get(ably.connection.connectionManager), 120000L);
+					} catch (NoSuchFieldException|IllegalAccessException e) {
+						fail("Unexpected exception in checking connectionStateTtl");
+					}
+					ably.close();
+				}
+			});
 		} catch (AblyException e) {
 			e.printStackTrace();
 			fail("init0: Unexpected exception instantiating library");

--- a/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
@@ -478,7 +478,7 @@ public class ConnectionManagerTest extends ParameterizedTest {
 			ably.connection.connectionManager.requestState(ConnectionState.disconnected);
 			connectionWaiter.waitFor(ConnectionState.disconnected);
 
-            ably.connection.once(ConnectionEvent.connected, new ConnectionStateListener() {
+			ably.connection.once(ConnectionEvent.connected, new ConnectionStateListener() {
 				@Override
 				public void onConnectionStateChanged(ConnectionStateChange state) {
 					assertEquals("Client has reconnected", ConnectionState.connected, state.current);
@@ -570,15 +570,14 @@ public class ConnectionManagerTest extends ParameterizedTest {
 			});
 			channel.attach();
 
-            /* Before disconnecting wait that newTtl + newIdleInterval has passed */
-            try {
-                Thread.sleep(intervalBeforeReconnecting);
-            } catch(InterruptedException e) {}
+			/* Before disconnecting wait that newTtl + newIdleInterval has passed */
+			try {
+				Thread.sleep(intervalBeforeReconnecting);
+			} catch(InterruptedException e) {}
 			ably.connection.connectionManager.requestState(ConnectionState.disconnected);
 
-            /* Since newTtl + newIdleInterval has passed we expect the connection to go into a suspended state */
-            connectionWaiter.waitFor(ConnectionState.suspended);
-
+			/* Since newTtl + newIdleInterval has passed we expect the connection to go into a suspended state */
+			connectionWaiter.waitFor(ConnectionState.suspended);
 			ably.connect();
 			ably.connection.once(ConnectionEvent.connected, new ConnectionStateListener() {
 				@Override

--- a/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
@@ -408,9 +408,10 @@ public class ConnectionManagerTest extends ParameterizedTest {
 					} catch (NoSuchFieldException|IllegalAccessException e) {
 						fail("Unexpected exception in checking connectionStateTtl");
 					}
-					ably.close();
 				}
 			});
+			new Helpers.ConnectionManagerWaiter(ably.connection.connectionManager).waitFor(ConnectionState.connected);
+			ably.close();
 		} catch (AblyException e) {
 			e.printStackTrace();
 			fail("init0: Unexpected exception instantiating library");

--- a/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
@@ -401,7 +401,6 @@ public class ConnectionManagerTest extends ParameterizedTest {
 			ably.connection.on(ConnectionEvent.connected, new ConnectionStateListener() {
 				@Override
 				public void onConnectionStateChanged(ConnectionStateChange state) {
-					assertEquals(1, 1);
 					try {
 						Field field = ably.connection.connectionManager.getClass().getDeclaredField("connectionStateTtl");
 						field.setAccessible(true);

--- a/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
@@ -410,9 +410,11 @@ public class ConnectionManagerTest extends ParameterizedTest {
 		try {
 			ClientOptions opts = createOptions(testVars.keys[0].keyStr);
 			final AblyRealtime ably = new AblyRealtime(opts);
+			final boolean[] callbackWasRun = new boolean[1];
 			ably.connection.on(ConnectionEvent.connected, new ConnectionStateListener() {
 				@Override
 				public void onConnectionStateChanged(ConnectionStateChange state) {
+					callbackWasRun[0] = true;
 					try {
 						Field field = ably.connection.connectionManager.getClass().getDeclaredField("connectionStateTtl");
 						field.setAccessible(true);
@@ -423,6 +425,7 @@ public class ConnectionManagerTest extends ParameterizedTest {
 				}
 			});
 			new Helpers.ConnectionManagerWaiter(ably.connection.connectionManager).waitFor(ConnectionState.connected);
+			assertTrue("Connected callback was not run", callbackWasRun[0]);
 			ably.close();
 		} catch (AblyException e) {
 			e.printStackTrace();

--- a/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
@@ -489,7 +489,7 @@ public class ConnectionManagerTest extends ParameterizedTest {
 				}
 			});
 
-			connectionWaiter.waitFor(ConnectionState.connected);
+			connectionWaiter.waitFor(ConnectionState.closed);
 
 		} catch (AblyException e) {
 			e.printStackTrace();

--- a/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
@@ -569,6 +569,7 @@ public class ConnectionManagerTest extends ParameterizedTest {
 				}
 			});
 			channel.attach();
+			(new Helpers.ChannelWaiter(channel)).waitFor(ChannelState.attached);
 
 			/* Before disconnecting wait that newTtl + newIdleInterval has passed */
 			try {

--- a/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -411,6 +412,47 @@ public class ConnectionManagerTest extends ParameterizedTest {
 				}
 			});
 			new Helpers.ConnectionManagerWaiter(ably.connection.connectionManager).waitFor(ConnectionState.connected);
+			ably.close();
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("init0: Unexpected exception instantiating library");
+		}
+	}
+
+	/**
+	 * RTN15g1, RTN15g2. Connect, disconnect, reconnect after (ttl + idle interval) period has passed,
+	 * check that the connection is a new one;
+	 */
+	@Test
+	public void connection_has_new_id_when_reconnecting_after_statettl_plus_idleinterval_has_passed() {
+		try {
+			ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+			final AblyRealtime ably = new AblyRealtime(opts);
+			ably.connection.on(ConnectionEvent.connected, new ConnectionStateListener() {
+				@Override
+				public void onConnectionStateChanged(ConnectionStateChange state) {
+					try {
+						Field connectionStateField = ably.connection.connectionManager.getClass().getDeclaredField("connectionStateTtl");
+						connectionStateField.setAccessible(true);
+						connectionStateField.setLong(ably.connection.connectionManager, 1000L);
+						Field maxIdleField = ably.connection.connectionManager.getClass().getDeclaredField("maxIdleInterval");
+						maxIdleField.setAccessible(true);
+						maxIdleField.setLong(ably.connection.connectionManager, 1000L);
+						ably.connection.connectionManager.requestState(ConnectionState.disconnected);
+					} catch (NoSuchFieldException|IllegalAccessException e) {
+						fail("Unexpected exception in checking connectionStateTtl");
+					}
+				}
+			});
+
+			ConnectionWaiter connectionWaiter = new ConnectionWaiter(ably.connection);
+			connectionWaiter.waitFor(ConnectionState.connected);
+			String firstConnectionId = ably.connection.id;
+			connectionWaiter.waitFor(ConnectionState.disconnected);
+			ably.connect();
+			connectionWaiter.waitFor(ConnectionState.connected);
+			String secondConnectionId = ably.connection.id;
+			assertNotEquals("connection has a different id", firstConnectionId, secondConnectionId);
 			ably.close();
 		} catch (AblyException e) {
 			e.printStackTrace();

--- a/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
@@ -595,6 +595,7 @@ public class ConnectionManagerTest extends ParameterizedTest {
 					});
 				}
 			});
+			connectionWaiter.waitFor(ConnectionState.closed);
 		} catch (AblyException e) {
 			e.printStackTrace();
 			fail("init0: Unexpected exception instantiating library");

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -1,42 +1,29 @@
 package io.ably.lib.test.realtime;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import io.ably.lib.realtime.*;
+import io.ably.lib.realtime.Channel.MessageListener;
+import io.ably.lib.test.common.Helpers;
+import io.ably.lib.test.common.Helpers.ChannelWaiter;
+import io.ably.lib.test.common.Helpers.ConnectionWaiter;
+import io.ably.lib.test.common.ParameterizedTest;
+import io.ably.lib.test.util.MockWebsocketFactory;
+import io.ably.lib.transport.ConnectionManager;
+import io.ably.lib.transport.Defaults;
+import io.ably.lib.types.*;
+import io.ably.lib.util.Log;
+import org.hamcrest.Matchers;
+import org.junit.Test;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-import org.hamcrest.Matchers;
-import org.junit.Test;
-import io.ably.lib.realtime.AblyRealtime;
-import io.ably.lib.realtime.Channel;
-import io.ably.lib.realtime.Channel.MessageListener;
-import io.ably.lib.realtime.ChannelEvent;
-import io.ably.lib.realtime.ChannelState;
-import io.ably.lib.realtime.ChannelStateListener;
-import io.ably.lib.realtime.CompletionListener;
-import io.ably.lib.realtime.ConnectionState;
-import io.ably.lib.realtime.ConnectionStateListener;
-import io.ably.lib.test.common.Helpers;
-import io.ably.lib.test.common.Helpers.ChannelWaiter;
-import io.ably.lib.test.common.Helpers.ConnectionWaiter;
-import io.ably.lib.test.common.ParameterizedTest;
-import io.ably.lib.transport.ConnectionManager;
-import io.ably.lib.test.util.MockWebsocketFactory;
-import io.ably.lib.transport.Defaults;
-import io.ably.lib.types.AblyException;
-import io.ably.lib.types.ClientOptions;
-import io.ably.lib.types.ErrorInfo;
-import io.ably.lib.types.Message;
-import io.ably.lib.types.ProtocolMessage;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
 
 public class RealtimeChannelTest extends ParameterizedTest {
 
@@ -1121,6 +1108,126 @@ public class RealtimeChannelTest extends ParameterizedTest {
 			if (ably != null)
 				ably.close();
 			Defaults.realtimeRequestTimeout = oldRealtimeTimeout;
+		}
+	}
+
+	/*
+	 * Establish connection, attach channel, disconnection and failed resume
+	 * verify that subsequent attaches are performed, and give rise to update events
+	 *
+	 * Tests RTN15c3
+	 */
+	@Test
+	public void channel_resume_lost_continuity() throws AblyException {
+		AblyRealtime ably = null;
+		final String attachedChannelName = "channel_resume_lost_continuity_attached";
+		final String suspendedChannelName = "channel_resume_lost_continuity_suspended";
+
+		try {
+			ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+			ably = new AblyRealtime(opts);
+
+			/* prepare channels */
+			Channel attachedChannel = ably.channels.get(attachedChannelName);
+			ChannelWaiter attachedChannelWaiter = new ChannelWaiter(attachedChannel);
+			attachedChannel.attach();
+			attachedChannelWaiter.waitFor(ChannelState.attached);
+
+			Channel suspendedChannel = ably.channels.get(suspendedChannelName);
+			suspendedChannel.state = ChannelState.suspended;
+			ChannelWaiter suspendedChannelWaiter = new ChannelWaiter(suspendedChannel);
+
+			final boolean[] suspendedStateReached = new boolean[2];
+			final boolean[] attachingStateReached = new boolean[2];
+			final boolean[] attachedStateReached = new boolean[2];
+			final boolean[] resumedFlag = new boolean[]{true, true};
+			attachedChannel.on(new ChannelStateListener() {
+				@Override
+				public void onChannelStateChanged(ChannelStateChange stateChange) {
+					switch(stateChange.current) {
+						case suspended:
+							suspendedStateReached[0] = true;
+							break;
+						case attaching:
+							attachingStateReached[0] = true;
+							break;
+						case attached:
+							attachedStateReached[0] = true;
+							resumedFlag[0] = stateChange.resumed;
+							break;
+						default:
+							break;
+					}
+				}
+			});
+			suspendedChannel.on(new ChannelStateListener() {
+				@Override
+				public void onChannelStateChanged(ChannelStateChange stateChange) {
+					switch(stateChange.current) {
+						case attaching:
+							attachingStateReached[1] = true;
+							break;
+						case attached:
+							attachedStateReached[1] = true;
+							resumedFlag[1] = stateChange.resumed;
+							break;
+						default:
+							break;
+					}
+				}
+			});
+
+			/* disconnect, and sabotage the resume */
+			String originalConnectionId = ably.connection.id;
+			ably.connection.key = "_____!ably___test_fake-key____";
+			ably.connection.id = "ably___tes";
+			ConnectionWaiter connectionWaiter = new ConnectionWaiter(ably.connection);
+
+			/* suppress automatic retries by the connection manager */
+			try {
+				Method method = ably.connection.connectionManager.getClass().getDeclaredMethod("disconnectAndSuppressRetries");
+				method.setAccessible(true);
+				method.invoke(ably.connection.connectionManager);
+			} catch (NoSuchMethodException|IllegalAccessException|InvocationTargetException e) {
+				fail("Unexpected exception in suppressing retries");
+			}
+
+			connectionWaiter.waitFor(ConnectionState.disconnected);
+			assertEquals("Verify disconnected state is reached", ConnectionState.disconnected, ably.connection.state);
+
+			/* wait */
+			try { Thread.sleep(2000L); } catch(InterruptedException e) {}
+
+			/* wait for connection to be reestablished */
+			System.out.println("channel_resume_lost_continuity: initiating reconnection (resume)");
+			ably.connection.connect();
+			connectionWaiter.waitFor(ConnectionState.connected);
+
+			/* verify a new connection was assigned */
+			assertNotEquals("A new connection was created", originalConnectionId, ably.connection.id);
+
+			/* previously suspended channel should transition to attaching, then to attached */
+			suspendedChannelWaiter.waitFor(ChannelState.attached);
+
+			/* previously attached channel should remain attached */
+			attachedChannelWaiter.waitFor(ChannelState.attached);
+
+			/*
+			 * Verify each channel undergoes relevant events:
+			 * - previously attached channel does attaching, attached, without visiting suspended;
+			 * - previously suspended channel does attaching, attached
+			 */
+			assertEquals("Verify channel was not suspended", suspendedStateReached[0], false);
+			assertEquals("Verify channel was attaching", attachingStateReached[0], true);
+			assertEquals("Verify channel was attached", attachedStateReached[0], true);
+			assertFalse("Verify resumed flag set false in ATTACHED event", resumedFlag[0]);
+
+			assertEquals("Verify channel was attaching", attachingStateReached[1], true);
+			assertEquals("Verify channel was attached", attachedStateReached[1], true);
+			assertFalse("Verify resumed flag set false in ATTACHED event", resumedFlag[1]);
+		} finally {
+			if (ably != null)
+				ably.close();
 		}
 	}
 

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -406,17 +407,13 @@ public class RealtimeConnectFailTest extends ParameterizedTest {
 	 * Allow token to expire and try to authorize with already expired token after that. Test that the connection state
 	 * is changed in the correct way and without duplicates:
 	 *
-	 * connecting -> connected -> disconnected -> connecting -> disconnected -> failed
+	 * connecting -> connected -> disconnected -> connecting -> failed
 	 */
 	@Test
 	public void connect_reauth_failure_state_flow_test() {
-		AblyRealtime ablyRealtime = null;
-		AblyRest ablyRest = null;
+
 		try {
-			/* To trigger the bug when connection is going to suspended if total connection time is more than
-			 * TIMEOUT_SUSPEND we set TIMEOUT_SUSPEND to smaller value
-			 */
-			Defaults.TIMEOUT_SUSPEND = 5000;
+			AblyRest ablyRest = null;
 			ClientOptions opts = createOptions(testVars.keys[0].keyStr);
 
 			ablyRest = new AblyRest(opts);
@@ -434,7 +431,24 @@ public class RealtimeConnectFailTest extends ParameterizedTest {
 				}
 			};
 			optsForRealtime.tokenDetails = tokenDetails;
-			ablyRealtime = new AblyRealtime(optsForRealtime);
+			final AblyRealtime ablyRealtime = new AblyRealtime(optsForRealtime);
+
+			ablyRealtime.connection.on(ConnectionState.connected, new ConnectionStateListener() {
+				@Override
+				public void onConnectionStateChanged(ConnectionStateChange state) {
+					/* To go quicker into a disconnected state we use a
+					 * smaller value for connectionStateTtl
+					 */
+					try {
+						Field field = ablyRealtime.connection.connectionManager.getClass().getDeclaredField("connectionStateTtl");
+						field.setAccessible(true);
+						field.setLong(ablyRealtime.connection.connectionManager, 5000L);
+					} catch (NoSuchFieldException|IllegalAccessException e) {
+						fail("Unexpected exception in checking connectionStateTtl");
+					}
+
+				}
+			});
 
 			(new ConnectionWaiter(ablyRealtime.connection)).waitFor(ConnectionState.connected);
 
@@ -453,7 +467,6 @@ public class RealtimeConnectFailTest extends ParameterizedTest {
 			List<ConnectionState> correctHistory = Arrays.asList(
 					ConnectionState.disconnected,
 					ConnectionState.connecting,
-					ConnectionState.disconnected,
 					ConnectionState.failed
 			);
 
@@ -461,14 +474,10 @@ public class RealtimeConnectFailTest extends ParameterizedTest {
 			synchronized (stateHistory) {
 				assertTrue("Verifying state change history", stateHistory.equals(correctHistory));
 			}
-
+            ablyRealtime.close();
 		} catch (AblyException e) {
 			e.printStackTrace();
 			fail("init0: Unexpected exception instantiating library");
-		} finally {
-			Defaults.TIMEOUT_SUSPEND = 120000;
-			if (ablyRealtime != null)
-				ablyRealtime.close();
 		}
 	}
 
@@ -479,12 +488,10 @@ public class RealtimeConnectFailTest extends ParameterizedTest {
 	public void connect_auth_failure_and_suspend_test() {
 		AblyRealtime ablyRealtime = null;
 		AblyRest ablyRest = null;
-		int oldSuspendTimeout = Defaults.TIMEOUT_SUSPEND;
 		int oldDisconnectTimeout = Defaults.TIMEOUT_DISCONNECT;
 
 		try {
 			/* Make test faster */
-			Defaults.TIMEOUT_SUSPEND = 2000;
 			Defaults.TIMEOUT_DISCONNECT = 1000;
 
 			final int[] numberOfAuthCalls = new int[] {0};
@@ -532,7 +539,6 @@ public class RealtimeConnectFailTest extends ParameterizedTest {
 			e.printStackTrace();
 			fail("init0: Unexpected exception instantiating library");
 		} finally {
-			Defaults.TIMEOUT_SUSPEND = oldSuspendTimeout;
 			Defaults.TIMEOUT_DISCONNECT = oldDisconnectTimeout;
 			if (ablyRealtime != null)
 				ablyRealtime.close();

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
@@ -825,27 +825,29 @@ public class RealtimeMessageTest extends ParameterizedTest {
 	public void reject_invalid_message_data() throws AblyException {
 		HashMap<String, Integer> data = new HashMap<String, Integer>();
 		Message message = new Message("event", data);
-		final Log.LogHandler logHandler = Log.handler;
+		Log.LogHandler originalLogHandler = Log.handler;
+		int originalLogLevel = Log.level;
+		Log.setLevel(Log.DEBUG);
+		final ArrayList<LogLine> capturedLog = new ArrayList<>();
+		Log.setHandler(new Log.LogHandler() {
+			@Override
+			public void println(int severity, String tag, String msg, Throwable tr) {
+				capturedLog.add(new LogLine(severity, tag, msg, tr));
+			}
+		});
+
 		try {
-			final ArrayList<LogLine> capturedLog = new ArrayList<>();
-			Log.setHandler(new Log.LogHandler() {
-				@Override
-				public void println(int severity, String tag, String msg, Throwable tr) {
-					capturedLog.add(new LogLine(severity, tag, msg, tr));
-				}
-			});
-
 			message.encode(null);
-
+		} catch (AblyException e) {
 			assertEquals(null, message.encoding);
 			assertEquals(data, message.data);
-
 			assertEquals(1, capturedLog.size());
 			LogLine capturedLine = capturedLog.get(0);
 			assertTrue(capturedLine.tag.contains("ably"));
-			assertTrue(capturedLine.msg.contains("Message data must be either `byte[]`, `String` or `JSONElement`; implicit coercion of other types to String is deprecated" ));
+			assertTrue(capturedLine.msg.contains("Message data must be either `byte[]`, `String` or `JSONElement`; implicit coercion of other types to String is deprecated"));
 		} finally {
-			Log.setHandler(logHandler);
+			Log.setHandler(originalLogHandler);
+			Log.setLevel(originalLogLevel);
 		}
 	}
 

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
@@ -845,6 +845,8 @@ public class RealtimeMessageTest extends ParameterizedTest {
 			LogLine capturedLine = capturedLog.get(0);
 			assertTrue(capturedLine.tag.contains("ably"));
 			assertTrue(capturedLine.msg.contains("Message data must be either `byte[]`, `String` or `JSONElement`; implicit coercion of other types to String is deprecated"));
+		} catch (Throwable t) {
+			fail("reject_invalid_message_data: Unexpected exception");
 		} finally {
 			Log.setHandler(originalLogHandler);
 			Log.setLevel(originalLogLevel);

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimePresenceHistoryTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimePresenceHistoryTest.java
@@ -625,7 +625,7 @@ public class RealtimePresenceHistoryTest extends ParameterizedTest {
 			(new ChannelWaiter(channel)).waitFor(ChannelState.attached);
 			assertEquals("Verify attached state reached", channel.state, ChannelState.attached);
 
-			/* send batches of messages with shprt inter-message delay */
+			/* send batches of messages with short inter-message delay */
 			CompletionSet msgComplete = new CompletionSet();
 			for(int i = 0; i < 20; i++) {
 				channel.presence.enter(String.valueOf(i), msgComplete.add());


### PR DESCRIPTION
In preparation for https://github.com/ably/ably-java/issues/358 

- [x] Remove `TIMEOUT_SUSPEND`
- [x] add `connectionStateTtl` and use it instead of `TIMEOUT_SUSPEND`