### PR TITLE
WebSocketTransport: don't null the wsConnection in onClose()

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -239,9 +239,6 @@ public class WebSocketTransport implements ITransport {
 				reason = ConnectionManager.REASON_FAILED;
 				break;
 			}
-			synchronized(WebSocketTransport.this) {
-				wsConnection = null;
-			}
 			connectListener.onTransportUnavailable(WebSocketTransport.this, params, reason, newState);
 			dispose();
 		}


### PR DESCRIPTION
Nulling the `wsConnection` is unnecessary and causes deadlock by reversing lock acquisition order.

Related: https://github.com/ably/ably-java/issues/495#issuecomment-543048381