### PR TITLE
Add connection freshness check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,3 @@ notifications:
       - cesare@ably.io
     on_success: change
     on_failure: always
-
-branches:
-  only:
-  - master
-  - develop

--- a/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
+++ b/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
@@ -159,10 +159,10 @@ public class AblyRealtime extends AblyRest {
 			channel.onChannelMessage(msg);
 		}
 
-		public void suspendAll(ErrorInfo error) {
+		public void suspendAll(ErrorInfo error, boolean notifyStateChange) {
 			for(Iterator<Map.Entry<String, Channel>> it = entrySet().iterator(); it.hasNext(); ) {
 				Map.Entry<String, Channel> entry = it.next();
-				entry.getValue().setSuspended(error);
+				entry.getValue().setSuspended(error, notifyStateChange);
 			}
 		}
 	}

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -205,6 +205,19 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	 *********************/
 
 	public void connect() {
+
+		if (transport != null) {
+			long intervalSinceLastActivity = System.currentTimeMillis() - transport.getLastActivity();
+			if (intervalSinceLastActivity > (maxIdleInterval + connectionStateTtl)) {
+				connection.id = null;
+				connection.key = null;
+				connection.recoveryKey = null;
+				startThread();
+				requestState(ConnectionState.connecting);
+				return;
+			}
+		}
+
 		boolean connectionExist = state.state == ConnectionState.connected;
 		boolean connectionAttemptInProgress = (requestedState != null && requestedState.state == ConnectionState.connecting) ||
 				state.state == ConnectionState.connecting;

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -153,7 +153,6 @@ public class ConnectionManager implements Runnable, ConnectListener {
 
 	long maxIdleInterval = Defaults.maxIdleInterval;
 	long connectionStateTtl = Defaults.connectionStateTtl;
-	private long failedAuthAttempts = 0;
 
 	public ErrorInfo getStateErrorInfo() {
 		return state.defaultErrorInfo;
@@ -582,9 +581,6 @@ public class ConnectionManager implements Runnable, ConnectListener {
 
 	private synchronized void onError(ProtocolMessage message) {
 		connection.key = null;
-		if((message.error.code >= 40140) && (message.error.code < 40150)) {
-			failedAuthAttempts += 1;
-		}
 		ConnectionState destinationState = isFatalError(message.error) ? ConnectionState.failed : ConnectionState.disconnected;
 		notifyState(transport, new StateIndication(destinationState, message.error));
 	}
@@ -1187,13 +1183,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	private boolean isFatalError(ErrorInfo err) {
 		if(err.code != 0) {
 			/* token errors are assumed to be recoverable */
-			if((err.code >= 40140) && (err.code < 40150)) {
-				/* unless one auth attempt has already been made and has failed */
-				if (failedAuthAttempts >= 1) {
-					return true;
-				}
-				return false;
-			}
+			if((err.code >= 40140) && (err.code < 40150)) { return false; }
 			/* 400 codes assumed to be fatal */
 			if((err.code >= 40000) && (err.code < 50000)) { return true; }
 		}

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -679,6 +679,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 		if(intervalSinceLastActivity > (maxIdleInterval + connectionStateTtl)) {
 			/* RTN15g1, RTN15g2 Force a new connection if the previous one is stale */
 			if(connection.id != null) {
+				Log.v(TAG, "Clearing the old stale connection");
 				connection.id = null;
 				connection.key = null;
 				connection.recoveryKey = null;

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -451,7 +451,6 @@ public class ConnectionManager implements Runnable, ConnectListener {
 		if (Log.level <= Log.VERBOSE)
 			Log.v(TAG, "onMessage(): " + message.action + ": " + new String(ProtocolSerializer.writeJSON(message)));
 		try {
-			lastActivity = System.currentTimeMillis();
 			if(protocolListener != null)
 				protocolListener.onRawMessageRecv(message);
 			switch(message.action) {
@@ -993,6 +992,10 @@ public class ConnectionManager implements Runnable, ConnectListener {
 		} catch(AblyException e) {
 			return false;
 		}
+	}
+
+	protected void setLastActivity(long lastActivityTime) {
+		this.lastActivity = lastActivityTime;
 	}
 
 	/******************

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -205,7 +205,6 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	 *********************/
 
 	public void connect() {
-
 		boolean connectionExist = state.state == ConnectionState.connected;
 		boolean connectionAttemptInProgress = (requestedState != null && requestedState.state == ConnectionState.connecting) ||
 				state.state == ConnectionState.connecting;
@@ -674,7 +673,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	private boolean checkConnectionStale() {
 	    if(lastActivity == 0) {
 	        return false;
-        }
+	    }
 		long now = System.currentTimeMillis();
 		long intervalSinceLastActivity = now - lastActivity;
 		if(intervalSinceLastActivity > (maxIdleInterval + connectionStateTtl)) {

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -276,7 +276,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 						/* (RTL3c) If the connection state enters the SUSPENDED
 						 * state, then an ATTACHING or ATTACHED channel state
 						 * will transition to SUSPENDED. */
-						channel.setSuspended(state.defaultErrorInfo);
+						channel.setSuspended(state.defaultErrorInfo, true);
 						break;
 				}
 			}
@@ -526,10 +526,12 @@ public class ConnectionManager implements Runnable, ConnectListener {
 
 		/* if there was a (non-fatal) connection error
 		 * that invalidates an existing connection id, then
-		 * remove all channels attached to the previous id */
+		 * suspend all channels attached to the previous id;
+		 * this will be reattached in setConnection() */
 		ErrorInfo error = message.error;
-		if(error != null && !message.connectionId.equals(connection.id))
-			ably.channels.suspendAll(error);
+		if(error != null && !message.connectionId.equals(connection.id)) {
+			ably.channels.suspendAll(error, false);
+		}
 
 		/* set the new connection id */
 		ConnectionDetails connectionDetails = message.connectionDetails;
@@ -715,9 +717,11 @@ public class ConnectionManager implements Runnable, ConnectListener {
 				stateChange = null;
 				break;
 			case connected:
-				/* we were connected, so retry immediately */
 				setSuspendTime();
-				requestState(ConnectionState.connecting);
+				/* we were connected, so retry immediately */
+				if(!suppressRetry) {
+					requestState(ConnectionState.connecting);
+				}
 				break;
 			case suspended:
 				/* Don't allow a second disconnected to make the state come out of suspended. */
@@ -823,7 +827,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 					}
 
 					/* if our state wants us to retry on timer expiry, do that */
-					if(state.retry) {
+					if(state.retry && !suppressRetry) {
 						requestState(ConnectionState.connecting);
 						continue;
 					}
@@ -1205,6 +1209,15 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	}
 
 	/*******************
+	 * for tests only
+	 ******************/
+
+	void disconnectAndSuppressRetries() {
+		requestState(ConnectionState.disconnected);
+		suppressRetry = true;
+	}
+
+	/*******************
 	 * internal
 	 ******************/
 
@@ -1238,6 +1251,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	private StateIndication indicatedState, requestedState;
 	private ConnectParams pendingConnect;
 	private boolean pendingReauth;
+	private boolean suppressRetry; /* for tests only; modified via reflection */
 	private ITransport transport;
 	private long suspendTime;
 	private long msgSerial;

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -207,7 +207,8 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	public void connect() {
 
 		if (transport != null) {
-			long intervalSinceLastActivity = System.currentTimeMillis() - transport.getLastActivity();
+			long now = System.currentTimeMillis();
+			long intervalSinceLastActivity = now - lastActivity;
 			if (intervalSinceLastActivity > (maxIdleInterval + connectionStateTtl)) {
 				connection.id = null;
 				connection.key = null;
@@ -464,6 +465,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 		if (Log.level <= Log.VERBOSE)
 			Log.v(TAG, "onMessage(): " + message.action + ": " + new String(ProtocolSerializer.writeJSON(message)));
 		try {
+			lastActivity = System.currentTimeMillis();
 			if(protocolListener != null)
 				protocolListener.onRawMessageRecv(message);
 			switch(message.action) {
@@ -1226,6 +1228,7 @@ public class ConnectionManager implements Runnable, ConnectListener {
 	private ITransport transport;
 	private long suspendTime;
 	private long msgSerial;
+	private long lastActivity;
 
 	/* for debug/test only */
 	private RawProtocolListener protocolListener;

--- a/lib/src/main/java/io/ably/lib/transport/ITransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/ITransport.java
@@ -117,4 +117,7 @@ public interface ITransport {
 	public String getURL();
 
 	public String getHost();
+
+	public long getLastActivity();
+
 }

--- a/lib/src/main/java/io/ably/lib/transport/ITransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/ITransport.java
@@ -118,6 +118,4 @@ public interface ITransport {
 
 	public String getHost();
 
-	public long getLastActivity();
-
 }

--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -139,6 +139,14 @@ public class WebSocketTransport implements ITransport {
 		return params.host;
 	}
 
+	@Override
+	public long getLastActivity() {
+		if (wsConnection != null) {
+			return wsConnection.lastActivityTime;
+		}
+		return 0;
+	}
+
 	/**************************
 	 * WebSocketHandler methods
 	 **************************/

--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -258,6 +258,7 @@ public class WebSocketTransport implements ITransport {
 
 		private void flagActivity() {
 			lastActivityTime = System.currentTimeMillis();
+			connectionManager.setLastActivity(lastActivityTime);
 			if (timer == null && connectionManager.maxIdleInterval != 0) {
 				/* No timer currently running because previously there was no
 				 * maxIdleInterval configured, but now there is a

--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -139,14 +139,6 @@ public class WebSocketTransport implements ITransport {
 		return params.host;
 	}
 
-	@Override
-	public long getLastActivity() {
-		if (wsConnection != null) {
-			return wsConnection.lastActivityTime;
-		}
-		return 0;
-	}
-
 	/**************************
 	 * WebSocketHandler methods
 	 **************************/

--- a/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
@@ -478,7 +478,7 @@ public class ConnectionManagerTest extends ParameterizedTest {
 			ably.connection.connectionManager.requestState(ConnectionState.disconnected);
 			connectionWaiter.waitFor(ConnectionState.disconnected);
 
-            ably.connection.once(ConnectionEvent.connected, new ConnectionStateListener() {
+			ably.connection.once(ConnectionEvent.connected, new ConnectionStateListener() {
 				@Override
 				public void onConnectionStateChanged(ConnectionStateChange state) {
 					assertEquals("Client has reconnected", ConnectionState.connected, state.current);
@@ -570,15 +570,14 @@ public class ConnectionManagerTest extends ParameterizedTest {
 			});
 			channel.attach();
 
-            /* Before disconnecting wait that newTtl + newIdleInterval has passed */
-            try {
-                Thread.sleep(intervalBeforeReconnecting);
-            } catch(InterruptedException e) {}
+			/* Before disconnecting wait that newTtl + newIdleInterval has passed */
+			try {
+				Thread.sleep(intervalBeforeReconnecting);
+			} catch(InterruptedException e) {}
 			ably.connection.connectionManager.requestState(ConnectionState.disconnected);
 
-            /* Since newTtl + newIdleInterval has passed we expect the connection to go into a suspended state */
-            connectionWaiter.waitFor(ConnectionState.suspended);
-
+			/* Since newTtl + newIdleInterval has passed we expect the connection to go into a suspended state */
+			connectionWaiter.waitFor(ConnectionState.suspended);
 			ably.connect();
 			ably.connection.once(ConnectionEvent.connected, new ConnectionStateListener() {
 				@Override

--- a/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
@@ -489,7 +489,7 @@ public class ConnectionManagerTest extends ParameterizedTest {
 				}
 			});
 
-			connectionWaiter.waitFor(ConnectionState.connected);
+			connectionWaiter.waitFor(ConnectionState.closed);
 
 		} catch (AblyException e) {
 			e.printStackTrace();

--- a/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
@@ -569,6 +569,7 @@ public class ConnectionManagerTest extends ParameterizedTest {
 				}
 			});
 			channel.attach();
+			(new Helpers.ChannelWaiter(channel)).waitFor(ChannelState.attached);
 
 			/* Before disconnecting wait that newTtl + newIdleInterval has passed */
 			try {

--- a/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
@@ -595,6 +595,7 @@ public class ConnectionManagerTest extends ParameterizedTest {
 					});
 				}
 			});
+			connectionWaiter.waitFor(ConnectionState.closed);
 		} catch (AblyException e) {
 			e.printStackTrace();
 			fail("init0: Unexpected exception instantiating library");

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -1,42 +1,29 @@
 package io.ably.lib.test.realtime;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import io.ably.lib.realtime.*;
+import io.ably.lib.realtime.Channel.MessageListener;
+import io.ably.lib.test.common.Helpers;
+import io.ably.lib.test.common.Helpers.ChannelWaiter;
+import io.ably.lib.test.common.Helpers.ConnectionWaiter;
+import io.ably.lib.test.common.ParameterizedTest;
+import io.ably.lib.test.util.MockWebsocketFactory;
+import io.ably.lib.transport.ConnectionManager;
+import io.ably.lib.transport.Defaults;
+import io.ably.lib.types.*;
+import io.ably.lib.util.Log;
+import org.hamcrest.Matchers;
+import org.junit.Test;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-import org.hamcrest.Matchers;
-import org.junit.Test;
-import io.ably.lib.realtime.AblyRealtime;
-import io.ably.lib.realtime.Channel;
-import io.ably.lib.realtime.Channel.MessageListener;
-import io.ably.lib.realtime.ChannelEvent;
-import io.ably.lib.realtime.ChannelState;
-import io.ably.lib.realtime.ChannelStateListener;
-import io.ably.lib.realtime.CompletionListener;
-import io.ably.lib.realtime.ConnectionState;
-import io.ably.lib.realtime.ConnectionStateListener;
-import io.ably.lib.test.common.Helpers;
-import io.ably.lib.test.common.Helpers.ChannelWaiter;
-import io.ably.lib.test.common.Helpers.ConnectionWaiter;
-import io.ably.lib.test.common.ParameterizedTest;
-import io.ably.lib.transport.ConnectionManager;
-import io.ably.lib.test.util.MockWebsocketFactory;
-import io.ably.lib.transport.Defaults;
-import io.ably.lib.types.AblyException;
-import io.ably.lib.types.ClientOptions;
-import io.ably.lib.types.ErrorInfo;
-import io.ably.lib.types.Message;
-import io.ably.lib.types.ProtocolMessage;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
 
 public class RealtimeChannelTest extends ParameterizedTest {
 
@@ -1121,6 +1108,126 @@ public class RealtimeChannelTest extends ParameterizedTest {
 			if (ably != null)
 				ably.close();
 			Defaults.realtimeRequestTimeout = oldRealtimeTimeout;
+		}
+	}
+
+	/*
+	 * Establish connection, attach channel, disconnection and failed resume
+	 * verify that subsequent attaches are performed, and give rise to update events
+	 *
+	 * Tests RTN15c3
+	 */
+	@Test
+	public void channel_resume_lost_continuity() throws AblyException {
+		AblyRealtime ably = null;
+		final String attachedChannelName = "channel_resume_lost_continuity_attached";
+		final String suspendedChannelName = "channel_resume_lost_continuity_suspended";
+
+		try {
+			ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+			ably = new AblyRealtime(opts);
+
+			/* prepare channels */
+			Channel attachedChannel = ably.channels.get(attachedChannelName);
+			ChannelWaiter attachedChannelWaiter = new ChannelWaiter(attachedChannel);
+			attachedChannel.attach();
+			attachedChannelWaiter.waitFor(ChannelState.attached);
+
+			Channel suspendedChannel = ably.channels.get(suspendedChannelName);
+			suspendedChannel.state = ChannelState.suspended;
+			ChannelWaiter suspendedChannelWaiter = new ChannelWaiter(suspendedChannel);
+
+			final boolean[] suspendedStateReached = new boolean[2];
+			final boolean[] attachingStateReached = new boolean[2];
+			final boolean[] attachedStateReached = new boolean[2];
+			final boolean[] resumedFlag = new boolean[]{true, true};
+			attachedChannel.on(new ChannelStateListener() {
+				@Override
+				public void onChannelStateChanged(ChannelStateChange stateChange) {
+					switch(stateChange.current) {
+						case suspended:
+							suspendedStateReached[0] = true;
+							break;
+						case attaching:
+							attachingStateReached[0] = true;
+							break;
+						case attached:
+							attachedStateReached[0] = true;
+							resumedFlag[0] = stateChange.resumed;
+							break;
+						default:
+							break;
+					}
+				}
+			});
+			suspendedChannel.on(new ChannelStateListener() {
+				@Override
+				public void onChannelStateChanged(ChannelStateChange stateChange) {
+					switch(stateChange.current) {
+						case attaching:
+							attachingStateReached[1] = true;
+							break;
+						case attached:
+							attachedStateReached[1] = true;
+							resumedFlag[1] = stateChange.resumed;
+							break;
+						default:
+							break;
+					}
+				}
+			});
+
+			/* disconnect, and sabotage the resume */
+			String originalConnectionId = ably.connection.id;
+			ably.connection.key = "_____!ably___test_fake-key____";
+			ably.connection.id = "ably___tes";
+			ConnectionWaiter connectionWaiter = new ConnectionWaiter(ably.connection);
+
+			/* suppress automatic retries by the connection manager */
+			try {
+				Method method = ably.connection.connectionManager.getClass().getDeclaredMethod("disconnectAndSuppressRetries");
+				method.setAccessible(true);
+				method.invoke(ably.connection.connectionManager);
+			} catch (NoSuchMethodException|IllegalAccessException|InvocationTargetException e) {
+				fail("Unexpected exception in suppressing retries");
+			}
+
+			connectionWaiter.waitFor(ConnectionState.disconnected);
+			assertEquals("Verify disconnected state is reached", ConnectionState.disconnected, ably.connection.state);
+
+			/* wait */
+			try { Thread.sleep(2000L); } catch(InterruptedException e) {}
+
+			/* wait for connection to be reestablished */
+			System.out.println("channel_resume_lost_continuity: initiating reconnection (resume)");
+			ably.connection.connect();
+			connectionWaiter.waitFor(ConnectionState.connected);
+
+			/* verify a new connection was assigned */
+			assertNotEquals("A new connection was created", originalConnectionId, ably.connection.id);
+
+			/* previously suspended channel should transition to attaching, then to attached */
+			suspendedChannelWaiter.waitFor(ChannelState.attached);
+
+			/* previously attached channel should remain attached */
+			attachedChannelWaiter.waitFor(ChannelState.attached);
+
+			/*
+			 * Verify each channel undergoes relevant events:
+			 * - previously attached channel does attaching, attached, without visiting suspended;
+			 * - previously suspended channel does attaching, attached
+			 */
+			assertEquals("Verify channel was not suspended", suspendedStateReached[0], false);
+			assertEquals("Verify channel was attaching", attachingStateReached[0], true);
+			assertEquals("Verify channel was attached", attachedStateReached[0], true);
+			assertFalse("Verify resumed flag set false in ATTACHED event", resumedFlag[0]);
+
+			assertEquals("Verify channel was attaching", attachingStateReached[1], true);
+			assertEquals("Verify channel was attached", attachedStateReached[1], true);
+			assertFalse("Verify resumed flag set false in ATTACHED event", resumedFlag[1]);
+		} finally {
+			if (ably != null)
+				ably.close();
 		}
 	}
 


### PR DESCRIPTION
Fix #358 

- [X] Add connection freshness check
- [X] Test reconnection after ttl + idleTime has passed
- [x] Test reconnection before ttl + idleTime has passed
- [x] Test channels attached during the first connection are correctly reattached after reconnecting when ttl + idleTime has passed
- [x] Include heartbeats in `lastActivityTime`
- [x] Fix [failing channels_are_reattached_after_reconnecting_when_statettl_plus_idleinterval_has_passed](https://github.com/ably/ably-java/blob/add-connection-freshness-check/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java#L533). Reason: channels stay in an `ATTACHED` state even when the connection freshness check disposes of the old connection and creates a new one.