### PR TITLE
Initial setup for Maven Central

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 .project
 
 local.properties
+*.DS_Store

--- a/android/maven.gradle
+++ b/android/maven.gradle
@@ -5,10 +5,6 @@ def groupId = "io.ably"
 def artifactId = "ably-android"
 def localReleaseDest = "${buildDir}/release/${version}"
 
-task promoteRepo {
-	println("HELLO PROMOTE REPO ANDROID")
-}
-
 /*
  * Task which signs and uploads the Android artifacts to Nexus OSSRH.
  */
@@ -20,11 +16,11 @@ uploadArchives {
 		beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
 		repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-			authentication(userName: ossrhUsername, password: ossrhPassword)
+			authentication(userName: nexusUsername, password: nexusPassword)
 		}
 
 		snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-			authentication(userName: ossrhUsername, password: ossrhPassword)
+			authentication(userName: nexusUsername, password: nexusPassword)
 		}
         pom.groupId = groupId
         pom.artifactId = artifactId

--- a/android/maven.gradle
+++ b/android/maven.gradle
@@ -5,6 +5,10 @@ def groupId = "io.ably"
 def artifactId = "ably-android"
 def localReleaseDest = "${buildDir}/release/${version}"
 
+task promoteRepo {
+	println("HELLO PROMOTE REPO ANDROID")
+}
+
 /*
  * Task which signs and uploads the Android artifacts to Nexus OSSRH.
  */

--- a/android/maven.gradle
+++ b/android/maven.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-def groupId = "com.amihaiemil"
+def groupId = "io.ably"
 def artifactId = "ably-android"
 def localReleaseDest = "${buildDir}/release/${version}"
 

--- a/android/maven.gradle
+++ b/android/maven.gradle
@@ -6,7 +6,19 @@ def artifactId = "ably-android"
 def localReleaseDest = "${buildDir}/release/${version}"
 
 uploadArchives {
+	signing {
+		sign configurations.archives
+	}
     repositories.mavenDeployer {
+		beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+		repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+			authentication(userName: ossrhUsername, password: ossrhPassword)
+		}
+
+		snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+			authentication(userName: ossrhUsername, password: ossrhPassword)
+		}
         pom.groupId = groupId
         pom.artifactId = artifactId
         pom.version = version
@@ -54,10 +66,10 @@ uploadArchives {
         }
 
 		// Export to local Maven cache
-		repository(url: repositories.mavenLocal().url)
+		//repository(url: repositories.mavenLocal().url)
 
         // Export files to local storage
-        repository(url: "file://${localReleaseDest}")
+        //repository(url: "file://${localReleaseDest}")
     }
 }
 

--- a/android/maven.gradle
+++ b/android/maven.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-def groupId = "io.ably"
+def groupId = "com.amihaiemil"
 def artifactId = "ably-android"
 def localReleaseDest = "${buildDir}/release/${version}"
 
@@ -36,7 +36,16 @@ uploadArchives {
             description 'An Android Realtime and REST client library for [Ably.io](https://www.ably.io), the realtime messaging service.'
             packaging 'aar'
             inceptionYear '2015'
-            scm {
+			url 'https://www.github.com/ably/ably-java'
+			developers {
+				developer {
+					name 'Paddy Byers'
+					email 'paddy@ably.io'
+					url 'https://github.com/paddybyers'
+					id 'paddybyers'
+				}
+			}
+			scm {
                 url 'scm:git:https://github.com/ably/ably-java'
                 connection 'scm:git:https://github.com/ably/ably-java'
                 developerConnection 'scm:git:git@github.com:ably/ably-java'

--- a/android/maven.gradle
+++ b/android/maven.gradle
@@ -5,6 +5,9 @@ def groupId = "io.ably"
 def artifactId = "ably-android"
 def localReleaseDest = "${buildDir}/release/${version}"
 
+/*
+ * Task which signs and uploads the Android artifacts to Nexus OSSRH.
+ */
 uploadArchives {
 	signing {
 		sign configurations.archives
@@ -64,12 +67,6 @@ uploadArchives {
                 dep -> dep.artifactId != 'play-services-gcm' && dep.artifactId != 'firebase-messaging'
             }
         }
-
-		// Export to local Maven cache
-		//repository(url: repositories.mavenLocal().url)
-
-        // Export files to local storage
-        //repository(url: "file://${localReleaseDest}")
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,5 +6,14 @@ repositories {
 buildscript {
     repositories {
         google()
-    }
+		mavenCentral()
+	}
+	dependencies {
+		classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.1'
+	}
+}
+apply plugin: 'io.codearte.nexus-staging'
+
+nexusStaging {
+	packageGroup = "io.ably"
 }

--- a/java/maven.gradle
+++ b/java/maven.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-def groupId = "io.ably"
+def groupId = "com.amihaiemil"
 def artifactId = "ably-java"
 def localReleaseDest = "${buildDir}/release/${version}"
 
@@ -37,6 +37,15 @@ uploadArchives {
             description 'A Java Realtime and REST client library for [Ably.io](https://www.ably.io), the realtime messaging service.'
             packaging 'jar'
             inceptionYear '2015'
+			url 'https://www.github.com/ably/ably-java'
+			developers {
+				developer {
+					name 'Paddy Byers'
+					email 'paddy@ably.io'
+					url 'https://github.com/paddybyers'
+					id 'paddybyers'
+				}
+			}
             scm {
                 url 'scm:git:https://github.com/ably/ably-java'
                 connection 'scm:git:https://github.com/ably/ably-java'

--- a/java/maven.gradle
+++ b/java/maven.gradle
@@ -6,10 +6,6 @@ def groupId = "io.ably"
 def artifactId = "ably-java"
 def localReleaseDest = "${buildDir}/release/${version}"
 
-task promoteRepo {
-	println("HELLO PROMOTE REPO")
-}
-
 /*
  * Task which signs and uploads the Java artifacts to Nexus OSSRH.
  */
@@ -21,11 +17,11 @@ uploadArchives {
         beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
 	    repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-         authentication(userName: ossrhUsername, password: ossrhPassword)
+         authentication(userName: nexusUsername, password: nexusPassword)
         }
 
         snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-          authentication(userName: ossrhUsername, password: ossrhPassword)
+          authentication(userName: nexusUsername, password: nexusPassword)
         }
         pom.groupId = groupId
         pom.artifactId = artifactId

--- a/java/maven.gradle
+++ b/java/maven.gradle
@@ -2,12 +2,24 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-def groupId = "io.ably"
+def groupId = "com.amihaiemil.ably"
 def artifactId = "ably-java"
 def localReleaseDest = "${buildDir}/release/${version}"
 
 uploadArchives {
+    signing {
+        sign configurations.archives
+    }
     repositories.mavenDeployer {
+	beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+      repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+        authentication(userName: ossrhUsername, password: ossrhPassword)
+      }
+
+      snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+        authentication(userName: ossrhUsername, password: ossrhPassword)
+      }
         pom.groupId = groupId
         pom.artifactId = artifactId
         pom.version = version
@@ -48,7 +60,7 @@ uploadArchives {
         }
 
         // Export files to local storage
-        repository(url: "file://${localReleaseDest}")
+        //repository(url: "file://${localReleaseDest}")
     }
 }
 

--- a/java/maven.gradle
+++ b/java/maven.gradle
@@ -11,15 +11,15 @@ uploadArchives {
         sign configurations.archives
     }
     repositories.mavenDeployer {
-	beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+        beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-      repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-        authentication(userName: ossrhUsername, password: ossrhPassword)
-      }
+	    repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+         authentication(userName: ossrhUsername, password: ossrhPassword)
+        }
 
-      snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-        authentication(userName: ossrhUsername, password: ossrhPassword)
-      }
+        snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+          authentication(userName: ossrhUsername, password: ossrhPassword)
+        }
         pom.groupId = groupId
         pom.artifactId = artifactId
         pom.version = version

