### PR TITLE
Add jwt tests

### DIFF
--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -607,7 +607,7 @@ public class Auth {
 								return null;
 							}
 							if(contentType != null) {
-								if(contentType.startsWith("text/plain")) {
+								if(contentType.startsWith("text/plain") || contentType.startsWith("application/jwt")) {
 									/* assumed to be token string */
 									String token = new String(body);
 									return new TokenDetails(token);

--- a/lib/src/test/java/io/ably/lib/test/common/ParameterizedTest.java
+++ b/lib/src/test/java/io/ably/lib/test/common/ParameterizedTest.java
@@ -34,7 +34,7 @@ public class ParameterizedTest {
 	public Timeout testTimeout = Timeout.seconds(10);
 
 	protected static Setup.TestVars testVars;
-	protected final String echoServer = "https://ably-echoserver.herokuapp.com/createJWT";
+	protected final String echoServer = "https://echo.ably.io/createJWT";
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {

--- a/lib/src/test/java/io/ably/lib/test/common/ParameterizedTest.java
+++ b/lib/src/test/java/io/ably/lib/test/common/ParameterizedTest.java
@@ -1,7 +1,10 @@
 package io.ably.lib.test.common;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
+import io.ably.lib.types.Param;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -31,6 +34,7 @@ public class ParameterizedTest {
 	public Timeout testTimeout = Timeout.seconds(10);
 
 	protected static Setup.TestVars testVars;
+	protected final String echoServer = "https://ably-echoserver.herokuapp.com/createJWT";
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
@@ -53,4 +57,19 @@ public class ParameterizedTest {
 	protected void fillInOptions(ClientOptions opts) {
 		testVars.fillInOptions(opts, testParams);
 	}
+
+	/**
+	 * Helper method to merge auth parameters
+	 */
+	protected static Param[] mergeParams(Param[] target, Param[] src) {
+		Map<String, Param> merged = new HashMap<String, Param>();
+		if(target != null) {
+			for(Param param : target) { merged.put(param.key, param); }
+		}
+		if(src != null) {
+			for(Param param : src) { merged.put(param.key, param); }
+		}
+		return merged.values().toArray(new Param[merged.size()]);
+	}
+
 }

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeJWTTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeJWTTest.java
@@ -193,6 +193,7 @@ public class RealtimeJWTTest extends ParameterizedTest {
 		try {
 			final String[] tokens = new String[1];
 			final boolean[] authMessages = new boolean[] { false };
+			final boolean[] updateEvents = new boolean[] { false };
 
 			/* create ably realtime with authUrl and params that include a ttl of 35 seconds */
 			DebugOptions options = new DebugOptions(testVars.keys[0].keyStr);
@@ -239,6 +240,7 @@ public class RealtimeJWTTest extends ParameterizedTest {
 				public void onConnectionStateChanged(ConnectionStateChange state) {
 					assertNotEquals("Token should not be the same", tokens[0], ablyRealtime.auth.getTokenDetails().token);
 					assertTrue("Auth protocol message has not been received", authMessages[0]);
+					updateEvents[0] = true;
 					ablyRealtime.close();
 				}
 			});
@@ -250,6 +252,7 @@ public class RealtimeJWTTest extends ParameterizedTest {
 
 			/* wait for closed state */
 			connectionWaiter.waitFor(ConnectionState.closed);
+			assertTrue("Update event not received", updateEvents[0]);
 		} catch (AblyException e) {
 			e.printStackTrace();
 			fail();

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeJWTTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeJWTTest.java
@@ -371,17 +371,22 @@ public class RealtimeJWTTest extends ParameterizedTest {
 	 */
 	private ClientOptions buildClientOptions(Param[] params, String capability) {
 		try {
-			jwtRequesterOptions = createOptions(testVars.keys[0].keyStr);
-			jwtRequesterOptions.authUrl = echoServer;
-			jwtRequesterOptions.authParams = params;
-			restJWTRequester = new AblyRest(jwtRequesterOptions);
-			TokenParams t = new TokenParams();
-			if (capability != null) {
-				t.capability = capability;
-			}
-			TokenDetails tokenDetails = restJWTRequester.auth.requestToken(t, null);
+			final String[] resultToken = new String[1];
+			AblyRest rest = new AblyRest(createOptions(testVars.keys[0].keyStr));
+			HttpHelpers.getUri(rest.httpCore, echoServer, null, params, new ResponseHandler() {
+				@Override
+				public Object handleResponse(HttpCore.Response response, ErrorInfo error) throws AblyException {
+					try {
+						resultToken[0] = new String(response.body, "UTF-8");
+					} catch (UnsupportedEncodingException e) {
+						e.printStackTrace();
+						fail("Error in fetching a JWT token " + e);
+					}
+					return null;
+				}
+			});
 			ClientOptions realtimeOptions = createOptions();
-			realtimeOptions.token = tokenDetails.token;
+			realtimeOptions.token = resultToken[0];
 			return realtimeOptions;
 		} catch (AblyException e) {
 			fail("Failure in fetching a JWT token to create ClientOptions " + e);

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeJWTTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeJWTTest.java
@@ -193,7 +193,7 @@ public class RealtimeJWTTest extends ParameterizedTest {
 
 	/**
 	 * Request a JWT with a ttl of 35 seconds and
-	 * verify that the client reauths without going through a disconnected state.
+	 * verify that the client reauths without going through a disconnected state. (RTC8a4)
 	 */
 	@Test
 	public void auth_jwt_with_client_than_reauths_without_disconnecting() {

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeJWTTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeJWTTest.java
@@ -1,0 +1,210 @@
+package io.ably.lib.test.realtime;
+
+import static org.junit.Assert.*;
+
+import io.ably.lib.test.common.Setup.Key;
+import io.ably.lib.types.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.ably.lib.realtime.*;
+import io.ably.lib.rest.AblyRest;
+import io.ably.lib.rest.Auth.*;
+import io.ably.lib.test.common.Helpers.*;
+import io.ably.lib.test.common.ParameterizedTest;
+
+import java.util.UUID;
+
+
+public class RealtimeJWTTest extends ParameterizedTest {
+
+	private AblyRest restJWTRequester;
+	private ClientOptions jwtRequesterOptions;
+	private ClientOptions realtimeOptions;
+	private Key key = testVars.keys[0];
+	private final String clientId = "testJWTClientID";
+	private final String channelName = "testJWTChannel" + UUID.randomUUID().toString();
+	private final String messageName = "testJWTMessage" + UUID.randomUUID().toString();
+	Param[] keys = new Param[]{ new Param("keyName", key.keyName), new Param("keySecret", key.keySecret) };
+	Param[] clientIdParam = new Param[] { new Param("clientId", clientId) };
+	Param[] shortTokenTtl = new Param[] { new Param("expiresIn", 5) };
+	private final String susbcribeOnlyCapability = "{\"" + channelName + "\": [\"subscribe\"]}";
+	private final String publishCapability = "{\"" + channelName + "\": [\"publish\"]}";
+
+	@Before
+	public void setUpBefore() throws Exception {
+		jwtRequesterOptions = createOptions(testVars.keys[0].keyStr);
+		jwtRequesterOptions.authUrl = echoServer;
+		realtimeOptions = new ClientOptions();
+		realtimeOptions.environment = "sandbox";
+	}
+
+	/**
+	 * Request a JWT that specifies a clientId
+	 * Verifies that the clientId matches the one requested
+	 */
+	@Test
+	public void auth_clientid_match_the_one_requested_in_jwt() {
+		try {
+			/* create ably realtime with JWT token */
+			realtimeOptions.token = getToken(mergeParams(keys, clientIdParam), null);
+			assertNotNull("Expected token value", realtimeOptions.token);
+			AblyRealtime ablyRealtime = new AblyRealtime(realtimeOptions);
+
+			/* wait for connected state */
+			ConnectionWaiter connectionWaiter = new ConnectionWaiter(ablyRealtime.connection);
+			connectionWaiter.waitFor(ConnectionState.connected);
+			assertEquals("Connected state was NOT reached", ConnectionState.connected, ablyRealtime.connection.state);
+
+			/* check expected clientId */
+			assertEquals("clientId does NOT match the one requested", clientId, ablyRealtime.auth.clientId);
+
+			ablyRealtime.close();
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail();
+		}
+	}
+
+	/**
+	 * Request a JWT with subscribe-only capabilities
+	 * Verifies that publishing on a channel fails
+	 */
+	@Test
+	public void auth_jwt_with_subscribe_only_capability() {
+		try {
+			/* create ably realtime with JWT token that has subscribe-only capabilities */
+			realtimeOptions.token = getToken(keys, susbcribeOnlyCapability);
+			assertNotNull("Expected token value", realtimeOptions.token);
+			final AblyRealtime ablyRealtime = new AblyRealtime(realtimeOptions);
+
+			/* wait for connected state */
+			ConnectionWaiter connectionWaiter = new ConnectionWaiter(ablyRealtime.connection);
+			connectionWaiter.waitFor(ConnectionState.connected);
+			assertEquals("Connected state was NOT reached", ConnectionState.connected, ablyRealtime.connection.state);
+
+			/* attach to channel and verify attached state */
+			Channel channel = ablyRealtime.channels.get(channelName);
+			channel.attach();
+			new ChannelWaiter(channel).waitFor(ChannelState.attached);
+
+			/* publish and verify that it fails */
+			channel.publish(messageName, null, new CompletionListener() {
+				@Override
+				public void onSuccess() {
+					fail("It should not succeed");
+				}
+
+				@Override
+				public void onError(ErrorInfo error) {
+					assertEquals("Unexpected status code", 401, error.statusCode);
+					assertEquals("Unexpected error code", 40160, error.code);
+					assertEquals("Unexpected error message", "Unable to perform channel operation (permission denied)", error.message);
+					ablyRealtime.close();
+				}
+			});
+			connectionWaiter.waitFor(ConnectionState.closed);
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail();
+		}
+	}
+
+	/**
+	 * Request a JWT with publish capabilities
+	 * Verifies that publishing on a channel succeeds
+	 */
+	@Test
+	public void auth_jwt_with_publish_capability() {
+		try {
+			/* create ably realtime with JWT token that has publish capabilities */
+			realtimeOptions.token = getToken(keys, publishCapability);
+			assertNotNull("Expected token value", realtimeOptions.token);
+			final AblyRealtime ablyRealtime = new AblyRealtime(realtimeOptions);
+
+			/* wait for connected state */
+			ConnectionWaiter connectionWaiter = new ConnectionWaiter(ablyRealtime.connection);
+			connectionWaiter.waitFor(ConnectionState.connected);
+			assertEquals("Connected state was NOT reached", ConnectionState.connected, ablyRealtime.connection.state);
+
+			/* attach to channel and verify attached state */
+			Channel channel = ablyRealtime.channels.get(channelName);
+			channel.attach();
+			new ChannelWaiter(channel).waitFor(ChannelState.attached);
+
+			/* publish, verify that it succeeds then close */
+			final Message message = new Message(messageName, null);
+			channel.publish(message, new CompletionListener() {
+				@Override
+				public void onSuccess() {
+					System.out.println("Message " + messageName + " published successfully");
+					ablyRealtime.close();
+				}
+
+				@Override
+				public void onError(ErrorInfo reason) {
+					fail("Publish should not fail");
+				}
+			});
+			connectionWaiter.waitFor(ConnectionState.closed);
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail();
+		}
+	}
+
+	/**
+	 * Request a JWT with a ttl of 5 seconds and
+	 * verify the correct error and message in the disconnected state change.
+	 */
+	@Test
+	public void auth_jwt_with_token_that_expires() {
+		try {
+			/* create ably realtime with JWT token that expires in 5 seconds */
+			realtimeOptions.token = getToken(mergeParams(keys, shortTokenTtl), null);
+			assertNotNull("Expected token value", realtimeOptions.token);
+			final AblyRealtime ablyRealtime = new AblyRealtime(realtimeOptions);
+
+			/* wait for connected state */
+			ConnectionWaiter connectionWaiter = new ConnectionWaiter(ablyRealtime.connection);
+			connectionWaiter.waitFor(ConnectionState.connected);
+			assertEquals("Connected state was NOT reached", ConnectionState.connected, ablyRealtime.connection.state);
+
+			/* Verify the expected error reason when disconnected */
+			ablyRealtime.connection.once(ConnectionEvent.disconnected, new ConnectionStateListener() {
+
+				@Override
+				public void onConnectionStateChanged(ConnectionStateChange stateChange) {
+					assertEquals("Unexpected connection stage change", 40142, stateChange.reason.code);
+					assertEquals("Unexpected error message", "Key/token status changed (expire)", stateChange.reason.message);
+					ablyRealtime.close();
+				}
+			});
+			connectionWaiter.waitFor(ConnectionState.disconnected);
+			connectionWaiter.waitFor(ConnectionState.closed);
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail();
+		}
+	}
+
+	/**
+	 * Helper to fetch a token with params via authUrl
+	 */
+	private String getToken(Param[] params, String capability) {
+		jwtRequesterOptions.authParams = params;
+		try {
+			restJWTRequester = new AblyRest(jwtRequesterOptions);
+			TokenParams t = new TokenParams();
+			if (capability != null) {
+				t.capability = capability;
+			}
+			TokenDetails tokenDetails = restJWTRequester.auth.requestToken(t, null);
+			return tokenDetails.token;
+		} catch (AblyException e) {
+			fail("Failure in fetching a JWT token" + e);
+			return null;
+		}
+	}
+
+}

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeJWTTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeJWTTest.java
@@ -38,8 +38,7 @@ public class RealtimeJWTTest extends ParameterizedTest {
 	public void setUpBefore() throws Exception {
 		jwtRequesterOptions = createOptions(testVars.keys[0].keyStr);
 		jwtRequesterOptions.authUrl = echoServer;
-		realtimeOptions = new ClientOptions();
-		realtimeOptions.environment = "sandbox";
+		realtimeOptions = createOptions();
 	}
 
 	/**
@@ -203,7 +202,7 @@ public class RealtimeJWTTest extends ParameterizedTest {
 
 			/* create ably realtime with authUrl and params that include a ttl of 35 seconds */
 			DebugOptions options = new DebugOptions(testVars.keys[0].keyStr);
-			options.environment = "sandbox";
+			options.environment = createOptions().environment;
 			options.authUrl = echoServer;
 			options.authParams = mergeParams(keys, mediumTokenTtl);
 			options.protocolListener = new RawProtocolListener() {

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeJWTTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeJWTTest.java
@@ -86,6 +86,7 @@ public class RealtimeJWTTest extends ParameterizedTest {
 			channel.publish(messageName, null, new CompletionListener() {
 				@Override
 				public void onSuccess() {
+					ablyRealtime.close();
 					fail("It should not succeed");
 				}
 
@@ -137,6 +138,7 @@ public class RealtimeJWTTest extends ParameterizedTest {
 
 				@Override
 				public void onError(ErrorInfo reason) {
+					ablyRealtime.close();
 					fail("Publish should not fail");
 				}
 			});

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeJWTTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeJWTTest.java
@@ -33,12 +33,6 @@ public class RealtimeJWTTest extends ParameterizedTest {
 	private final String susbcribeOnlyCapability = "{\"" + channelName + "\": [\"subscribe\"]}";
 	private final String publishCapability = "{\"" + channelName + "\": [\"publish\"]}";
 
-	@Before
-	public void setUpBefore() throws Exception {
-		jwtRequesterOptions = createOptions(testVars.keys[0].keyStr);
-		jwtRequesterOptions.authUrl = echoServer;
-	}
-
 	/**
 	 * Request a JWT that specifies a clientId
 	 * Verifies that the clientId matches the one requested
@@ -264,8 +258,10 @@ public class RealtimeJWTTest extends ParameterizedTest {
 	 * Helper to create ClientOptions with a JWT token fetched via authUrl according to the parameters
 	 */
 	private ClientOptions buildClientOptions(Param[] params, String capability) {
-		jwtRequesterOptions.authParams = params;
 		try {
+			jwtRequesterOptions = createOptions(testVars.keys[0].keyStr);
+			jwtRequesterOptions.authUrl = echoServer;
+			jwtRequesterOptions.authParams = params;
 			restJWTRequester = new AblyRest(jwtRequesterOptions);
 			TokenParams t = new TokenParams();
 			if (capability != null) {

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeSuite.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeSuite.java
@@ -18,6 +18,7 @@ import io.ably.lib.test.common.Setup;
 	EventEmitterTest.class,
 	RealtimeHttpHeaderTest.class,
 	RealtimeAuthTest.class,
+	RealtimeJWTTest.class,
 	RealtimeReauthTest.class,
 	RealtimeInitTest.class,
 	RealtimeConnectTest.class,

--- a/lib/src/test/java/io/ably/lib/test/rest/RestJWTTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestJWTTest.java
@@ -25,7 +25,7 @@ public class RestJWTTest extends ParameterizedTest {
 	 * Base request of a JWT token (RSA8g RSA8c)
 	 */
 	@Test
-	public void authjwtrequest() {
+	public void auth_jwt_request() {
 		try {
 			ClientOptions options = buildClientOptions(validKeys);
 			AblyRest client = new AblyRest(options);
@@ -33,7 +33,7 @@ public class RestJWTTest extends ParameterizedTest {
 			assertNotNull("Stats should not be null", stats);
 		} catch (AblyException e) {
 			e.printStackTrace();
-			fail("authjwtrequest: Unexpected exception");
+			fail("auth_jwt_request: Unexpected exception");
 		}
 	}
 
@@ -41,7 +41,7 @@ public class RestJWTTest extends ParameterizedTest {
 	 * Base request of a JWT token with wrong credentials (RSA8g RSA8c)
 	 */
 	@Test
-	public void authjwtrequestwrongkeys() {
+	public void auth_jwt_request_wrong_keys() {
 		try {
 			ClientOptions options = buildClientOptions(invalidKeys);
 			AblyRest client = new AblyRest(options);
@@ -57,7 +57,7 @@ public class RestJWTTest extends ParameterizedTest {
 	 * Request of a JWT token that embeds and Ably token (RSC1 RSC1a RSC1c RSA3d)
 	 */
 	@Test
-	public void authjwtrequestembeddedtoken() {
+	public void auth_jwt_request_embedded_token() {
 		try {
 			ClientOptions options = buildClientOptions(mergeParams(validKeys, tokenEmbedded));
 			AblyRest client = new AblyRest(options);
@@ -65,7 +65,7 @@ public class RestJWTTest extends ParameterizedTest {
 			assertNotNull("Stats should not be null", stats);
 		} catch (AblyException e) {
 			e.printStackTrace();
-			fail("authjwtrequestembeddedtoken: Unexpected exception");
+			fail("auth_jwt_request_embedded_token: Unexpected exception");
 		}
 	}
 
@@ -73,7 +73,7 @@ public class RestJWTTest extends ParameterizedTest {
 	 * Request of a JWT token that embeds and Ably token and is encrypted (RSC1 RSC1a RSC1c RSA3d)
 	 */
 	@Test
-	public void authjwtrequestembeddedtokenencrypted() {
+	public void auth_jwt_request_embedded_token_encrypted() {
 		try {
 			ClientOptions options = buildClientOptions(mergeParams(validKeys, tokenEmbeddedAndEncrypted));
 			AblyRest client = new AblyRest(options);
@@ -81,7 +81,7 @@ public class RestJWTTest extends ParameterizedTest {
 			assertNotNull("Stats should not be null", stats);
 		} catch (AblyException e) {
 			e.printStackTrace();
-			fail("authjwtrequestembeddedtokenencrypted: Unexpected exception");
+			fail("auth_jwt_request_embedded_token_encrypted: Unexpected exception");
 		}
 	}
 
@@ -89,7 +89,7 @@ public class RestJWTTest extends ParameterizedTest {
 	 * Request of a JWT token that is returned with application/jwt content type (RSA4f, RSA8c)
 	 */
 	@Test
-	public void authjwtrequestreturntype() {
+	public void auth_jwt_request_returntype() {
 		try {
 			ClientOptions options = buildClientOptions(mergeParams(validKeys, jwtReturnType));
 			AblyRest client = new AblyRest(options);
@@ -97,7 +97,7 @@ public class RestJWTTest extends ParameterizedTest {
 			assertNotNull("Stats should not be null", stats);
 		} catch (AblyException e) {
 			e.printStackTrace();
-			fail("authjwtrequestreturntype: Unexpected exception");
+			fail("auth_jwt_request_returntype: Unexpected exception");
 		}
 	}
 
@@ -105,7 +105,7 @@ public class RestJWTTest extends ParameterizedTest {
 	 * Request of a JWT token via authCallback (RSA8g)
 	 */
 	@Test
-	public void authjwtrequestauthcallback() {
+	public void auth_jwt_request_authcallback() {
 		try {
 			restJWTRequester = new AblyRest(createOptions(testVars.keys[0].keyStr));
 			TokenCallback authCallback = new TokenCallback() {
@@ -121,7 +121,7 @@ public class RestJWTTest extends ParameterizedTest {
 			assertNotNull("Stats should not be null", stats);
 		} catch (AblyException e) {
 			e.printStackTrace();
-			fail("authjwtrequestauthcallback: Unexpected exception");
+			fail("auth_jwt_request_authcallback: Unexpected exception");
 		}
 	}
 

--- a/lib/src/test/java/io/ably/lib/test/rest/RestJWTTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestJWTTest.java
@@ -1,0 +1,172 @@
+package io.ably.lib.test.rest;
+
+import static org.junit.Assert.*;
+
+import io.ably.lib.test.common.Setup.Key;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.ably.lib.rest.AblyRest;
+import io.ably.lib.types.*;
+import io.ably.lib.rest.Auth.*;
+import io.ably.lib.test.common.ParameterizedTest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RestJWTTest extends ParameterizedTest {
+
+	private static String echoServer = "https://ably-echoserver.herokuapp.com/createJWT"; // TODO: change this
+	private AblyRest restJWTRequester;
+	private ClientOptions jwtRequesterOptions;
+	private ClientOptions options;
+	private Key key = testVars.keys[0];
+	Param[] validKeys = new Param[]{ new Param("keyName", key.keyName), new Param("keySecret", key.keySecret) };
+	Param[] invalidKeys = new Param[]{ new Param("keyName", key.keyName), new Param("keySecret", "invalidinvalid") };
+	Param[] tokenEmbedded = new Param[]{ new Param("jwtType", "embedded") };
+	Param[] tokenEmbeddedAndEncrypted = new Param[]{ new Param("jwtType", "embedded"), new Param("encrypted", 1) };
+	Param[] jwtReturnType = new Param[]{ new Param("returnType", "jwt") };
+
+	@Before
+	public void setUpBefore() throws Exception {
+		jwtRequesterOptions = createOptions(testVars.keys[0].keyStr);
+		jwtRequesterOptions.authUrl = echoServer;
+		options = new ClientOptions();
+		options.environment = "sandbox";
+	}
+
+	/**
+	 * Base request of a JWT token
+	 */
+	@Test
+	public void authjwtrequest() {
+		try {
+			options.token = getTokenWithParams(validKeys);
+			AblyRest client = new AblyRest(options);
+			PaginatedResult<Stats> stats = client.stats(null);
+			assertNotNull("Stats should not be null", stats);
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("authjwtrequest: Unexpected exception");
+		}
+	}
+
+	/**
+	 * Base request of a JWT token with wrong credentials
+	 */
+	@Test
+	public void authjwtrequestwrongkeys() {
+		try {
+			options.token = getTokenWithParams(invalidKeys);
+			AblyRest client = new AblyRest(options);
+			PaginatedResult<Stats> stats = client.stats(null);
+		} catch (AblyException e) {
+			assertEquals("Unexpected code from exception", 40144, e.errorInfo.code);
+			assertEquals("Unexpected statusCode from exception", 401, e.errorInfo.statusCode);
+			assertEquals("Error message not matching the expected one", "Error verifying JWT; err = invalid signature", e.errorInfo.message);
+		}
+	}
+
+	/**
+	 * Request of a JWT token that embeds and Ably token
+	 */
+	@Test
+	public void authjwtrequestembeddedtoken() {
+		try {
+			options.token = getTokenWithParams(mergeParams(validKeys, tokenEmbedded));
+			AblyRest client = new AblyRest(options);
+			PaginatedResult<Stats> stats = client.stats(null);
+			assertNotNull("Stats should not be null", stats);
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("authjwtrequestembeddedtoken: Unexpected exception");
+		}
+	}
+
+	/**
+	 * Request of a JWT token that embeds and Ably token and is encrypted
+	 */
+	@Test
+	public void authjwtrequestembeddedtokenencrypted() {
+		try {
+			options.token = getTokenWithParams(mergeParams(validKeys, tokenEmbeddedAndEncrypted));
+			AblyRest client = new AblyRest(options);
+			PaginatedResult<Stats> stats = client.stats(null);
+			assertNotNull("Stats should not be null", stats);
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("authjwtrequestembeddedtokenencrypted: Unexpected exception");
+		}
+	}
+
+	/**
+	 * Request of a JWT token that is returned with application/jwt content type
+	 */
+	@Test
+	public void authjwtrequestreturntype() {
+		try {
+			options.token = getTokenWithParams(mergeParams(validKeys, jwtReturnType));
+			AblyRest client = new AblyRest(options);
+			PaginatedResult<Stats> stats = client.stats(null);
+			assertNotNull("Stats should not be null", stats);
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("authjwtrequestreturntype: Unexpected exception");
+		}
+	}
+
+	/**
+	 * Request of a JWT token via authCallback
+	 */
+	@Test
+	public void authjwtrequestauthcallback() {
+		try {
+			restJWTRequester = new AblyRest(createOptions(testVars.keys[0].keyStr));
+			TokenCallback authCallback = new TokenCallback() {
+				@Override
+				public Object getTokenRequest(TokenParams params) throws AblyException {
+					return restJWTRequester.auth.createTokenRequest(params, null);
+				}
+			};
+			ClientOptions optionsWithCallback = new ClientOptions();
+			optionsWithCallback.authCallback = authCallback;
+			optionsWithCallback.environment = "sandbox";
+			AblyRest client = new AblyRest(optionsWithCallback);
+			PaginatedResult<Stats> stats = client.stats(null);
+			assertNotNull("Stats should not be null", stats);
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("authjwtrequestauthcallback: Unexpected exception");
+		}
+	}
+
+	/**
+	 * Helper to fetch a token with params via authUrl
+	 */
+	private String getTokenWithParams(Param[] params) {
+		jwtRequesterOptions.authParams = params;
+		try {
+			restJWTRequester = new AblyRest(jwtRequesterOptions);
+			TokenDetails tokenDetails = restJWTRequester.auth.requestToken(null, null);
+			return tokenDetails.token;
+		} catch (AblyException e) {
+			fail("Failure in fetching a JWT token" + e);
+			return null;
+		}
+	}
+
+	/**
+	 * Helper method to merge auth parameters
+	 */
+	private static Param[] mergeParams(Param[] target, Param[] src) {
+		Map<String, Param> merged = new HashMap<String, Param>();
+		if(target != null) {
+			for(Param param : target) { merged.put(param.key, param); }
+		}
+		if(src != null) {
+			for(Param param : src) { merged.put(param.key, param); }
+		}
+		return merged.values().toArray(new Param[merged.size()]);
+	}
+
+}

--- a/lib/src/test/java/io/ably/lib/test/rest/RestJWTTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestJWTTest.java
@@ -16,7 +16,6 @@ import java.util.Map;
 
 public class RestJWTTest extends ParameterizedTest {
 
-	private static String echoServer = "https://ably-echoserver.herokuapp.com/createJWT"; // TODO: change this
 	private AblyRest restJWTRequester;
 	private ClientOptions jwtRequesterOptions;
 	private ClientOptions options;
@@ -153,20 +152,6 @@ public class RestJWTTest extends ParameterizedTest {
 			fail("Failure in fetching a JWT token" + e);
 			return null;
 		}
-	}
-
-	/**
-	 * Helper method to merge auth parameters
-	 */
-	private static Param[] mergeParams(Param[] target, Param[] src) {
-		Map<String, Param> merged = new HashMap<String, Param>();
-		if(target != null) {
-			for(Param param : target) { merged.put(param.key, param); }
-		}
-		if(src != null) {
-			for(Param param : src) { merged.put(param.key, param); }
-		}
-		return merged.values().toArray(new Param[merged.size()]);
 	}
 
 }

--- a/lib/src/test/java/io/ably/lib/test/rest/RestJWTTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestJWTTest.java
@@ -113,7 +113,7 @@ public class RestJWTTest extends ParameterizedTest {
 			TokenCallback authCallback = new TokenCallback() {
 				@Override
 				public Object getTokenRequest(TokenParams params) throws AblyException {
-					return restJWTRequester.auth.createTokenRequest(params, null);
+					return restJWTRequester.auth.requestToken(params, null);
 				}
 			};
 			ClientOptions optionsWithCallback = createOptions();

--- a/lib/src/test/java/io/ably/lib/test/rest/RestJWTTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestJWTTest.java
@@ -30,8 +30,7 @@ public class RestJWTTest extends ParameterizedTest {
 	public void setUpBefore() throws Exception {
 		jwtRequesterOptions = createOptions(testVars.keys[0].keyStr);
 		jwtRequesterOptions.authUrl = echoServer;
-		options = new ClientOptions();
-		options.environment = "sandbox";
+		options = createOptions();
 	}
 
 	/**
@@ -127,9 +126,8 @@ public class RestJWTTest extends ParameterizedTest {
 					return restJWTRequester.auth.createTokenRequest(params, null);
 				}
 			};
-			ClientOptions optionsWithCallback = new ClientOptions();
+			ClientOptions optionsWithCallback = createOptions();
 			optionsWithCallback.authCallback = authCallback;
-			optionsWithCallback.environment = "sandbox";
 			AblyRest client = new AblyRest(optionsWithCallback);
 			PaginatedResult<Stats> stats = client.stats(null);
 			assertNotNull("Stats should not be null", stats);

--- a/lib/src/test/java/io/ably/lib/test/rest/RestJWTTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestJWTTest.java
@@ -35,7 +35,7 @@ public class RestJWTTest extends ParameterizedTest {
 	}
 
 	/**
-	 * Base request of a JWT token
+	 * Base request of a JWT token (RSA8g RSA8c)
 	 */
 	@Test
 	public void authjwtrequest() {
@@ -51,7 +51,7 @@ public class RestJWTTest extends ParameterizedTest {
 	}
 
 	/**
-	 * Base request of a JWT token with wrong credentials
+	 * Base request of a JWT token with wrong credentials (RSA8g RSA8c)
 	 */
 	@Test
 	public void authjwtrequestwrongkeys() {
@@ -67,7 +67,7 @@ public class RestJWTTest extends ParameterizedTest {
 	}
 
 	/**
-	 * Request of a JWT token that embeds and Ably token
+	 * Request of a JWT token that embeds and Ably token (RSC1 RSC1a RSC1c RSA3d)
 	 */
 	@Test
 	public void authjwtrequestembeddedtoken() {
@@ -83,7 +83,7 @@ public class RestJWTTest extends ParameterizedTest {
 	}
 
 	/**
-	 * Request of a JWT token that embeds and Ably token and is encrypted
+	 * Request of a JWT token that embeds and Ably token and is encrypted (RSC1 RSC1a RSC1c RSA3d)
 	 */
 	@Test
 	public void authjwtrequestembeddedtokenencrypted() {
@@ -99,7 +99,7 @@ public class RestJWTTest extends ParameterizedTest {
 	}
 
 	/**
-	 * Request of a JWT token that is returned with application/jwt content type
+	 * Request of a JWT token that is returned with application/jwt content type (RSA4f, RSA8c)
 	 */
 	@Test
 	public void authjwtrequestreturntype() {
@@ -115,7 +115,7 @@ public class RestJWTTest extends ParameterizedTest {
 	}
 
 	/**
-	 * Request of a JWT token via authCallback
+	 * Request of a JWT token via authCallback (RSA8g)
 	 */
 	@Test
 	public void authjwtrequestauthcallback() {

--- a/lib/src/test/java/io/ably/lib/test/rest/RestJWTTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestJWTTest.java
@@ -110,9 +110,11 @@ public class RestJWTTest extends ParameterizedTest {
 	public void auth_jwt_request_authcallback() {
 		try {
 			restJWTRequester = new AblyRest(createOptions(testVars.keys[0].keyStr));
+			final boolean[] callbackCalled = new boolean[] { false };
 			TokenCallback authCallback = new TokenCallback() {
 				@Override
 				public Object getTokenRequest(TokenParams params) throws AblyException {
+					callbackCalled[0] = true;
 					return restJWTRequester.auth.requestToken(params, null);
 				}
 			};
@@ -121,6 +123,7 @@ public class RestJWTTest extends ParameterizedTest {
 			AblyRest client = new AblyRest(optionsWithCallback);
 			PaginatedResult<Stats> stats = client.stats(null);
 			assertNotNull("Stats should not be null", stats);
+			assertTrue("Callback was not called", callbackCalled[0]);
 		} catch (AblyException e) {
 			e.printStackTrace();
 			fail("auth_jwt_request_authcallback: Unexpected exception");

--- a/lib/src/test/java/io/ably/lib/test/rest/RestJWTTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestJWTTest.java
@@ -91,7 +91,9 @@ public class RestJWTTest extends ParameterizedTest {
 	@Test
 	public void auth_jwt_request_returntype() {
 		try {
-			ClientOptions options = buildClientOptions(mergeParams(validKeys, jwtReturnType));
+			ClientOptions options = createOptions();
+			options.authUrl = echoServer;
+			options.authParams = mergeParams(validKeys, jwtReturnType);
 			AblyRest client = new AblyRest(options);
 			PaginatedResult<Stats> stats = client.stats(null);
 			assertNotNull("Stats should not be null", stats);

--- a/lib/src/test/java/io/ably/lib/test/rest/RestSuite.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestSuite.java
@@ -22,6 +22,7 @@ import io.ably.lib.test.common.Setup;
 	RestAuthTest.class,
 	RestAuthAttributeTest.class,
 	RestTokenTest.class,
+	RestJWTTest.class,
 	RestCapabilityTest.class,
 	RestChannelTest.class,
 	RestChannelHistoryTest.class,


### PR DESCRIPTION
Fix #384 

- [X] Add tests that use `ClientOptions`
- [X] Add tests that use `authURL`
- [X] Add tests that use `authCallback`
- [X] Add tests with JWT wrapping an Ably native token `x-ably-token`
- [X] Add tests with encrypted token
- [X] Add example when token is returned with `application/jwt` Content-Type
- [X] Add tests with JWT that includes client_id
- [X] Add tests with JWT that includes publish/subscribe capabilities
- [X] Add tests for automatic reauth with and without disconnection
- [X] Add refs to spec items
