### PR TITLE
Add support for ErrorInfo.href (TI4/TI5)

### DIFF
--- a/lib/src/main/java/io/ably/lib/http/HttpCore.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpCore.java
@@ -328,11 +328,10 @@ public class HttpCore {
 				}
 			}
 			if(error == null) {
-				Log.e(TAG, "Error response from server: statusCode = " + response.statusCode + "; statusLine = " + response.statusLine);
 				error = ErrorInfo.fromResponseStatus(response.statusLine, response.statusCode);
 			} else {
-				Log.e(TAG, "Error response from server: " + error);
 			}
+			Log.e(TAG, "Error response from server: err = " + error.toString());
 			if(responseHandler != null) {
 				return responseHandler.handleResponse(response, error);
 			}

--- a/lib/src/test/java/io/ably/lib/test/rest/RestErrorTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestErrorTest.java
@@ -1,0 +1,163 @@
+package io.ably.lib.test.rest;
+
+import fi.iki.elonen.NanoHTTPD;
+import io.ably.lib.rest.AblyRest;
+import io.ably.lib.test.common.ParameterizedTest;
+import io.ably.lib.types.*;
+import io.ably.lib.util.Log;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Vector;
+
+import static io.ably.lib.http.HttpUtils.encodeURIComponent;
+import static org.junit.Assert.*;
+
+public class RestErrorTest extends ParameterizedTest {
+
+	private static SessionHandlerNanoHTTPD server;
+
+	@BeforeClass
+	public static void setUp() throws IOException {
+		/* Create custom RouterNanoHTTPD class for getting session object */
+		server = new SessionHandlerNanoHTTPD(27331);
+		server.start(NanoHTTPD.SOCKET_READ_TIMEOUT, true);
+
+		/* wait for server to start */
+		while (!server.wasStarted()) {
+			try {
+				Thread.sleep(100);
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+
+	@AfterClass
+	public static void tearDown() {
+		server.stop();
+	}
+
+	/**
+	 * Verify an href is logged when included in an error.href
+	 * Spec: TI5
+	 */
+	@Test
+	public void errorHrefWhenPresentInHref() {
+		final Vector<String> logMessages = new Vector<String>();
+		try {
+			ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+			opts.environment = null;
+			opts.tls = false;
+			opts.port = server.getListeningPort();
+			opts.restHost = "localhost";
+			opts.logHandler = new Log.LogHandler() {
+				@Override
+				public void println(int severity, String tag, String msg, Throwable tr) {
+					logMessages.add(msg);
+				}
+			};
+			AblyRest ably = new AblyRest(opts);
+
+			/* make a call that will generate an error */
+			ably.stats(new Param[]{new Param("message", encodeURIComponent("Test message")), new Param("href", href(12345))});
+		} catch (AblyException e) {
+			/* verify that the expected error message is present */
+			assertTrue(logMessages.get(0).contains(href(12345)));
+		}
+	}
+
+	/**
+	 * Verify an href is logged when included in an error.message
+	 * Spec: TI5
+	 */
+	@Test
+	public void errorHrefWhenPresentInMessage() {
+		final Vector<String> logMessages = new Vector<String>();
+		try {
+			ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+			opts.environment = null;
+			opts.tls = false;
+			opts.port = server.getListeningPort();
+			opts.restHost = "localhost";
+			opts.logHandler = new Log.LogHandler() {
+				@Override
+				public void println(int severity, String tag, String msg, Throwable tr) {
+					logMessages.add(msg);
+				}
+			};
+			AblyRest ably = new AblyRest(opts);
+
+			/* make a call that will generate an error */
+			ably.stats(new Param[]{new Param("message", encodeURIComponent("Test message. See " + href(12345)))});
+		} catch (AblyException e) {
+			/* verify that the expected error message is present */
+			assertTrue(logMessages.get(0).contains(href(12345)));
+		}
+	}
+
+	/**
+	 * Verify an href is logged when derived from error.code
+	 * Spec: TI5
+	 */
+	@Test
+	public void errorHrefWhenCodePresent() {
+		final Vector<String> logMessages = new Vector<String>();
+		try {
+			ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+			opts.environment = null;
+			opts.tls = false;
+			opts.port = server.getListeningPort();
+			opts.restHost = "localhost";
+			opts.logHandler = new Log.LogHandler() {
+				@Override
+				public void println(int severity, String tag, String msg, Throwable tr) {
+					logMessages.add(msg);
+				}
+			};
+			AblyRest ably = new AblyRest(opts);
+
+			/* make a call that will generate an error */
+			ably.stats(new Param[]{new Param("message", encodeURIComponent("Test message")), new Param("code", "12345")});
+		} catch (AblyException e) {
+			/* verify that the expected error message is present */
+			assertTrue(logMessages.get(0).contains(href(12345)));
+		}
+	}
+
+	private static String href(int code) { return HREF_BASE + String.valueOf(code); }
+	private static final String HREF_BASE = "https://help.ably.io/error/";
+
+	private static class SessionHandlerNanoHTTPD extends NanoHTTPD {
+		Map<String, String> requestHeaders;
+		Map<String, String> requestParams;
+
+		public SessionHandlerNanoHTTPD(int port) {
+			super(port);
+		}
+
+		@Override
+		public Response serve(IHTTPSession session) {
+			requestHeaders = new HashMap<>(session.getHeaders());
+			requestParams = new HashMap<>(session.getParms());
+			String code = requestParams.get("code"),
+					href = requestParams.get("href"),
+					message = requestParams.get("message");
+
+			StringBuilder responseBody = new StringBuilder().append("{\"error\":{");
+			responseBody.append("\"message\":\"").append(message).append("\"");
+			if(code != null) {
+				responseBody.append(",\"code\":\"").append(code).append("\"");
+			}
+			if(href != null) {
+				responseBody.append(",\"href\":\"").append(href).append("\"");
+			}
+			responseBody.append("}}");
+			return newFixedLengthResponse(Response.Status.BAD_REQUEST, "application/json", responseBody.toString());
+		}
+	}
+}

--- a/lib/src/test/java/io/ably/lib/test/rest/RestSuite.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestSuite.java
@@ -29,7 +29,8 @@ import io.ably.lib.test.common.Setup;
 	RestChannelPublishTest.class,
 	RestCryptoTest.class,
 	RestPresenceTest.class,
-	RestProxyTest.class
+	RestProxyTest.class,
+	RestErrorTest.class
 })
 public class RestSuite {
 


### PR DESCRIPTION
This implements support for the `href` property of `ErrorInfo` (which conveys all errors either returned by the backend or raised in the library). The `href` property contains a link to reference/help documentation for the specific error condition indicated in the `ErrorInfo`.

The relevant requirement text is:

> [(TI4)](https://docs.ably.io/client-lib-development-guide/features/#TI4) Ably may additionally include a href attribute with a string value. This is included for REST responses to provide a URL for customers to find more help on the error code
[(TI5)](https://docs.ably.io/client-lib-development-guide/features/#TI5) Log entries generated from errors, where possible, should include a URL to help developers understand the error and resolve the issue. If the URL is not already present within the contents of the message attribute, then it should be included in the log entry as follows: “See [URL]”. If the href attribute is present, it should be used as the URL. If the href attribute is not present, and the code attribute is present, then the URL should be constructed as follows “https://help.ably.io/error/[CODE]”. If neither the href or code attributes are present, then an additional URL should not be included in the log entry.