--- a/java/maven.gradle
+++ b/java/maven.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-def groupId = "com.amihaiemil.ably"
+def groupId = "io.ably"
 def artifactId = "ably-java"
 def localReleaseDest = "${buildDir}/release/${version}"
 

--- a/java/maven.gradle
+++ b/java/maven.gradle
@@ -6,6 +6,9 @@ def groupId = "io.ably"
 def artifactId = "ably-java"
 def localReleaseDest = "${buildDir}/release/${version}"
 
+/*
+ * Task which signs and uploads the Java artifacts to Nexus OSSRH.
+ */
 uploadArchives {
     signing {
         sign configurations.archives
@@ -58,9 +61,6 @@ uploadArchives {
                 dep -> dep.scope == 'runtime'
             }
         }
-
-        // Export files to local storage
-        //repository(url: "file://${localReleaseDest}")
     }
 }
 

--- a/java/maven.gradle
+++ b/java/maven.gradle
@@ -6,6 +6,10 @@ def groupId = "io.ably"
 def artifactId = "ably-java"
 def localReleaseDest = "${buildDir}/release/${version}"
 
+task promoteRepo {
+	println("HELLO PROMOTE REPO")
+}
+
 /*
  * Task which signs and uploads the Java artifacts to Nexus OSSRH.
  */

--- a/java/maven.gradle
+++ b/java/maven.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-def groupId = "com.amihaiemil"
+def groupId = "io.ably"
 def artifactId = "ably-java"
 def localReleaseDest = "${buildDir}/release/${version}"
 


### PR DESCRIPTION
Changes for #505 

* specify Sonatype snapshot and release repos
* specify signing task
* tested with my own sonatype account (I specified my own coordonates and GPG key) -- the release was succesfully transfered to my staging repo, 

![image](https://user-images.githubusercontent.com/6305156/67685048-09bbe000-f99d-11e9-8c15-570a7ec5d2f8.png)


**TODO**

* Ably needs a Sonatype account and groupId for Maven Central (as specified [here](https://github.com/ably/ably-java/issues/505#issuecomment-546906599)).
* Ably needs a GPG key (see [here](https://central.sonatype.org/pages/working-with-pgp-signatures.html))
* The following stuff needs to be specified in **gradle.properties**
    ```
    signing.keyId=blaId
    signing.password=blabla
    signing.secretKeyRingFile=/path/to//secring.gpg

    nexusUsername=AblyUsername
    nexusPassword=AblyPassword
    ```
    **IMPORTANT** the above configs have to be encrypted before being commited to the Git repo, and decrypted on-the-fly when performing the release.

* integrate Nexus plugin for releasing to Maven Central (so far the config only uploads the artifacts to  the Sonatype Staging Repo from where they have to be "promoted" to Maven Central)

**OTHER**

- I'm not sure what branching convensions are used. Personally, I always work on a separate branch, for each ticket. The branch's name is the ticket's number (e.g. this PR comes from ``amihaiemil:505``).