### PR TITLE
Fixes in HttpScheduler.AsyncRequest

### DIFF
--- a/lib/src/main/java/io/ably/lib/http/HttpScheduler.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpScheduler.java
@@ -114,10 +114,9 @@ public class HttpScheduler<Executor extends java.util.concurrent.Executor> {
 				final Param[] headers,
 				final Param[] params,
 				final HttpCore.RequestBody requestBody,
-				final boolean withCredentials,
 				final HttpCore.ResponseHandler<T> responseHandler,
 				final Callback<T> callback) {
-			super(method, headers, params, requestBody, withCredentials, responseHandler, callback);
+			super(method, headers, params, requestBody, responseHandler, callback);
 			this.url = url;
 		}
 		@Override
@@ -150,7 +149,7 @@ public class HttpScheduler<Executor extends java.util.concurrent.Executor> {
 				final HttpCore.ResponseHandler<T> responseHandler,
 				final boolean requireAblyAuth,
 				final Callback<T> callback) {
-			super(method, headers, params, requestBody, true, responseHandler, callback);
+			super(method, headers, params, requestBody, responseHandler, callback);
 			this.host = host;
 			this.path = path;
 			this.requireAblyAuth = requireAblyAuth;
@@ -186,7 +185,7 @@ public class HttpScheduler<Executor extends java.util.concurrent.Executor> {
 				final HttpCore.ResponseHandler<T> responseHandler,
 				final boolean requireAblyAuth,
 				final Callback<T> callback) {
-			super(method, headers, params, requestBody, true, responseHandler, callback);
+			super(method, headers, params, requestBody, responseHandler, callback);
 			this.path = path;
 			this.requireAblyAuth = requireAblyAuth;
 		}
@@ -235,7 +234,6 @@ public class HttpScheduler<Executor extends java.util.concurrent.Executor> {
 				final Param[] headers,
 				final Param[] params,
 				final HttpCore.RequestBody requestBody,
-				final boolean withCredentials,
 				final HttpCore.ResponseHandler<T> responseHandler,
 				final Callback<T> callback) {
 			this.method = method;
@@ -358,7 +356,6 @@ public class HttpScheduler<Executor extends java.util.concurrent.Executor> {
 	 * @param method
 	 * @param headers
 	 * @param requestBody
-	 * @param withCredentials
 	 * @param responseHandler
 	 * @param callback
 	 * @return
@@ -368,11 +365,10 @@ public class HttpScheduler<Executor extends java.util.concurrent.Executor> {
 			final String method,
 			final Param[] headers,
 			final HttpCore.RequestBody requestBody,
-			final boolean withCredentials,
 			final HttpCore.ResponseHandler<T> responseHandler,
 			final Callback<T> callback) {
 
-		UrlRequest<T> request = new UrlRequest<>(url, method, headers, null, requestBody, withCredentials, responseHandler, callback);
+		UrlRequest<T> request = new UrlRequest<>(url, method, headers, null, requestBody, responseHandler, callback);
 		executor.execute(request);
 		return request;
 	}

--- a/lib/src/main/java/io/ably/lib/http/HttpScheduler.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpScheduler.java
@@ -107,7 +107,7 @@ public class HttpScheduler<Executor extends java.util.concurrent.Executor> {
 	 * An AsyncRequest type representing a request to a specific URL
 	 * @param <T>
 	 */
-	private class UrlRequest<T> extends AsyncRequest<T> implements Runnable {
+	private class UrlRequest<T> extends AsyncRequest<T> {
 		private UrlRequest(
 				URL url,
 				final String method,
@@ -138,7 +138,7 @@ public class HttpScheduler<Executor extends java.util.concurrent.Executor> {
 	 * supporting reauthentication on receipt of WWW-Authenticate
 	 * @param <T>
 	 */
-	private class AblyRequestWithRetry<T> extends AsyncRequest<T> implements Runnable {
+	private class AblyRequestWithRetry<T> extends AsyncRequest<T> {
 		private AblyRequestWithRetry(
 				String host,
 				String path,
@@ -175,7 +175,7 @@ public class HttpScheduler<Executor extends java.util.concurrent.Executor> {
 	 * supporting host fallback and reauthentication on receipt of WWW-Authenticate
 	 * @param <T>
 	 */
-	private class AblyRequestWithFallback<T> extends AsyncRequest<T> implements Runnable {
+	private class AblyRequestWithFallback<T> extends AsyncRequest<T> {
 		private AblyRequestWithFallback(
 				String path,
 				final String method,
@@ -228,7 +228,7 @@ public class HttpScheduler<Executor extends java.util.concurrent.Executor> {
 	 * A class encapsulating a scheduled or in-process async HTTP request
 	 * @param <T>
 	 */
-	private abstract class AsyncRequest<T> implements Future<T> {
+	private abstract class AsyncRequest<T> implements Future<T>, Runnable {
 		private AsyncRequest(
 				final String method,
 				final Param[] headers,


### PR DESCRIPTION
Fixes #517 

Changes:

* Removed unused ``withCreadentials`` parameter from ``HttpScheduler.AsyncRequest``'s constructor
* Make ``HttpScheduler.AsyncRequest`` implement ``Runnable`` so we are sure all of its children do it.