### PR TITLE
Add support for bulk rest publish API

### DIFF
--- a/lib/src/main/java/io/ably/annotation/Experimental.java
+++ b/lib/src/main/java/io/ably/annotation/Experimental.java
@@ -1,0 +1,10 @@
+package io.ably.annotation;
+
+import java.lang.annotation.Documented;
+
+/**
+ * An annotation indicating an experimental API. Any or all detail of this
+ * API are subject to change in the future. Feedback on the API is welcomed.
+ */
+@Documented
+public @interface Experimental { }

--- a/lib/src/main/java/io/ably/lib/rest/AblyRest.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyRest.java
@@ -2,6 +2,7 @@ package io.ably.lib.rest;
 
 import java.util.HashMap;
 
+import io.ably.annotation.Experimental;
 import io.ably.lib.http.AsyncHttpScheduler;
 import io.ably.lib.http.Http;
 import io.ably.lib.http.HttpCore;
@@ -224,15 +225,17 @@ public class AblyRest {
 	 * independent requests.
 	 * @throws AblyException
 	 */
-	public PublishResponse[] publish(Message.Batch[] pubSpecs, ChannelOptions channelOptions) throws AblyException {
-		return publishImpl(pubSpecs, channelOptions).sync();
+	@Experimental
+	public PublishResponse[] publishBatch(Message.Batch[] pubSpecs, ChannelOptions channelOptions) throws AblyException {
+		return publishBatchImpl(pubSpecs, channelOptions).sync();
 	}
 
-	public void publishAsync(Message.Batch[] pubSpecs, ChannelOptions channelOptions, final Callback<PublishResponse[]> callback) throws AblyException {
-		publishImpl(pubSpecs, channelOptions).async(callback);
+	@Experimental
+	public void publishBatchAsync(Message.Batch[] pubSpecs, ChannelOptions channelOptions, final Callback<PublishResponse[]> callback) throws AblyException {
+		publishBatchImpl(pubSpecs, channelOptions).async(callback);
 	}
 
-	private Http.Request<PublishResponse[]> publishImpl(final Message.Batch[] pubSpecs, ChannelOptions channelOptions) throws AblyException {
+	private Http.Request<PublishResponse[]> publishBatchImpl(final Message.Batch[] pubSpecs, ChannelOptions channelOptions) throws AblyException {
 		boolean hasClientSuppliedId = false;
 		for(Message.Batch spec : pubSpecs) {
 			for(Message message : spec.messages) {

--- a/lib/src/main/java/io/ably/lib/rest/AblyRest.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyRest.java
@@ -196,28 +196,6 @@ public class AblyRest {
 	}
 
 	/**
-	 * Authentication token has changed. waitForResult is true if there is a need to
-	 * wait for server response to auth request
-	 */
-
-	/**
-	 * Override this method in AblyRealtime and pass updated token to ConnectionManager
-	 * @param token new token
-	 * @param waitForResponse wait for server response before returning from method
-	 * @throws AblyException
-	 */
-	protected void onAuthUpdated(String token, boolean waitForResponse) throws AblyException {
-		/* Default is to do nothing. Overridden by subclass. */
-	}
-
-	/**
-	 * Authentication error occurred
-	 */
-	protected void onAuthError(ErrorInfo errorInfo) {
-		/* Default is to do nothing. Overridden by subclass. */
-	}
-
-	/**
 	 * Publish a messages on one or more channels. When there are
 	 * messages to be sent on multiple channels simultaneously,
 	 * it is more efficient to use this method to publish them in
@@ -261,7 +239,7 @@ public class AblyRest {
 				http.post("/messages", HttpUtils.defaultAcceptHeaders(options.useBinaryProtocol), null, requestBody, new HttpCore.ResponseHandler<PublishResponse[]>() {
 					@Override
 					public PublishResponse[] handleResponse(HttpCore.Response response, ErrorInfo error) throws AblyException {
-						if(error != null) {
+						if(error != null && error.code != 40020) {
 							throw AblyException.fromErrorInfo(error);
 						}
 						return PublishResponse.getBulkPublishResponseHandler(response.statusCode).handleResponseBody(response.contentType, response.body);
@@ -269,5 +247,27 @@ public class AblyRest {
 				}, true, callback);
 			}
 		});
+	}
+
+	/**
+	 * Authentication token has changed. waitForResult is true if there is a need to
+	 * wait for server response to auth request
+	 */
+
+	/**
+	 * Override this method in AblyRealtime and pass updated token to ConnectionManager
+	 * @param token new token
+	 * @param waitForResponse wait for server response before returning from method
+	 * @throws AblyException
+	 */
+	protected void onAuthUpdated(String token, boolean waitForResponse) throws AblyException {
+		/* Default is to do nothing. Overridden by subclass. */
+	}
+
+	/**
+	 * Authentication error occurred
+	 */
+	protected void onAuthError(ErrorInfo errorInfo) {
+		/* Default is to do nothing. Overridden by subclass. */
 	}
 }

--- a/lib/src/main/java/io/ably/lib/types/Message.java
+++ b/lib/src/main/java/io/ably/lib/types/Message.java
@@ -2,6 +2,7 @@ package io.ably.lib.types;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.Collection;
 
 import org.msgpack.core.MessageFormat;
 import org.msgpack.core.MessagePacker;
@@ -90,6 +91,43 @@ public class Message extends BaseMessage {
 			}
 		}
 		return this;
+	}
+
+	/**
+	 * A specification for a collection of messages to be sent using the batch API
+	 * @author paddy
+	 *
+	 */
+	public static class Batch {
+		public String[] channels;
+		public Message[] messages;
+
+		public Batch(String channel, Message[] messages) {
+			if(channel == null || channel.isEmpty()) throw new IllegalArgumentException("A Batch spec cannot have an empty set of channels");
+			if(messages == null || messages.length == 0) throw new IllegalArgumentException("A Batch spec cannot have an empty set of messages");
+			this.channels = new String[] { channel };
+			this.messages = messages;
+		}
+
+		public Batch(String[] channels, Message[] messages) {
+			if(channels == null || channels.length == 0) throw new IllegalArgumentException("A Batch spec cannot have an empty set of channels");
+			if(messages == null || messages.length == 0) throw new IllegalArgumentException("A Batch spec cannot have an empty set of messages");
+			this.channels = channels;
+			this.messages = messages;
+		}
+
+		public Batch(Collection<String> channels, Collection<Message> messages) {
+			this(channels.toArray(new String[channels.size()]), messages.toArray(new Message[messages.size()]));
+		}
+
+		public void writeMsgpack(MessagePacker packer) throws IOException {
+			packer.packMapHeader(2);
+			packer.packString("channels");
+			packer.packArrayHeader(channels.length);
+			for(String ch : channels) packer.packString(ch);
+			packer.packString("messages");
+			MessageSerializer.writeMsgpackArray(messages, packer);
+		}
 	}
 
 	static Message fromMsgpack(MessageUnpacker unpacker) throws IOException {

--- a/lib/src/main/java/io/ably/lib/types/PublishResponse.java
+++ b/lib/src/main/java/io/ably/lib/types/PublishResponse.java
@@ -1,5 +1,6 @@
 package io.ably.lib.types;
 
+import com.google.gson.annotations.SerializedName;
 import io.ably.lib.http.HttpCore;
 import io.ably.lib.util.Log;
 import io.ably.lib.util.Serialisation;
@@ -14,7 +15,8 @@ import java.io.IOException;
 
 public class PublishResponse {
 	public ErrorInfo error;
-	public String channel;
+	@SerializedName("channel")
+	public String channelId;
 	public String messageId;
 
 	private static PublishResponse[] fromJSONArray(byte[] json) {
@@ -51,7 +53,8 @@ public class PublishResponse {
 					error = ErrorInfo.fromMsgpack(unpacker);
 					break;
 				case "channel":
-					channel = unpacker.unpackString();
+				case "channelId":
+					channelId = unpacker.unpackString();
 					break;
 				case "messageId":
 					messageId = unpacker.unpackString();

--- a/lib/src/main/java/io/ably/lib/types/PublishResponse.java
+++ b/lib/src/main/java/io/ably/lib/types/PublishResponse.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 public class PublishResponse {
 	public ErrorInfo error;
 	public String channel;
-	public String id;
+	public String messageId;
 
 	private static PublishResponse[] fromJSONArray(byte[] json) {
 		return Serialisation.gson.fromJson(new String(json), PublishResponse[].class);
@@ -53,8 +53,8 @@ public class PublishResponse {
 				case "channel":
 					channel = unpacker.unpackString();
 					break;
-				case "id":
-					id = unpacker.unpackString();
+				case "messageId":
+					messageId = unpacker.unpackString();
 					break;
 				default:
 					Log.v(TAG, "Unexpected field: " + fieldName);

--- a/lib/src/main/java/io/ably/lib/types/PublishResponse.java
+++ b/lib/src/main/java/io/ably/lib/types/PublishResponse.java
@@ -1,0 +1,150 @@
+package io.ably.lib.types;
+
+import io.ably.lib.http.HttpCore;
+import io.ably.lib.util.Log;
+import io.ably.lib.util.Serialisation;
+import org.msgpack.core.MessageFormat;
+import org.msgpack.core.MessageUnpacker;
+
+import java.io.IOException;
+
+/****************************************
+ *            PublishResponse
+ ****************************************/
+
+public class PublishResponse {
+	public ErrorInfo error;
+	public String channel;
+	public String id;
+
+	private static PublishResponse[] fromJSONArray(byte[] json) {
+		return Serialisation.gson.fromJson(new String(json), PublishResponse[].class);
+	}
+
+	private static PublishResponse fromMsgpack(MessageUnpacker unpacker) throws IOException {
+		return (new PublishResponse()).readMsgpack(unpacker);
+	}
+
+	private static PublishResponse[] fromMsgpackArray(byte[] msgpack) throws IOException {
+		MessageUnpacker unpacker = Serialisation.msgpackUnpackerConfig.newUnpacker(msgpack);
+		return fromMsgpackArray(unpacker);
+	}
+
+	private static PublishResponse[] fromMsgpackArray(MessageUnpacker unpacker) throws IOException {
+		int count = unpacker.unpackArrayHeader();
+		PublishResponse[] result = new PublishResponse[count];
+		for(int j = 0; j < count; j++) {
+			result[j] = PublishResponse.fromMsgpack(unpacker);
+		}
+		return result;
+	}
+
+	private PublishResponse readMsgpack(MessageUnpacker unpacker) throws IOException {
+		int fieldCount = unpacker.unpackMapHeader();
+		for(int i = 0; i < fieldCount; i++) {
+			String fieldName = unpacker.unpackString().intern();
+			MessageFormat fieldFormat = unpacker.getNextFormat();
+			if(fieldFormat.equals(MessageFormat.NIL)) { unpacker.unpackNil(); continue; }
+
+			switch(fieldName) {
+				case "error":
+					error = ErrorInfo.fromMsgpack(unpacker);
+					break;
+				case "channel":
+					channel = unpacker.unpackString();
+					break;
+				case "id":
+					id = unpacker.unpackString();
+					break;
+				default:
+					Log.v(TAG, "Unexpected field: " + fieldName);
+					unpacker.skipValue();
+			}
+		}
+		return this;
+	}
+
+	public static HttpCore.BodyHandler<PublishResponse> getBulkPublishResponseHandler(int statusCode) {
+		return (statusCode < 300) ? bulkResponseBodyHandler : batchErrorBodyHandler;
+	}
+
+	private static class BatchErrorResponse {
+		public ErrorInfo error;
+		public PublishResponse[] batchResponse;
+
+		static BatchErrorResponse readJSON(byte[] json) {
+			return Serialisation.gson.fromJson(new String(json), BatchErrorResponse.class);
+		}
+
+		static BatchErrorResponse readMsgpack(byte[] msgpack) throws IOException {
+			MessageUnpacker unpacker = Serialisation.msgpackUnpackerConfig.newUnpacker(msgpack);
+			return (new BatchErrorResponse()).readMsgpack(unpacker);
+		}
+
+		BatchErrorResponse readMsgpack(MessageUnpacker unpacker) throws IOException {
+			int fieldCount = unpacker.unpackMapHeader();
+			for(int i = 0; i < fieldCount; i++) {
+				String fieldName = unpacker.unpackString().intern();
+				MessageFormat fieldFormat = unpacker.getNextFormat();
+				if(fieldFormat.equals(MessageFormat.NIL)) { unpacker.unpackNil(); continue; }
+
+				switch(fieldName) {
+					case "error":
+						error = ErrorInfo.fromMsgpack(unpacker);
+						break;
+					case "batchResponse":
+						batchResponse = PublishResponse.fromMsgpackArray(unpacker);
+						break;
+					default:
+						Log.v(TAG, "Unexpected field: " + fieldName);
+						unpacker.skipValue();
+				}
+			}
+			return this;
+		}
+	}
+
+	private static class BulkResponseBodyHandler implements HttpCore.BodyHandler<PublishResponse> {
+		@Override
+		public PublishResponse[] handleResponseBody(String contentType, byte[] body) throws AblyException {
+			try {
+				if("application/json".equals(contentType)) {
+					return PublishResponse.fromJSONArray(body);
+				} else if("application/x-msgpack".equals(contentType)) {
+					return PublishResponse.fromMsgpackArray(body);
+				}
+				return null;
+			} catch(IOException e) {
+				throw AblyException.fromThrowable(e);
+			}
+		}
+	}
+
+	private static class BatchErrorBodyHandler implements HttpCore.BodyHandler<PublishResponse> {
+		@Override
+		public PublishResponse[] handleResponseBody(String contentType, byte[] body) throws AblyException {
+			try {
+				BatchErrorResponse response = null;
+				if("application/json".equals(contentType)) {
+					response = BatchErrorResponse.readJSON(body);
+				} else if("application/x-msgpack".equals(contentType)) {
+					response = BatchErrorResponse.readMsgpack(body);
+				}
+				if(response == null) {
+					return null;
+				}
+				if(response.error != null && response.error.code != 40020) {
+					throw AblyException.fromErrorInfo(response.error);
+				}
+				return response.batchResponse;
+			} catch(IOException e) {
+				throw AblyException.fromThrowable(e);
+			}
+		}
+	}
+
+	private static HttpCore.BodyHandler<PublishResponse> batchErrorBodyHandler = new BatchErrorBodyHandler();
+	private static HttpCore.BodyHandler<PublishResponse> bulkResponseBodyHandler = new BulkResponseBodyHandler();
+
+	private static final String TAG = MessageSerializer.class.getName();
+}

--- a/lib/src/test/java/io/ably/lib/test/rest/RestChannelBulkPublishTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestChannelBulkPublishTest.java
@@ -50,7 +50,7 @@ public class RestChannelBulkPublishTest extends ParameterizedTest  {
 		Message.Batch payload = new Message.Batch(channels, Collections.singleton(message));
 
 		try {
-			PublishResponse[] result = ably.publish(new Message.Batch[] { payload }, null);
+			PublishResponse[] result = ably.publishBatch(new Message.Batch[] { payload }, null);
 		} catch(AblyException e) {
 			e.printStackTrace();
 			fail("bulkpublish_multiple_channels_simple: Unexpected exception");
@@ -125,7 +125,7 @@ public class RestChannelBulkPublishTest extends ParameterizedTest  {
 		}
 
 		try {
-			ably.publish(payload.toArray(new Message.Batch[payload.size()]), null);
+			ably.publishBatch(payload.toArray(new Message.Batch[payload.size()]), null);
 		} catch(AblyException e) {
 			e.printStackTrace();
 			fail("bulk_publish_multiple_channels_multiple_messages: Unexpected exception");

--- a/lib/src/test/java/io/ably/lib/test/rest/RestChannelBulkPublishTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestChannelBulkPublishTest.java
@@ -1,0 +1,153 @@
+package io.ably.lib.test.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Random;
+
+import io.ably.lib.test.common.ParameterizedTest;
+import io.ably.lib.types.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.ably.lib.rest.AblyRest;
+
+public class RestChannelBulkPublishTest extends ParameterizedTest  {
+
+	private AblyRest ably;
+
+	@Before
+	public void setUpBefore() throws Exception {
+		ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+		ably = new AblyRest(opts);
+	}
+
+	/**
+	 * Publish a single message on multiple channels
+	 * 
+	 * The payload constructed has the form
+	 * [
+	 *   {
+	 *     channel: [ <channel 0>, <channel 1>, ... ],
+	 *     message: [{ data: <message text> }]
+	 *   }
+	 * ]
+	 * 
+	 * It publishes the given message on all of the given channels.
+	 */
+	@Test
+	public void bulk_publish_multiple_channels_simple() {
+		/* first, publish some messages */
+		int channelCount = 5;
+		ArrayList<String> channels = new ArrayList<String>();
+		for(int i = 0; i < channelCount; i++)
+			channels.add("persisted:" + randomString());
+
+		Message message = new Message(null, "bulk_publish_multiple_channels_simple");
+		Message.Batch payload = new Message.Batch(channels, Collections.singleton(message));
+
+		try {
+			PublishResponse[] result = ably.publish(new Message.Batch[] { payload }, null);
+		} catch(AblyException e) {
+			e.printStackTrace();
+			fail("bulkpublish_multiple_channels_simple: Unexpected exception");
+			return;
+		}
+
+		/* get the history for this channel */
+		try {
+			for(String channel : channels) {
+				PaginatedResult<Message> messages = ably.channels.get(channel).history(null);
+				assertNotNull("Expected non-null messages", messages);
+				assertEquals("Expected 1 message", messages.items().length, 1);
+				/* verify message contents */
+				assertEquals("Expect message data to be expected String", messages.items()[0].data, message.data);
+			}
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("bulkpublish_multiple_channels_simple: Unexpected exception");
+			return;
+		}
+	}
+
+	/**
+	 * Publish a multiple messages on multiple channels
+	 * 
+	 * The payload constructed has the form
+	 * [
+	 *   {
+	 *     channel: [ <channel 0> ],
+	 *     message: [
+	 *       { data: <message text> },
+	 *       { data: <message text> },
+	 *       { data: <message text> },
+	 *       ...
+	 *     ]
+	 *   },
+	 *   {
+	 *     channel: [ <channel 1> ],
+	 *     message: [
+	 *       { data: <message text> },
+	 *       { data: <message text> },
+	 *       { data: <message text> },
+	 *       ...
+	 *     ]
+	 *   },
+	 *   ...
+	 * ]
+	 * 
+	 * It publishes the given messages on the associated channels.
+	 */
+	@Test
+	public void bulk_publish_multiple_channels_multiple_messages() {
+		/* first, publish some messages */
+		int channelCount = 5;
+		int messageCount = 6;
+		String baseMessageText = "bulk_publish_multiple_channels_multiple_messages";
+		ArrayList<Message.Batch> payload = new ArrayList<Message.Batch>();
+
+		ArrayList<String> rndMessageTexts = new ArrayList<String>();
+		for(int i = 0; i < messageCount; i++) {
+			rndMessageTexts.add(randomString());
+		}
+
+		ArrayList<String> channels = new ArrayList<String>();
+		for(int i = 0; i < channelCount; i++) {
+			String channel = "persisted:" + randomString();
+			channels.add(channel);
+			ArrayList<Message> messages = new ArrayList<Message>();
+			for(int j = 0; j < messageCount; j++)
+				messages.add(new Message(null, baseMessageText + '-' + channel + '-' + rndMessageTexts.get(j)));
+			payload.add(new Message.Batch(Collections.singleton(channel), messages));
+		}
+
+		try {
+			ably.publish(payload.toArray(new Message.Batch[payload.size()]), null);
+		} catch(AblyException e) {
+			e.printStackTrace();
+			fail("bulk_publish_multiple_channels_multiple_messages: Unexpected exception");
+			return;
+		}
+
+		/* get the history for this channel */
+		try {
+			for(String channel : channels) {
+				PaginatedResult<Message> messages = ably.channels.get(channel).history(new Param[] {new Param("direction", "forwards")});
+				assertNotNull("Expected non-null messages", messages);
+				assertEquals("Expected correct number of messages", messages.items().length, messageCount);
+				/* verify message contents */
+				for(int i = 0; i < messageCount; i++)
+					assertEquals("Expect message data to be expected String", messages.items()[i].data, baseMessageText + '-' + channel + '-' + rndMessageTexts.get(i));
+			}
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("bulk_publish_multiple_channels_multiple_messages: Unexpected exception");
+			return;
+		}
+	}
+
+	private String randomString() { return String.valueOf(new Random().nextDouble()).substring(2); }
+}

--- a/lib/src/test/java/io/ably/lib/test/rest/RestChannelBulkPublishTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestChannelBulkPublishTest.java
@@ -39,24 +39,24 @@ public class RestChannelBulkPublishTest extends ParameterizedTest  {
 
 			/* first, publish some messages */
 			int channelCount = 5;
-			ArrayList<String> channels = new ArrayList<String>();
+			ArrayList<String> channelIds = new ArrayList<String>();
 			for(int i = 0; i < channelCount; i++) {
-				channels.add("persisted:" + randomString());
+				channelIds.add("persisted:" + randomString());
 			}
 
 			Message message = new Message(null, "bulk_publish_multiple_channels_simple");
 			String messageId = message.id = randomString();
-			Message.Batch payload = new Message.Batch(channels, Collections.singleton(message));
+			Message.Batch payload = new Message.Batch(channelIds, Collections.singleton(message));
 
 			PublishResponse[] result = ably.publishBatch(new Message.Batch[] { payload }, null);
 			for(PublishResponse response : result) {
 				assertEquals("Verify expected response id", response.messageId, messageId);
-				assertTrue("Verify expected channel name", channels.contains(response.channel));
+				assertTrue("Verify expected channel name", channelIds.contains(response.channelId));
 				assertNull("Verify no publish error", response.error);
 			}
 
 			/* get the history for this channel */
-			for(String channel : channels) {
+			for(String channel : channelIds) {
 				PaginatedResult<Message> messages = ably.channels.get(channel).history(null);
 				assertNotNull("Expected non-null messages", messages);
 				assertEquals("Expected 1 message", messages.items().length, 1);
@@ -117,10 +117,10 @@ public class RestChannelBulkPublishTest extends ParameterizedTest  {
 				rndMessageTexts.add(randomString());
 			}
 
-			ArrayList<String> channels = new ArrayList<String>();
+			ArrayList<String> channelIds = new ArrayList<String>();
 			for(int i = 0; i < channelCount; i++) {
 				String channel = "persisted:" + randomString();
-				channels.add(channel);
+				channelIds.add(channel);
 				ArrayList<Message> messages = new ArrayList<Message>();
 				for(int j = 0; j < messageCount; j++) {
 					messages.add(new Message(null, baseMessageText + '-' + channel + '-' + rndMessageTexts.get(j)));
@@ -131,12 +131,12 @@ public class RestChannelBulkPublishTest extends ParameterizedTest  {
 			PublishResponse[] result = ably.publishBatch(payload.toArray(new Message.Batch[payload.size()]), null);
 			for(PublishResponse response : result) {
 				assertNotNull("Verify expected response id", response.messageId);
-				assertTrue("Verify expected channel name", channels.contains(response.channel));
+				assertTrue("Verify expected channel name", channelIds.contains(response.channelId));
 				assertNull("Verify no publish error", response.error);
 			}
 
 			/* get the history for this channel */
-			for(String channel : channels) {
+			for(String channel : channelIds) {
 				PaginatedResult<Message> messages = ably.channels.get(channel).history(new Param[] {new Param("direction", "forwards")});
 				assertNotNull("Expected non-null messages", messages);
 				assertEquals("Expected correct number of messages", messages.items().length, messageCount);
@@ -177,20 +177,20 @@ public class RestChannelBulkPublishTest extends ParameterizedTest  {
 			/* first, publish some messages */
 			String baseChannelName = "persisted:" + testParams.name + ":channel";
 			int channelCount = 5;
-			ArrayList<String> channels = new ArrayList<String>();
+			ArrayList<String> channelIds = new ArrayList<String>();
 			for(int i = 0; i < channelCount; i++) {
-				channels.add(baseChannelName + i);
+				channelIds.add(baseChannelName + i);
 			}
 
 			Message message = new Message(null, "bulk_publish_multiple_channels_partial_error");
 			String messageId = message.id = randomString();
-			Message.Batch payload = new Message.Batch(channels, Collections.singleton(message));
+			Message.Batch payload = new Message.Batch(channelIds, Collections.singleton(message));
 
 			PublishResponse[] result = ably.publishBatch(new Message.Batch[] { payload }, null);
 			for(PublishResponse response : result) {
-				if((baseChannelName + "1").compareTo(response.channel) >= 0) {
+				if((baseChannelName + "1").compareTo(response.channelId) >= 0) {
 					assertEquals("Verify expected response id", response.messageId, messageId);
-					assertTrue("Verify expected channel name", channels.contains(response.channel));
+					assertTrue("Verify expected channel name", channelIds.contains(response.channelId));
 					assertNull("Verify no publish error", response.error);
 				} else {
 					assertNotNull("Verify expected publish error", response.error);
@@ -199,7 +199,7 @@ public class RestChannelBulkPublishTest extends ParameterizedTest  {
 			}
 
 			/* get the history for this channel */
-			for(String channel : channels) {
+			for(String channel : channelIds) {
 				if((baseChannelName + "1").compareTo(channel) >= 0) {
 					PaginatedResult<Message> messages = ably.channels.get(channel).history(null);
 					assertNotNull("Expected non-null messages", messages);

--- a/lib/src/test/java/io/ably/lib/test/rest/RestSuite.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestSuite.java
@@ -27,6 +27,7 @@ import io.ably.lib.test.common.Setup;
 	RestChannelTest.class,
 	RestChannelHistoryTest.class,
 	RestChannelPublishTest.class,
+	RestChannelBulkPublishTest.class,
 	RestCryptoTest.class,
 	RestPresenceTest.class,
 	RestProxyTest.class,

--- a/lib/src/test/resources/local/testAppSpec.json
+++ b/lib/src/test/resources/local/testAppSpec.json
@@ -16,6 +16,9 @@
 		{
 			"privileged": true,
 			"capability": "{\"channel0\":[\"publish\"],\"channel1\":[\"publish\"],\"channel2\":[\"publish\",\"subscribe\"],\"channel3\":[\"subscribe\"],\"channel4\":[\"presence\",\"publish\",\"subscribe\"],\"channel5\":[\"presence\"],\"channel6\":[\"*\"]}"
+		},
+		{
+			"capability": "{\"persisted:text_protocol:channel0\":[\"publish\",\"subscribe\",\"history\"],\"persisted:text_protocol:channel1\":[\"publish\",\"subscribe\",\"history\"],\"persisted:binary_protocol:channel0\":[\"publish\",\"subscribe\",\"history\"],\"persisted:binary_protocol:channel1\":[\"publish\",\"subscribe\",\"history\"],\"persisted:*\":[\"subscribe\",\"history\"]}"
 		}
 	],
 	"namespaces": [

--- a/lib/src/test/resources/local/testAppSpec.json.src
+++ b/lib/src/test/resources/local/testAppSpec.json.src
@@ -40,6 +40,15 @@
 				channel5:['presence'],
 				channel6:['*']
 			})
+		},
+		{   /* key 6, has permissions for selected persisted channels */
+			capability: JSON.stringify({
+				'persisted:text_protocol:channel0':['publish', 'subscribe','history'],
+				'persisted:text_protocol:channel1':['publish', 'subscribe','history'],
+				'persisted:binary_protocol:channel0':['publish', 'subscribe','history'],
+				'persisted:binary_protocol:channel1':['publish', 'subscribe','history'],
+				'persisted:*':['subscribe','history']
+			})
 		}
 	],
 	namespaces: [


### PR DESCRIPTION
This adds support for the bulk publish API:

    POST /messages

This performs a publish in parallel of messages to channels specified in the request body.

A single `BatchSpec` is an object of the form:

````
{
  channels: <channels>,
  messages: <messages>
}
````

where:
- `<channels>` is a single channel name `String`, or an `Array` of channel name `Strings`; and
- `<messages>` is a single `Message`, or an `Array` of `Message`s.

The bulk publish endpoint accepts a request body containing either a single `BatchSpec` object, or an array of `BatchSpec` objects.

Therefore the following are all valid request bodies for a bulk publish request:

````
{
  channels: ['a channel name, containing a comma', 'another channel name'],
  messages: {data: 'My message contents'}
}
````

````
[
  {
    channels: ['a channel name, containing a comma', 'another channel name'],
    messages: {data: 'My message contents'}
  },
  {
    channels: 'single channel',
    messages: [
      {data: 'My message contents'},
      {name: 'an event', data: 'My event message contents'},
    ]
  }
]
````

There is an obvious mapping from the request body to the array of individual publish requests.
