### PR TITLE
Auth RSA4b1 spec update: conditional token validity check

### DIFF
--- a/lib/src/main/java/io/ably/lib/debug/DebugOptions.java
+++ b/lib/src/main/java/io/ably/lib/debug/DebugOptions.java
@@ -22,6 +22,7 @@ public class DebugOptions extends ClientOptions {
 		public void onRawHttpException(String id, String method, Throwable t);
 	}
 
+	public DebugOptions() throws AblyException { super(); }
 	public DebugOptions(String key) throws AblyException { super(key); }
 
 	public RawProtocolListener protocolListener;

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -674,7 +674,7 @@ public class Auth {
 			Log.i("Auth.requestToken()", "using token auth with client-side signing");
 			signedTokenRequest = createTokenRequest(params, tokenOptions);
 		} else {
-			throw AblyException.fromErrorInfo(new ErrorInfo("Auth.requestToken(): options must include valid authentication parameters", 400, 40000));
+			throw AblyException.fromErrorInfo(new ErrorInfo("Auth.requestToken(): options must include valid authentication parameters", 400, 40106));
 		}
 
 		String tokenPath = "/keys/" + signedTokenRequest.keyName + "/requestToken";
@@ -963,7 +963,8 @@ public class Auth {
 	}
 
 	private static boolean tokenValid(TokenDetails tokenDetails) {
-		return tokenDetails.expires > Auth.serverTimestamp();
+		/* RSA4b1: only perform a local check for token validity if we have time sync with the server */
+		return (timeDelta == Long.MAX_VALUE) || (tokenDetails.expires > Auth.serverTimestamp());
 	}
 
 	/**


### PR DESCRIPTION
Only make a local token validity check if we have already determined the local to server time offset.

Fixes: https://github.com/ably/ably-java/issues/462.

See https://github.com/ably/docs/pull/622 for the requirement change.