### PR TITLE
Prevent Travis timeout on Android tests

### DIFF
--- a/ci/run-android-tests.sh
+++ b/ci/run-android-tests.sh
@@ -1,1 +1,1 @@
-./gradlew connectedAndroidTest
+./gradlew connectedAndroidTest --info


### PR DESCRIPTION
Sometimes Travis builds for android fail due to a timeout.
Example [here](https://travis-ci.org/ably/ably-java/jobs/357569119) 
This happens because:

- there's no test failure for > 10 minutes
- Travis detects that there's no output for longer than default timeout (10 minutes)
- Travis terminates the build

This PR makes android tests more verbose to avoid the timeout.

