### PR TITLE
Implement idempotent REST publishing

### DIFF
--- a/lib/src/main/java/io/ably/lib/debug/DebugOptions.java
+++ b/lib/src/main/java/io/ably/lib/debug/DebugOptions.java
@@ -18,8 +18,8 @@ public class DebugOptions extends ClientOptions {
 
 	public interface RawHttpListener {
 		public void onRawHttpRequest(String id, HttpURLConnection conn, String method, String authHeader, Map<String, List<String>> requestHeaders, HttpCore.RequestBody requestBody);
-		public void onRawHttpResponse(String id, HttpCore.Response response);
-		public void onRawHttpException(String id, Throwable t);
+		public void onRawHttpResponse(String id, String method, HttpCore.Response response);
+		public void onRawHttpException(String id, String method, Throwable t);
 	}
 
 	public DebugOptions(String key) throws AblyException { super(key); }

--- a/lib/src/main/java/io/ably/lib/http/HttpCore.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpCore.java
@@ -241,11 +241,12 @@ public class HttpCore {
 			}
 			response = readResponse(conn);
 			if(rawHttpListener != null) {
-				rawHttpListener.onRawHttpResponse(id, response);
+				rawHttpListener.onRawHttpResponse(id, method, response);
 			}
 		} catch(IOException ioe) {
+			ioe.printStackTrace();
 			if(rawHttpListener != null) {
-				rawHttpListener.onRawHttpException(id, ioe);
+				rawHttpListener.onRawHttpException(id, method, ioe);
 			}
 			throw AblyException.fromThrowable(ioe);
 		}

--- a/lib/src/main/java/io/ably/lib/transport/Defaults.java
+++ b/lib/src/main/java/io/ably/lib/transport/Defaults.java
@@ -3,9 +3,12 @@ package io.ably.lib.transport;
 import io.ably.lib.BuildConfig;
 import io.ably.lib.types.ClientOptions;
 
+import java.text.DecimalFormat;
+
 public class Defaults {
 	/* versions */
-	public static final String ABLY_VERSION         = "1.0";
+	public static final float ABLY_VERSION_NUMBER   = 1.0f;
+	public static final String ABLY_VERSION         = new DecimalFormat("0.0").format(ABLY_VERSION_NUMBER);
 	public static final String ABLY_LIB_VERSION     = String.format("%s-%s", BuildConfig.LIBRARY_NAME, BuildConfig.VERSION);
 
 	/* params */

--- a/lib/src/main/java/io/ably/lib/types/ClientOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ClientOptions.java
@@ -126,6 +126,11 @@ public class ClientOptions extends AuthOptions {
 	public String environment;
 
 	/**
+	 * Spec: TO3n
+	 */
+	public boolean idempotentRestPublishing = (Defaults.ABLY_VERSION_NUMBER >= 1.2);
+
+	/**
 	 * Spec: TO313
 	 */
 	public int httpOpenTimeout = Defaults.TIMEOUT_HTTP_OPEN;

--- a/lib/src/main/java/io/ably/lib/util/Crypto.java
+++ b/lib/src/main/java/io/ably/lib/util/Crypto.java
@@ -299,6 +299,12 @@ public class Crypto {
 		};
 	}
 
+	public static String getRandomMessageId() {
+		byte[] entropy = new byte[9];
+		secureRandom.nextBytes(entropy);
+		return Base64Coder.encode(entropy).toString();
+	}
+
 	/**
 	 * Determine whether or not 256-bit AES is supported. (If this determines that
 	 * it is not supported, install the JCE unlimited strength JCE extensions).

--- a/lib/src/test/java/io/ably/lib/test/common/Helpers.java
+++ b/lib/src/test/java/io/ably/lib/test/common/Helpers.java
@@ -725,7 +725,7 @@ public class Helpers {
 		}
 
 		@Override
-		public void onRawHttpResponse(String id, HttpCore.Response response) {
+		public void onRawHttpResponse(String id, String method, HttpCore.Response response) {
 			/* duplicating if necessary, ensure lower-case versions of header names are present */
 			Map<String, List<String>> headers = response.headers;
 			Map<String, List<String>> normalisedHeaders = new HashMap<String, List<String>>();
@@ -744,7 +744,7 @@ public class Helpers {
 		}
 
 		@Override
-		public void onRawHttpException(String id, Throwable t) {
+		public void onRawHttpException(String id, String method, Throwable t) {
 			RawHttpRequest req = get(id);
 			if(req != null) {
 				req.error = t;

--- a/lib/src/test/java/io/ably/lib/test/rest/RestAuthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestAuthTest.java
@@ -1390,10 +1390,10 @@ public class RestAuthTest extends ParameterizedTest {
 					}
 
 					@Override
-					public void onRawHttpResponse(String id, HttpCore.Response response) {}
+					public void onRawHttpResponse(String id, String method, HttpCore.Response response) {}
 
 					@Override
-					public void onRawHttpException(String id, Throwable t) {}
+					public void onRawHttpException(String id, String method, Throwable t) {}
 				};
 			}};
 			fillInOptions(options);
@@ -1457,10 +1457,10 @@ public class RestAuthTest extends ParameterizedTest {
 					}
 
 					@Override
-					public void onRawHttpResponse(String id, HttpCore.Response response) {}
+					public void onRawHttpResponse(String id, String method, HttpCore.Response response) {}
 
 					@Override
-					public void onRawHttpException(String id, Throwable t) {}
+					public void onRawHttpException(String id, String method, Throwable t) {}
 				};
 			}};
 			fillInOptions(options);

