### PR TITLE
Attach exception handling

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/Channel.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Channel.java
@@ -3,7 +3,6 @@ package io.ably.lib.realtime;
 import io.ably.lib.http.BasePaginatedQuery;
 import io.ably.lib.http.HttpCore;
 import io.ably.lib.http.HttpUtils;
-import io.ably.lib.http.PaginatedQuery;
 import io.ably.lib.transport.ConnectionManager;
 import io.ably.lib.transport.ConnectionManager.QueuedMessage;
 import io.ably.lib.transport.Defaults;
@@ -125,15 +124,14 @@ public class Channel extends EventEmitter<ChannelEvent, ChannelStateListener> {
 				}
 				return;
 			case attached:
-				if(listener != null) {
-					listener.onSuccess();
-				}
+				callCompletionListenerSuccess(listener);
 				return;
 			default:
 		}
 		ConnectionManager connectionManager = ably.connection.connectionManager;
-		if(!connectionManager.isActive())
+		if(!connectionManager.isActive()) {
 			throw AblyException.fromErrorInfo(connectionManager.getStateErrorInfo());
+		}
 
 		/* send attach request and pending state */
 		Log.v(TAG, "attach(); channel = " + name + "; sending ATTACH request");
@@ -177,9 +175,7 @@ public class Channel extends EventEmitter<ChannelEvent, ChannelStateListener> {
 		switch(state) {
 			case initialized:
 			case detached: {
-				if(listener != null) {
-					listener.onSuccess();
-				}
+				callCompletionListenerSuccess(listener);
 				return;
 			}
 			case detaching:
@@ -231,6 +227,26 @@ public class Channel extends EventEmitter<ChannelEvent, ChannelStateListener> {
 	 * internal
 	 *
 	 */
+	private static void callCompletionListenerSuccess(CompletionListener listener) {
+		if(listener != null) {
+			try {
+				listener.onSuccess();
+			} catch(Throwable t) {
+				Log.e(TAG, "Unexpected exception calling CompletionListener", t);
+			}
+		}
+	}
+
+	private static void callCompletionListenerError(CompletionListener listener, ErrorInfo err) {
+		if(listener != null) {
+			try {
+				listener.onError(err);
+			} catch(Throwable t) {
+				Log.e(TAG, "Unexpected exception calling CompletionListener", t);
+			}
+		}
+	}
+
 	private void setAttached(ProtocolMessage message) {
 		clearAttachTimers();
 		boolean resumed = (message.flags & ( 1 << Flag.resumed.ordinal())) != 0;
@@ -296,24 +312,24 @@ public class Channel extends EventEmitter<ChannelEvent, ChannelStateListener> {
 				@Override
 				public void onSuccess() {
 					clearAttachTimers();
-					if (listener != null)
-						listener.onSuccess();
+					callCompletionListenerSuccess(listener);
 				}
 
 				@Override
 				public void onError(ErrorInfo reason) {
 					clearAttachTimers();
-					if (listener != null)
-						listener.onError(reason);
+					callCompletionListenerError(listener, reason);
 				}
 			});
 		} catch(AblyException e) {
 			attachTimer = null;
+			callCompletionListenerError(listener, e.errorInfo);
 		}
 
-		if(attachTimer == null)
+		if(attachTimer == null) {
 			/* operation has already succeeded or failed, no need to set the timer */
 			return;
+		}
 
 		attachTimer.schedule(
 				new TimerTask() {
@@ -365,7 +381,7 @@ public class Channel extends EventEmitter<ChannelEvent, ChannelStateListener> {
 	 * Try to detach the channel. If the server doesn't confirm the detach operation within realtime
 	 * request timeout return channel to previous state
 	 */
-	synchronized private void detachWithTimeout(final CompletionListener listener) throws AblyException {
+	synchronized private void detachWithTimeout(final CompletionListener listener) {
 		final ChannelState originalState = state;
 		final Timer currentDetachTimer = new Timer();
 		attachTimer = currentDetachTimer;
@@ -375,24 +391,23 @@ public class Channel extends EventEmitter<ChannelEvent, ChannelStateListener> {
 				@Override
 				public void onSuccess() {
 					clearAttachTimers();
-					if (listener != null)
-						listener.onSuccess();
+					callCompletionListenerSuccess(listener);
 				}
 
 				@Override
 				public void onError(ErrorInfo reason) {
 					clearAttachTimers();
-					if (listener != null)
-						listener.onError(reason);
+					callCompletionListenerError(listener, reason);
 				}
 			});
 		} catch (AblyException e) {
 			attachTimer = null;
 		}
 
-		if(attachTimer == null)
+		if(attachTimer == null) {
 			/* operation has already succeeded or failed, no need to set the timer */
 			return;
+		}
 
 		attachTimer.schedule(new TimerTask() {
 			@Override
@@ -403,8 +418,7 @@ public class Channel extends EventEmitter<ChannelEvent, ChannelStateListener> {
 					attachTimer = null;
 					if (state == ChannelState.detaching) {
 						ErrorInfo reason = new ErrorInfo("Detach operation timed out", 90007);
-						if(listener != null)
-							listener.onError(reason);
+						callCompletionListenerError(listener, reason);
 						setState(originalState, reason);
 					}
 				}
@@ -473,7 +487,11 @@ public class Channel extends EventEmitter<ChannelEvent, ChannelStateListener> {
 
 	@Override
 	protected void apply(ChannelStateListener listener, ChannelEvent event, Object... args) {
-		listener.onChannelStateChanged((ChannelStateListener.ChannelStateChange)args[0]);
+		try {
+			listener.onChannelStateChanged((ChannelStateListener.ChannelStateChange)args[0]);
+		} catch (Throwable t) {
+			Log.e(TAG, "Unexpected exception calling ChannelStateListener", t);
+		}
 	}
 
 	static ErrorInfo REASON_NOT_ATTACHED = new ErrorInfo("Channel not attached", 400, 90001);
@@ -745,9 +763,7 @@ public class Channel extends EventEmitter<ChannelEvent, ChannelStateListener> {
 				message.encode(options);
 			}
 		} catch(AblyException e) {
-			if(listener != null) {
-				listener.onError(e.errorInfo);
-			}
+			callCompletionListenerError(listener, e.errorInfo);
 			return;
 		}
 		ProtocolMessage msg = new ProtocolMessage(Action.message, this.name);
@@ -793,8 +809,9 @@ public class Channel extends EventEmitter<ChannelEvent, ChannelStateListener> {
 		}
 
 		/* Call completion callbacks for failed messages without holding the lock */
-		for (FailedMessage failed: failedMessages)
-			failed.msg.listener.onError(failed.reason);
+		for (FailedMessage failed: failedMessages) {
+			callCompletionListenerError(failed.msg.listener, failed.reason);
+		}
 	}
 
 	private void failQueuedMessages(ErrorInfo reason) {
@@ -810,11 +827,7 @@ public class Channel extends EventEmitter<ChannelEvent, ChannelStateListener> {
 		}
 
 		for(FailedMessage failed : failedMessages) {
-			try {
-				failed.msg.listener.onError(failed.reason);
-			} catch (Throwable t) {
-				Log.e(TAG, "failQueuedMessages(): Unexpected exception calling listener", t);
-			}
+			callCompletionListenerError(failed.msg.listener, failed.reason);
 		}
 	}
 

--- a/lib/src/main/java/io/ably/lib/realtime/Connection.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Connection.java
@@ -4,6 +4,7 @@ import io.ably.lib.realtime.ConnectionStateListener.ConnectionStateChange;
 import io.ably.lib.transport.ConnectionManager;
 import io.ably.lib.types.ErrorInfo;
 import io.ably.lib.util.EventEmitter;
+import io.ably.lib.util.Log;
 
 /**
  * A class representing the connection associated with an AblyRealtime instance.
@@ -88,7 +89,11 @@ public class Connection extends EventEmitter<ConnectionEvent, ConnectionStateLis
 
 	@Override
 	protected void apply(ConnectionStateListener listener, ConnectionEvent event, Object... args) {
-		listener.onConnectionStateChanged((ConnectionStateChange)args[0]);
+		try {
+			listener.onConnectionStateChanged((ConnectionStateChange)args[0]);
+		} catch (Throwable t) {
+			Log.e(TAG, "Unexpected exception calling ConnectionStateListener", t);
+		}
 	}
 
 	public void emitUpdate(ErrorInfo errorInfo) {
@@ -111,6 +116,7 @@ public class Connection extends EventEmitter<ConnectionEvent, ConnectionStateLis
 		super.once(state.getConnectionEvent(), listener);
 	}
 
+	private static final String TAG = Connection.class.getName();
 	final AblyRealtime ably;
 	public final ConnectionManager connectionManager;
 }

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -155,7 +155,7 @@ public class ConnectionManager implements ConnectListener {
 	long connectionStateTtl = Defaults.connectionStateTtl;
 
 	public ErrorInfo getStateErrorInfo() {
-		return state.defaultErrorInfo;
+		return stateError != null ? stateError : state.defaultErrorInfo;
 	}
 
 	public boolean isActive() {
@@ -244,6 +244,7 @@ public class ConnectionManager implements ConnectListener {
 			change = new ConnectionStateListener.ConnectionStateChange(state.state, newState.state, newStateInfo.timeout, reason);
 			newStateInfo.host = newState.currentHost;
 			state = newStateInfo;
+			stateError = reason;
 
 			if(change.current != change.previous) {
 				/* any state change clears pending reauth flag */
@@ -1293,6 +1294,7 @@ public class ConnectionManager implements ConnectListener {
 
 	private CMThread mgrThread;
 	private StateInfo state;
+	private ErrorInfo stateError;
 	private StateIndication indicatedState, requestedState;
 	private ConnectParams pendingConnect;
 	private boolean pendingReauth;


### PR DESCRIPTION
Fixes: https://github.com/ably/ably-java/issues/448

Ensure that exceptions occurring during an attach attempt - eg because the connection is `failed` - are not silently swallowed, and any client listener is called.