### PR TITLE
 RSC15f: implement fallback affinity

### DIFF
--- a/lib/src/main/java/io/ably/lib/http/HttpCore.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpCore.java
@@ -95,8 +95,8 @@ public class HttpCore {
 	 *
 	 * @param host URL string
 	 */
-	public void setHost(String host) {
-		hosts.setHost(host);
+	public void setPreferredHost(String host) {
+		hosts.setPreferredHost(host, false);
 	}
 
 	/**
@@ -104,8 +104,17 @@ public class HttpCore {
 	 *
 	 * @return
      */
-	public String getHost() {
-		return hosts.getHost();
+	public String getPreferredHost() {
+		return hosts.getPreferredHost();
+	}
+
+	/**
+	 * Gets host for this HTTP client
+	 *
+	 * @return
+	 */
+	public String getPrimaryHost() {
+		return hosts.getPrimaryHost();
 	}
 
 	/**************************

--- a/lib/src/main/java/io/ably/lib/http/HttpScheduler.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpScheduler.java
@@ -192,13 +192,14 @@ public class HttpScheduler<Executor extends java.util.concurrent.Executor> {
         }
         @Override
         public void run() {
-            String candidateHost = httpCore.getHost();
-            int retryCountRemaining = httpCore.hosts.getFallback(candidateHost) != null ? httpCore.options.httpMaxRetryCount : 0;
+            String candidateHost = httpCore.hosts.getPreferredHost();
+            int retryCountRemaining = (httpCore.hosts.fallbackHostsRemaining(candidateHost) > 0) ? httpCore.options.httpMaxRetryCount : 0;
 
             while(!isCancelled) {
                 try {
                     result = httpExecuteWithRetry(candidateHost, path, requireAblyAuth);
                     setResult(result);
+                    httpCore.hosts.setPreferredHost(candidateHost, true);
                     break;
                 } catch (AblyException.HostFailedException e) {
                     if(--retryCountRemaining < 0) {

--- a/lib/src/main/java/io/ably/lib/rest/AblyRest.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyRest.java
@@ -33,7 +33,7 @@ import io.ably.lib.util.Serialisation;
  *
  */
 public class AblyRest {
-	
+
 	public final ClientOptions options;
 	final String clientId;
 	public final Http http;

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -540,9 +540,9 @@ public class ConnectionManager implements ConnectListener {
 		 *    back), set http to the same as realtime.
 		 */
 		if (pendingConnect.host == options.realtimeHost) {
-			ably.httpCore.setHost(options.restHost);
+			ably.httpCore.setPreferredHost(options.restHost);
 		} else {
-			ably.httpCore.setHost(pendingConnect.host);
+			ably.httpCore.setPreferredHost(pendingConnect.host);
 		}
 
 		/* if the returned connection id differs from
@@ -964,8 +964,9 @@ public class ConnectionManager implements ConnectListener {
 		 * checkSuspend has already chosen a fallback host at random */
 
 		String host = request.fallback;
-		if (host == null)
-			host = hosts.getHost();
+		if (host == null) {
+			host = hosts.getPreferredHost();
+		}
 		checkConnectionStale();
 		pendingConnect = new ConnectParams(options);
 		pendingConnect.host = host;

--- a/lib/src/main/java/io/ably/lib/transport/Defaults.java
+++ b/lib/src/main/java/io/ably/lib/transport/Defaults.java
@@ -34,6 +34,8 @@ public class Defaults {
 	public static int TIMEOUT_HTTP_REQUEST = 15000;
 	/* DF1b */
 	public static long realtimeRequestTimeout = 10000L;
+	/* TO3l10 */
+	public static long fallbackRetryTimeout = 10*60*1000L;
 	/* CD2h (but no default in the spec) */
 	public static long maxIdleInterval = 20000L;
 	/* DF1a */

--- a/lib/src/main/java/io/ably/lib/types/ClientOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ClientOptions.java
@@ -158,6 +158,10 @@ public class ClientOptions extends AuthOptions {
 	public boolean fallbackHostsUseDefault;
 
 	/**
+	 * Spec: TO3l10
+	 */
+	public long fallbackRetryTimeout = Defaults.fallbackRetryTimeout;
+	/**
 	 * When a TokenParams object is provided, it will override
 	 * the client library defaults described in TokenParams
 	 * Spec: TO3j11

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeInitTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeInitTest.java
@@ -77,7 +77,7 @@ public class RealtimeInitTest extends ParameterizedTest {
 			String hostExpected = "some.other.host";
 			opts.restHost = hostExpected;
 			ably = new AblyRealtime(opts);
-			assertEquals("Unexpected host mismatch", hostExpected, ably.httpCore.getHost());
+			assertEquals("Unexpected host mismatch", hostExpected, ably.httpCore.getPrimaryHost());
 		} catch (AblyException e) {
 			e.printStackTrace();
 			fail("init4: Unexpected exception instantiating library");

--- a/lib/src/test/java/io/ably/lib/test/rest/HttpTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/HttpTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import io.ably.lib.http.*;
 import io.ably.lib.test.util.TimeHandler;
 import io.ably.lib.types.*;
 import io.ably.lib.util.Log;
@@ -41,9 +42,6 @@ import org.mockito.stubbing.Answer;
 
 import fi.iki.elonen.NanoHTTPD;
 import fi.iki.elonen.router.RouterNanoHTTPD;
-import io.ably.lib.http.HttpConstants;
-import io.ably.lib.http.HttpCore;
-import io.ably.lib.http.HttpHelpers;
 import io.ably.lib.rest.AblyRest;
 import io.ably.lib.test.util.StatusHandler;
 import io.ably.lib.transport.Defaults;
@@ -138,9 +136,10 @@ public class HttpTest {
 			}
 		}.setUrlArgumentStack(urlHostArgumentStack);
 
+		Http http = new Http(new AsyncHttpScheduler(httpCore, options), new SyncHttpScheduler(httpCore));
 		try {
 			HttpHelpers.ablyHttpExecute(
-					httpCore, "/path/to/fallback", /* Ignore path */
+					http, "/path/to/fallback", /* Ignore path */
 					HttpConstants.Methods.GET, /* Ignore method */
 					new Param[0], /* Ignore headers */
 					new Param[0], /* Ignore params */
@@ -198,9 +197,10 @@ public class HttpTest {
 			}
 		}.setUrlArgumentStack(urlHostArgumentStack);
 
+		Http http = new Http(new AsyncHttpScheduler(httpCore, options), new SyncHttpScheduler(httpCore));
 		try {
 			HttpHelpers.ablyHttpExecute(
-					httpCore, "/path/to/fallback", /* Ignore path */
+					http, "/path/to/fallback", /* Ignore path */
 					HttpConstants.Methods.GET, /* Ignore method */
 					new Param[0], /* Ignore headers */
 					new Param[0], /* Ignore params */
@@ -266,8 +266,9 @@ public class HttpTest {
 						any(HttpCore.ResponseHandler.class) /* Ignore */
 				);
 
+		Http http = new Http(new AsyncHttpScheduler(httpCore, options), new SyncHttpScheduler(httpCore));
 		String responseActual = (String) HttpHelpers.ablyHttpExecute(
-				httpCore, "", /* Ignore */
+				http, "", /* Ignore */
 				"", /* Ignore */
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
@@ -286,7 +287,7 @@ public class HttpTest {
 		} catch(InterruptedException ie) {}
 
 		String responseActual2 = (String) HttpHelpers.ablyHttpExecute(
-				httpCore, "", /* Ignore */
+				http, "", /* Ignore */
 				"", /* Ignore */
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
@@ -354,9 +355,10 @@ public class HttpTest {
 						any(HttpCore.ResponseHandler.class) /* Ignore */
 				);
 
+		Http http = new Http(new AsyncHttpScheduler(httpCore, options), new SyncHttpScheduler(httpCore));
 		try {
 			HttpHelpers.ablyHttpExecute(
-					httpCore, "", /* Ignore */
+					http, "", /* Ignore */
 					"", /* Ignore */
 					new Param[0], /* Ignore */
 					new Param[0], /* Ignore */
@@ -376,7 +378,7 @@ public class HttpTest {
 
 		try {
 			HttpHelpers.ablyHttpExecute(
-					httpCore, "", /* Ignore */
+					http, "", /* Ignore */
 					"", /* Ignore */
 					new Param[0], /* Ignore */
 					new Param[0], /* Ignore */
@@ -449,9 +451,10 @@ public class HttpTest {
 						any(HttpCore.ResponseHandler.class) /* Ignore */
 				);
 
+		Http http = new Http(new AsyncHttpScheduler(httpCore, options), new SyncHttpScheduler(httpCore));
 		try {
 			HttpHelpers.ablyHttpExecute(
-					httpCore, "", /* Ignore */
+					http, "", /* Ignore */
 					"", /* Ignore */
 					new Param[0], /* Ignore */
 					new Param[0], /* Ignore */
@@ -528,8 +531,9 @@ public class HttpTest {
 						any(HttpCore.ResponseHandler.class) /* Ignore */
 				);
 
+		Http http = new Http(new AsyncHttpScheduler(httpCore, options), new SyncHttpScheduler(httpCore));
 		String responseActual = (String) HttpHelpers.ablyHttpExecute(
-				httpCore, "", /* Ignore */
+				http, "", /* Ignore */
 				"", /* Ignore */
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
@@ -596,9 +600,10 @@ public class HttpTest {
 			}
 		}.setUrlArgumentStack(urlHostArgumentStack);
 
+		Http http = new Http(new AsyncHttpScheduler(httpCore, options), new SyncHttpScheduler(httpCore));
 		try {
 			HttpHelpers.ablyHttpExecute(
-					httpCore, "/path/to/fallback", /* Ignore path */
+					http, "/path/to/fallback", /* Ignore path */
 					HttpConstants.Methods.GET, /* Ignore method */
 					new Param[0], /* Ignore headers */
 					new Param[0], /* Ignore params */
@@ -656,8 +661,9 @@ public class HttpTest {
 						any(HttpCore.ResponseHandler.class) /* Ignore */
 				);
 
+		Http http = new Http(new AsyncHttpScheduler(httpCore, new ClientOptions()), new SyncHttpScheduler(httpCore));
 		String responseActual = (String) HttpHelpers.ablyHttpExecute(
-				httpCore, "", /* Ignore */
+				http, "", /* Ignore */
 				"", /* Ignore */
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
@@ -725,8 +731,9 @@ public class HttpTest {
 				);
 
         /* Call method with real parameters */
+		Http http = new Http(new AsyncHttpScheduler(httpCore, new ClientOptions()), new SyncHttpScheduler(httpCore));
 		String responseActual = (String) HttpHelpers.ablyHttpExecute(
-				httpCore, "", /* Ignore */
+				http, "", /* Ignore */
 				"", /* Ignore */
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
@@ -794,8 +801,9 @@ public class HttpTest {
 						any(HttpCore.ResponseHandler.class) /* Ignore */
 				);
 
+		Http http = new Http(new AsyncHttpScheduler(httpCore, new ClientOptions()), new SyncHttpScheduler(httpCore));
 		String responseActual = (String) HttpHelpers.ablyHttpExecute(
-				httpCore, "", /* Ignore */
+				http, "", /* Ignore */
 				"", /* Ignore */
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
@@ -873,8 +881,9 @@ public class HttpTest {
 						any(HttpCore.ResponseHandler.class) /* Ignore */
 				);
 
+		Http http = new Http(new AsyncHttpScheduler(httpCore, new ClientOptions()), new SyncHttpScheduler(httpCore));
 		HttpHelpers.ablyHttpExecute(
-				httpCore, "", /* Ignore */
+				http, "", /* Ignore */
 				"", /* Ignore */
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
@@ -905,7 +914,7 @@ public class HttpTest {
 				);
 
 		HttpHelpers.ablyHttpExecute(
-				httpCore, "", /* Ignore */
+				http, "", /* Ignore */
 				"", /* Ignore */
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
@@ -959,8 +968,9 @@ public class HttpTest {
 						any(HttpCore.ResponseHandler.class) /* Ignore */
 				);
 
+		Http http = new Http(new AsyncHttpScheduler(httpCore, new ClientOptions()), new SyncHttpScheduler(httpCore));
 		HttpHelpers.ablyHttpExecute(
-				httpCore, "", /* Ignore */
+				http, "", /* Ignore */
 				"", /* Ignore */
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
@@ -996,7 +1006,7 @@ public class HttpTest {
 				);
 
 		HttpHelpers.ablyHttpExecute(
-				httpCore, "", /* Ignore */
+				http, "", /* Ignore */
 				"", /* Ignore */
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
@@ -1049,8 +1059,9 @@ public class HttpTest {
 						any(HttpCore.ResponseHandler.class) /* Ignore */
 				);
 
+		Http http = new Http(new AsyncHttpScheduler(httpCore, new ClientOptions()), new SyncHttpScheduler(httpCore));
 		HttpHelpers.ablyHttpExecute(
-				httpCore, "", /* Ignore */
+				http, "", /* Ignore */
 				"", /* Ignore */
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
@@ -1080,7 +1091,7 @@ public class HttpTest {
 				);
 
 		HttpHelpers.ablyHttpExecute(
-				httpCore, "", /* Ignore */
+				http, "", /* Ignore */
 				"", /* Ignore */
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */
@@ -1138,8 +1149,9 @@ public class HttpTest {
          */
 		thrown.expect(AblyException.HostFailedException.class);
 
+		Http http = new Http(new AsyncHttpScheduler(httpCore, new ClientOptions()), new SyncHttpScheduler(httpCore));
 		HttpHelpers.ablyHttpExecute(
-				httpCore, "", /* Ignore */
+				http, "", /* Ignore */
 				"", /* Ignore */
 				new Param[0], /* Ignore */
 				new Param[0], /* Ignore */

--- a/lib/src/test/java/io/ably/lib/test/rest/RestInitTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestInitTest.java
@@ -280,7 +280,7 @@ public class RestInitTest {
 			ClientOptions opts = new ClientOptions(testVars.keys[0].keyStr);
 			opts.environment = "production";
 			AblyRest ably = new AblyRest(opts);
-			assertEquals("Unexpected host mismatch", Defaults.HOST_REST, ably.httpCore.getHost());
+			assertEquals("Unexpected host mismatch", Defaults.HOST_REST, ably.httpCore.getPrimaryHost());
 		} catch (AblyException e) {
 			e.printStackTrace();
 			fail("init4: Unexpected exception instantiating library");
@@ -299,7 +299,7 @@ public class RestInitTest {
 			ClientOptions opts = new ClientOptions(testVars.keys[0].keyStr);
 			opts.environment = givenEnvironment;
 			AblyRest ably = new AblyRest(opts);
-			assertEquals("Unexpected host mismatch", String.format("%s-%s", givenEnvironment, Defaults.HOST_REST), ably.httpCore.getHost());
+			assertEquals("Unexpected host mismatch", String.format("%s-%s", givenEnvironment, Defaults.HOST_REST), ably.httpCore.getPrimaryHost());
 		} catch (AblyException e) {
 			e.printStackTrace();
 			fail("init4: Unexpected exception instantiating library");


### PR DESCRIPTION
This PR implements temporary affinity to a fallback host for REST operations, as specified in https://docs.ably.io/client-lib-development-guide/features/#RSC15f:

> (RSC15f) Once/if a given fallback host succeeds, the client should store that successful fallback host for ClientOptions.fallbackRetryTimeout. Future HTTP requests during that period should use that host. If during this period a [qualifying errors](https://docs.ably.io/client-lib-development-guide/features/#RSC15d) occurs on that host, or after `fallbackRetryTimeout` has expired, it should be unstored, and the fallback sequence begun again from scratch, starting with the default primary host (`rest.ably.io` or `ClientOptions#restHost`)

Affinity to a successful fallback host is for 10 minutes by default, but is configurable via the `fallbackRetryTimeout` client option as specified in https://docs.ably.io/client-lib-development-guide/features/#TO3l10.