### PR TITLE
RTL6c: implement transient realtime publishing

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -72,9 +72,9 @@ public class ConnectionManager implements ConnectListener {
 	public static class StateInfo {
 		public final ConnectionState state;
 		public final ErrorInfo defaultErrorInfo;
+		public final boolean queueEvents;
+		public final boolean sendEvents;
 
-		final boolean queueEvents;
-		final boolean sendEvents;
 		final boolean terminal;
 		final boolean retry;
 		final long timeout;

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
@@ -200,55 +200,6 @@ public class RealtimeMessageTest extends ParameterizedTest {
 	}
 
 	/**
-	 * Get a channel and publish without explicitly attaching.
-	 * Verify that the channel reaches the attached state.
-	 */
-	@Test
-	public void publish_implicit_attach() {
-		AblyRealtime pubAbly = null;
-		AblyRealtime subAbly = null;
-		String channelName = "publish_implicit_attach_" + testParams.name;
-		try {
-			ClientOptions opts = createOptions(testVars.keys[0].keyStr);
-			pubAbly = new AblyRealtime(opts);
-			subAbly = new AblyRealtime(opts);
-
-			/* create a channel */
-			final Channel pubChannel = pubAbly.channels.get(channelName);
-			final Channel subChannel = subAbly.channels.get(channelName);
-
-			/* subscribe and wait for subscription channel to attach */
-			MessageWaiter messageWaiter =  new MessageWaiter(subChannel);
-			(new ChannelWaiter(subChannel)).waitFor(ChannelState.attached);
-
-			/* publish to the channel */
-			CompletionWaiter msgComplete = new CompletionWaiter();
-			pubChannel.publish("test_event", "Test message (" + channelName + ")", msgComplete);
-
-			/* verify attached state is reached */
-			(new ChannelWaiter(pubChannel)).waitFor(ChannelState.attached);
-			assertEquals("Verify attached state reached", pubChannel.state, ChannelState.attached);
-
-			/* wait for the publish callback to be called */
-			msgComplete.waitFor();
-			assertTrue("Verify success callback was called", msgComplete.success);
-
-			/* wait for the subscription callback to be called */
-			messageWaiter.waitFor(1);
-			assertEquals("Verify message subscription was called", messageWaiter.receivedMessages.size(), 1);
-
-		} catch (AblyException e) {
-			e.printStackTrace();
-			fail("init0: Unexpected exception instantiating library");
-		} finally {
-			if(pubAbly != null)
-				pubAbly.close();
-			if(subAbly != null)
-				subAbly.close();
-		}
-	}
-
-	/**
 	 * Connect to the service using the default (binary) protocol
 	 * and attach, subscribe to an event, and publish multiple
 	 * messages on that channel


### PR DESCRIPTION
This implements the ability to publish on a realtime connection without triggering an `attach()`, as specified in https://docs.ably.io/client-lib-development-guide/features/#RTL6c5:

> (RTL6c5) A publish should not trigger an implicit attach