--- a/lib/src/test/java/io/ably/lib/test/rest/RestChannelPublishTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestChannelPublishTest.java
@@ -39,7 +39,7 @@ public class RestChannelPublishTest extends ParameterizedTest {
 	/**
 	 * Publish events with data of various datatypes using text protocol
 	 */
-	//@Test
+	@Test
 	public void channelpublish() {
 		/* first, publish some messages */
 		String channelName = "persisted:channelpublish_" + testParams.name;
@@ -74,7 +74,7 @@ public class RestChannelPublishTest extends ParameterizedTest {
 	/**
 	 * Publish events using the async publish API
 	 */
-	//@Test
+	@Test
 	public void channelpublish_async() {
 		/* first, publish some messages */
 		String channelName = "persisted:channelpublish_async_" + testParams.name;
@@ -297,7 +297,7 @@ public class RestChannelPublishTest extends ParameterizedTest {
 			opts.useBinaryProtocol = true;
 			opts.httpListener = requestListener;
 			/* generate a fallback which resolves to the same address, which the library will treat as a different host */
-			opts.fallbackHosts = new String[]{ablyForToken.httpCore.getHost().toUpperCase()};
+			opts.fallbackHosts = new String[]{ablyForToken.httpCore.getPrimaryHost().toUpperCase()};
 			AblyRest ably = new AblyRest(opts);
 
 			/* publish message */
@@ -405,7 +405,7 @@ public class RestChannelPublishTest extends ParameterizedTest {
 			opts.useBinaryProtocol = true;
 			opts.httpListener = requestListener;
 			/* generate a fallback which resolves to the same address, which the library will treat as a different host */
-			opts.fallbackHosts = new String[]{ablyForToken.httpCore.getHost().toUpperCase()};
+			opts.fallbackHosts = new String[]{ablyForToken.httpCore.getPrimaryHost().toUpperCase()};
 			AblyRest ably = new AblyRest(opts);
 
 			/* publish message */

--- a/lib/src/test/java/io/ably/lib/test/rest/RestChannelPublishTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestChannelPublishTest.java
@@ -3,11 +3,20 @@ package io.ably.lib.test.rest;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.net.HttpURLConnection;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+import io.ably.lib.debug.DebugOptions;
+import io.ably.lib.http.HttpCore;
+import io.ably.lib.rest.Auth;
+import io.ably.lib.types.*;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -16,12 +25,6 @@ import io.ably.lib.rest.Channel;
 import io.ably.lib.test.common.Helpers.AsyncWaiter;
 import io.ably.lib.test.common.Helpers.CompletionSet;
 import io.ably.lib.test.common.ParameterizedTest;
-import io.ably.lib.types.AblyException;
-import io.ably.lib.types.AsyncPaginatedResult;
-import io.ably.lib.types.ClientOptions;
-import io.ably.lib.types.ErrorInfo;
-import io.ably.lib.types.Message;
-import io.ably.lib.types.PaginatedResult;
 
 public class RestChannelPublishTest extends ParameterizedTest {
 
@@ -36,7 +39,7 @@ public class RestChannelPublishTest extends ParameterizedTest {
 	/**
 	 * Publish events with data of various datatypes using text protocol
 	 */
-	@Test
+	//@Test
 	public void channelpublish() {
 		/* first, publish some messages */
 		String channelName = "persisted:channelpublish_" + testParams.name;
@@ -71,7 +74,7 @@ public class RestChannelPublishTest extends ParameterizedTest {
 	/**
 	 * Publish events using the async publish API
 	 */
-	@Test
+	//@Test
 	public void channelpublish_async() {
 		/* first, publish some messages */
 		String channelName = "persisted:channelpublish_async_" + testParams.name;
@@ -109,4 +112,317 @@ public class RestChannelPublishTest extends ParameterizedTest {
 		assertEquals("Expect pub_text to be expected String", messageContents.get("pub_text"), textPayload);
 		assertThat("Expect pub_binary to be expected byte[]", (byte[])messageContents.get("pub_binary"), equalTo(binaryPayload));
 	}
+
+	/**
+	 * Verify processing of a client-supplied message id
+	 */
+	@Test
+	public void channel_idempotent_publish_client_generated_single() {
+
+		String channelName = "persisted:channel_idempotent_publish_client_generated_single_" + testParams.name;
+		Channel pubChannel;
+		final Message messageWithId = new Message("name_withId", "data_withId");
+		messageWithId.id = "client_generated_id";
+		try {
+			DebugOptions opts = new DebugOptions(testVars.keys[0].keyStr);
+			fillInOptions(opts);
+			opts.useBinaryProtocol = true;
+			opts.httpListener = new DebugOptions.RawHttpListener() {
+				@Override
+				public void onRawHttpRequest(String id, HttpURLConnection conn, String method, String authHeader, Map<String, List<String>> requestHeaders, HttpCore.RequestBody requestBody) {
+					/* verify request body contains the supplied ids */
+					try {
+						if(method.equalsIgnoreCase("POST")) {
+							Message[] requestedMessages = MessageSerializer.readMsgpack(requestBody.getEncoded());
+							assertEquals(requestedMessages[0].id, messageWithId.id);
+						}
+					} catch (AblyException e) {
+						e.printStackTrace();
+					}
+				}
+
+				@Override
+				public void onRawHttpResponse(String id, String method, HttpCore.Response response) {}
+
+				@Override
+				public void onRawHttpException(String id, String method, Throwable t) {}
+			};
+			AblyRest ably = new AblyRest(opts);
+
+			/* first, publish messages */
+			pubChannel = ably.channels.get(channelName);
+			pubChannel.publish(new Message[]{messageWithId});
+		} catch(AblyException e) {
+			e.printStackTrace();
+			fail("channel_idempotent_publish_client_generated_single: Unexpected exception");
+			return;
+		}
+
+		/* get the history for this channel */
+		try {
+            PaginatedResult<Message> messages = pubChannel.history(new Param[]{new Param("direction", "forwards")});
+			assertNotNull("Expected non-null messages", messages);
+			assertEquals("Expected 1 message", messages.items().length, 1);
+			assertEquals(messages.items()[0].id, messageWithId.id);
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("channel_idempotent_publish_client_generated_single: Unexpected exception");
+			return;
+		}
+	}
+
+	/**
+	 * Verify processing of a client-supplied message id
+	 */
+	@Test
+	public void channel_idempotent_publish_client_generated_multiple() {
+
+		String channelName = "persisted:channel_idempotent_publish_client_generated_multiple_" + testParams.name;
+		Channel pubChannel;
+		final Message messageWithId0 = new Message("name_withId", "data_withId");
+		messageWithId0.id = "client_generated_id:0";
+		final Message messageWithId1 = new Message("name_withId", "data_withId");
+		messageWithId1.id = "client_generated_id:1";
+		try {
+			DebugOptions opts = new DebugOptions(testVars.keys[0].keyStr);
+			fillInOptions(opts);
+			opts.useBinaryProtocol = true;
+			opts.httpListener = new DebugOptions.RawHttpListener() {
+				@Override
+				public void onRawHttpRequest(String id, HttpURLConnection conn, String method, String authHeader, Map<String, List<String>> requestHeaders, HttpCore.RequestBody requestBody) {
+					/* verify request body contains the supplied ids */
+					try {
+						if(method.equalsIgnoreCase("POST")) {
+							Message[] requestedMessages = MessageSerializer.readMsgpack(requestBody.getEncoded());
+							assertEquals(requestedMessages[0].id, messageWithId0.id);
+							assertEquals(requestedMessages[1].id, messageWithId1.id);
+						}
+					} catch (AblyException e) {
+						e.printStackTrace();
+					}
+				}
+
+				@Override
+				public void onRawHttpResponse(String id, String method, HttpCore.Response response) {}
+
+				@Override
+				public void onRawHttpException(String id, String method, Throwable t) {}
+			};
+			AblyRest ably = new AblyRest(opts);
+
+			/* first, publish messages */
+			pubChannel = ably.channels.get(channelName);
+			pubChannel.publish(new Message[]{messageWithId0, messageWithId1});
+		} catch(AblyException e) {
+			e.printStackTrace();
+			fail("channel_idempotent_publish_client_generated_multiple: Unexpected exception");
+			return;
+		}
+
+		/* get the history for this channel */
+		try {
+			PaginatedResult<Message> messages = pubChannel.history(new Param[]{new Param("direction", "forwards")});
+			assertNotNull("Expected non-null messages", messages);
+			assertEquals("Expected 2 messages", messages.items().length, 2);
+			assertEquals(messages.items()[0].id, messageWithId0.id);
+			assertEquals(messages.items()[1].id, messageWithId1.id);
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("channel_idempotent_publish_client_generated_multiple: Unexpected exception");
+			return;
+		}
+	}
+
+	static class FailFirstRequest implements DebugOptions.RawHttpListener {
+		int postRequestCount = 0;
+		final String expectedId;
+
+		FailFirstRequest() {
+			this.expectedId = null;
+		}
+
+		FailFirstRequest(String expectedId) {
+			this.expectedId = expectedId;
+		}
+
+		@Override
+		public void onRawHttpRequest(String id, HttpURLConnection conn, String method, String authHeader, Map<String, List<String>> requestHeaders, HttpCore.RequestBody requestBody) {
+			/* verify request body contains the supplied ids */
+			try {
+				if(method.equalsIgnoreCase("POST")) {
+					++postRequestCount;
+					Message[] requestedMessages = MessageSerializer.readMsgpack(requestBody.getEncoded());
+					if(expectedId != null) {
+						assertEquals(requestedMessages[0].id, expectedId);
+					}
+				}
+			} catch (AblyException e) {}
+		}
+
+		@Override
+		public void onRawHttpResponse(String id, String method, HttpCore.Response response) {
+			if(method.equalsIgnoreCase("POST") && postRequestCount == 1) {
+				response.statusCode = 500;
+			}
+		}
+
+		@Override
+		public void onRawHttpException(String id, String method, Throwable t) {}
+	}
+
+	/**
+	 * Verify processing of a client-supplied message id
+	 * Spec: RSL1k5
+	 */
+	@Test
+	public void channel_idempotent_publish_client_generated_retried() {
+		String channelName = "persisted:channel_idempotent_publish_client_generated_retried_" + testParams.name;
+
+		final Message messageWithId = new Message("name_withId", "data_withId");
+		messageWithId.id = "client_generated_id";
+		FailFirstRequest requestListener = new FailFirstRequest(messageWithId.id);
+
+		try {
+			final ClientOptions optsForToken = createOptions(testVars.keys[0].keyStr);
+			final AblyRest ablyForToken = new AblyRest(optsForToken);
+			Auth.AuthOptions restAuthOptions = new Auth.AuthOptions() {{
+				key = optsForToken.key;
+				queryTime = true;
+			}};
+
+			Auth.TokenDetails tokenDetails = ablyForToken.auth.requestToken(new Auth.TokenParams() {{ ttl = 8000L; }}, restAuthOptions);
+
+			DebugOptions opts = new DebugOptions(tokenDetails.token);
+			fillInOptions(opts);
+			opts.useBinaryProtocol = true;
+			opts.httpListener = requestListener;
+			/* generate a fallback which resolves to the same address, which the library will treat as a different host */
+			opts.fallbackHosts = new String[]{ablyForToken.httpCore.getHost().toUpperCase()};
+			AblyRest ably = new AblyRest(opts);
+
+			/* publish message */
+			Channel pubChannel = ably.channels.get(channelName);
+			pubChannel.publish(new Message[]{messageWithId});
+
+			/* get the history for this channel */
+			PaginatedResult<Message> messages = pubChannel.history(new Param[]{new Param("direction", "forwards")});
+			assertEquals("Expected 2 requests", requestListener.postRequestCount, 2);
+			assertNotNull("Expected non-null messages", messages);
+			assertEquals("Expected 1 message", messages.items().length, 1);
+			assertEquals(messages.items()[0].id, messageWithId.id);
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("channel_idempotent_publish_client_generated_retried: Unexpected exception");
+			return;
+		}
+	}
+
+	/**
+	 * Verify processing of a library-generated message id
+	 */
+	@Test
+	public void channel_idempotent_publish_library_generated_multiple() {
+
+		String channelName = "persisted:channel_idempotent_publish_library_generated_multiple_" + testParams.name;
+		Channel pubChannel;
+		final Message messageWithId0 = new Message("name0", "data0");
+		final Message messageWithId1 = new Message("name1", "data1");
+		try {
+			DebugOptions opts = new DebugOptions(testVars.keys[0].keyStr);
+			fillInOptions(opts);
+			opts.idempotentRestPublishing = true;
+			opts.useBinaryProtocol = true;
+			opts.httpListener = new DebugOptions.RawHttpListener() {
+				@Override
+				public void onRawHttpRequest(String id, HttpURLConnection conn, String method, String authHeader, Map<String, List<String>> requestHeaders, HttpCore.RequestBody requestBody) {
+					/* verify request body contains the library-generated ids */
+					try {
+						if(method.equalsIgnoreCase("POST")) {
+							Message[] requestedMessages = MessageSerializer.readMsgpack(requestBody.getEncoded());
+							assertTrue(requestedMessages[0].id.endsWith(":0"));
+							assertTrue(requestedMessages[1].id.endsWith(":1"));
+						}
+					} catch (AblyException e) {
+						e.printStackTrace();
+					}
+				}
+
+				@Override
+				public void onRawHttpResponse(String id, String method, HttpCore.Response response) {}
+
+				@Override
+				public void onRawHttpException(String id, String method, Throwable t) {}
+			};
+			AblyRest ably = new AblyRest(opts);
+
+			/* first, publish messages */
+			pubChannel = ably.channels.get(channelName);
+			pubChannel.publish(new Message[]{messageWithId0, messageWithId1});
+		} catch(AblyException e) {
+			e.printStackTrace();
+			fail("channel_idempotent_publish_client_generated_multiple: Unexpected exception");
+			return;
+		}
+
+		/* get the history for this channel */
+		try {
+			PaginatedResult<Message> messages = pubChannel.history(new Param[]{new Param("direction", "forwards")});
+			assertNotNull("Expected non-null messages", messages);
+			assertEquals("Expected 2 messages", messages.items().length, 2);
+			assertEquals(messages.items()[0].id, messageWithId0.id);
+			assertEquals(messages.items()[1].id, messageWithId1.id);
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("channel_idempotent_publish_client_generated_multiple: Unexpected exception");
+			return;
+		}
+	}
+
+	/**
+	 * Verify processing of a library-generated message id
+	 * Spec: RSL1k4
+	 */
+	@Test
+	public void channel_idempotent_publish_library_generated_retried() {
+		String channelName = "persisted:channel_idempotent_publish_library_generated_retried_" + testParams.name;
+
+		final Message messageWithId = new Message("name0", "data0");
+		FailFirstRequest requestListener = new FailFirstRequest();
+
+		try {
+			final ClientOptions optsForToken = createOptions(testVars.keys[0].keyStr);
+			final AblyRest ablyForToken = new AblyRest(optsForToken);
+			Auth.AuthOptions restAuthOptions = new Auth.AuthOptions() {{
+				key = optsForToken.key;
+				queryTime = true;
+			}};
+
+			Auth.TokenDetails tokenDetails = ablyForToken.auth.requestToken(new Auth.TokenParams() {{ ttl = 8000L; }}, restAuthOptions);
+
+			DebugOptions opts = new DebugOptions(tokenDetails.token);
+			fillInOptions(opts);
+			opts.idempotentRestPublishing = true;
+			opts.useBinaryProtocol = true;
+			opts.httpListener = requestListener;
+			/* generate a fallback which resolves to the same address, which the library will treat as a different host */
+			opts.fallbackHosts = new String[]{ablyForToken.httpCore.getHost().toUpperCase()};
+			AblyRest ably = new AblyRest(opts);
+
+			/* publish message */
+			Channel pubChannel = ably.channels.get(channelName);
+			pubChannel.publish(new Message[]{messageWithId});
+
+			/* get the history for this channel */
+			PaginatedResult<Message> messages = pubChannel.history(new Param[]{new Param("direction", "forwards")});
+			assertEquals("Expected 2 requests", requestListener.postRequestCount, 2);
+			assertNotNull("Expected non-null messages", messages);
+			assertEquals("Expected 1 message", messages.items().length, 1);
+			assertEquals(messages.items()[0].id, messageWithId.id);
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("channel_idempotent_publish_library_generated_retried: Unexpected exception");
+			return;
+		}
+	}
+
 }


### PR DESCRIPTION
This implements optional idempotent REST publishing as specified in https://docs.ably.io/client-lib-development-guide/features/#RSL1k:

> (RSL1k) Idempotent publishing via REST is supported by populating the id attribute of Message instances passed to publish():
(RSL1k1) Idempotent publishing via library-generated `Message` `id`s is supported if `idempotentRestPublishing` (see [TO3n](https://docs.ably.io/client-lib-development-guide/features/#TO3n)) is enabled and one or more `Message` instances are passed to `publish()` and all `Message`s have an empty `id` attribute. The library generates a base `id` string by base64-encoding a sequence of at least 9 bytes obtained from a source of randomness. Each individual Message in the set of messages to be published is assigned a unique `id` of the form `<base id>:<serial>` (where `serial` is the zero-based index into the set).
(RSL1k2) Idempotent publishing via client-supplied Message `id`s is supported where a single `Message` is passed to `publish()` and it contains a non-empty `id`. The `id` is preserved on sending the message.

Prior to the 1.2 release, idempotent publishing via a library-generated `id` is disabled by default, but can be enabled via the `idempotentRestPublishing`client option ([TO3n](https://docs.ably.io/client-lib-development-guide/features/#TO3n)).