### PR TITLE
ConnectionManager: ensure that cached token details are cleared on any connection error

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -77,7 +77,7 @@ public class ConnectionManager implements ConnectListener {
 
 		final boolean terminal;
 		final boolean retry;
-		final long timeout;
+		public long timeout;
 		String host;
 
 		StateInfo(ConnectionState state, boolean queueEvents, boolean sendEvents, boolean terminal, boolean retry, long timeout, ErrorInfo defaultErrorInfo) {
@@ -615,8 +615,10 @@ public class ConnectionManager implements ConnectListener {
 
 	private synchronized void onError(ProtocolMessage message) {
 		connection.key = null;
-		ConnectionState destinationState = isFatalError(message.error) ? ConnectionState.failed : ConnectionState.disconnected;
-		notifyState(transport, new StateIndication(destinationState, message.error));
+		ErrorInfo reason = message.error;
+		ably.auth.onAuthError(reason);
+		ConnectionState destinationState = isFatalError(reason) ? ConnectionState.failed : ConnectionState.disconnected;
+		notifyState(transport, new StateIndication(destinationState, reason));
 	}
 
 	private void onAck(ProtocolMessage message) {


### PR DESCRIPTION
Fixes: https://github.com/ably/ably-java/issues/470