### PR TITLE
ChannelOptions.withCipherKey + tests

### DIFF
--- a/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
@@ -33,7 +33,37 @@ public class ChannelOptions {
 		}
 	}
 
+	/**
+	 * <b>Deprecated. Use withCipherKey(byte[]) instead.</b><br><br>
+	 * Create ChannelOptions from the given cipher key.
+	 * @param key Byte array cipher key.
+	 * @return Created ChannelOptions.
+	 * @throws AblyException If something goes wrong.
+	 */
+	@Deprecated
 	public static ChannelOptions fromCipherKey(byte[] key) throws AblyException {
+		return withCipherKey(key);
+	}
+
+	/**
+	 * <b>Deprecated. Use withCipherKey(String) instead.</b><br><br>
+	 * Create ChannelOptions from the given cipher key.
+	 * @param base64Key The cipher key as a base64-encoded String,
+	 * @return Created ChannelOptions.
+	 * @throws AblyException If something goes wrong.
+	 */
+	@Deprecated
+	public static ChannelOptions fromCipherKey(String base64Key) throws AblyException {
+		return fromCipherKey(Base64Coder.decode(base64Key));
+	}
+
+	/**
+	 * Create ChannelOptions with the given cipher key.
+	 * @param key Byte array cipher key.
+	 * @return Created ChannelOptions.
+	 * @throws AblyException If something goes wrong.
+	 */
+	public static ChannelOptions withCipherKey(byte[] key) throws AblyException {
 		ChannelOptions options = new ChannelOptions();
 		options.encrypted = true;
 		options.cipherParams = Crypto.getDefaultParams(key);
@@ -41,7 +71,13 @@ public class ChannelOptions {
 		return options;
 	}
 
-	public static ChannelOptions fromCipherKey(String base64Key) throws AblyException {
-		return fromCipherKey(Base64Coder.decode(base64Key));
+	/**
+	 * Create ChannelOptions with the given cipher key.
+	 * @param base64Key The cipher key as a base64-encoded String,
+	 * @return Created ChannelOptions.
+	 * @throws AblyException If something goes wrong.
+	 */
+	public static ChannelOptions withCipherKey(String base64Key) throws AblyException {
+		return withCipherKey(Base64Coder.decode(base64Key));
 	}
 }

--- a/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
@@ -17,7 +17,7 @@ public class ChannelOptions {
 	public Object cipherParams;
 
 	/**
-	 * Are these options encrypted or not?
+	 * Whether or not this ChannelOptions is encrypted.
 	 */
 	public boolean encrypted;
 

--- a/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
@@ -22,9 +22,15 @@ public class ChannelOptions {
 	public boolean encrypted;
 
 	public ChannelCipher getCipher() throws AblyException {
-		if(!encrypted) return null;
-		if(cipher != null) return cipher;
-		return (cipher = Crypto.getCipher(this));
+		if(!this.encrypted) {
+			return null;
+		}
+		if(this.cipher != null) {
+			return this.cipher;
+		} else {
+			this.cipher = Crypto.getCipher(this);
+			return this.cipher;
+		}
 	}
 
 	public static ChannelOptions fromCipherKey(byte[] key) throws AblyException {

--- a/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
@@ -5,8 +5,21 @@ import io.ably.lib.util.Crypto;
 import io.ably.lib.util.Crypto.ChannelCipher;
 
 public class ChannelOptions {
-	public boolean encrypted;
+
+	/**
+	 * Cipher in use.
+	 */
+	private ChannelCipher cipher;
+
+	/**
+	 * Parameters for the cipher.
+	 */
 	public Object cipherParams;
+
+	/**
+	 * Are these options encrypted or not?
+	 */
+	public boolean encrypted;
 
 	public ChannelCipher getCipher() throws AblyException {
 		if(!encrypted) return null;
@@ -25,6 +38,4 @@ public class ChannelOptions {
 	public static ChannelOptions fromCipherKey(String base64Key) throws AblyException {
 		return fromCipherKey(Base64Coder.decode(base64Key));
 	}
-
-	private ChannelCipher cipher;
 }

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeCryptoTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeCryptoTest.java
@@ -534,9 +534,14 @@ public class RealtimeCryptoTest extends ParameterizedTest {
 
 	/**
 	 * Test channel options creation from the cipher key
-	 * Tests TB3
+	 * Tests TB3.
+	 *
+	 * This test should be removed when we get rid of the methods
+	 * ChannelOptions.fromCipherKey(...) which are deprecated and have
+	 * been replaced with ChannelOptions.withCipherKey(...).
 	 */
 	@Test
+	@Deprecated
 	public void channel_options_from_cipher_key() {
 		String channelName = "cipher_params_test_" + testParams.name;
 		AblyRealtime ably1 = null, ably2 = null;
@@ -554,6 +559,63 @@ public class RealtimeCryptoTest extends ParameterizedTest {
 			final Channel channelSend = ably1.channels.get(channelName, ChannelOptions.fromCipherKey(key));
 			/* create a receiving channel using (the same) key encoded with base64 */
 			final Channel channelReceive = ably2.channels.get(channelName, ChannelOptions.fromCipherKey(base64key));
+
+			/* attach */
+			channelSend.attach();
+			channelReceive.attach();
+
+			/* subscribe */
+			MessageWaiter messageWaiter =  new MessageWaiter(channelReceive);
+
+			/* publish to the channel */
+			String messageText = "Test message";
+			CompletionWaiter msgComplete = new CompletionWaiter();
+			channelSend.publish("test_event", messageText, msgComplete);
+
+			/* wait for the publish callback to be called */
+			msgComplete.waitFor();
+			assertTrue("Verify success callback was called", msgComplete.success);
+
+			/* wait for the subscription callback to be called */
+			messageWaiter.waitFor(1);
+			assertEquals("Verify message subscription was called", messageWaiter.receivedMessages.size(), 1);
+
+			/* check the correct plaintext recovered from the message */
+			assertTrue("Verify correct plaintext received", messageText.equals(messageWaiter.receivedMessages.get(0).data));
+
+		} catch (AblyException e) {
+			e.printStackTrace();
+			fail("init0: Unexpected exception instantiating library");
+		} finally {
+			if(ably1 != null)
+				ably1.close();
+			if(ably2 != null)
+				ably2.close();
+		}
+	}
+
+	/**
+	 * Test channel options creation with the cipher key
+	 * Tests TB3.
+	 */
+	@Test
+	public void channel_options_with_cipher_key() {
+		String channelName = "cipher_params_test_" + testParams.name;
+		AblyRealtime ably1 = null, ably2 = null;
+		try {
+			ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+			ably1 = new AblyRealtime(opts);
+			ably2 = new AblyRealtime(opts);
+
+			/* 128-bit key */
+			byte[] key = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+			/* Same key but encoded with Base64 */
+			String base64key = "AQIDBAUGBwgJCgsMDQ4PEA==";
+
+			/* create a sending channel using byte[] array */
+			final Channel channelSend = ably1.channels.get(channelName, ChannelOptions.withCipherKey(key));
+			/* create a receiving channel using (the same) key encoded with base64 */
+			final Channel channelReceive = ably2.channels.get(channelName, ChannelOptions.withCipherKey(base64key));
 
 			/* attach */
 			channelSend.attach();


### PR DESCRIPTION
PR for #492 
Changes:

* Commit 1: moved attributes of ChannelOptions at the top + javadocs
* Commit 2: formatted method ``getCipher()`` (we should avoid inline ``if``s)
* Commit 3: 
    - Added method ``withChiperKey`` as per spec and deprecated ``fromCipherKey``.
    - Added tests.
* Commit 4: cosmetic changes on ``RealtimeCryptoTest``:
     - added braces to ``if``s;
     - renamed ``tx`` and ``rx`` to ``sender`` and ``receiver`` respectively
     - fixed asserts' error messages
     - removed multiple inline variable initializations