### PR TITLE
More http encapsulation

### DIFF
--- a/lib/src/main/java/io/ably/lib/http/AsyncHttpScheduler.java
+++ b/lib/src/main/java/io/ably/lib/http/AsyncHttpScheduler.java
@@ -1,9 +1,6 @@
 package io.ably.lib.http;
 
-import io.ably.lib.types.AblyException;
 import io.ably.lib.types.ClientOptions;
-import io.ably.lib.types.ErrorInfo;
-
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -12,23 +9,32 @@ import java.util.concurrent.TimeUnit;
  * A HttpScheduler that uses a thread pool to run HTTP operations.
  */
 class AsyncHttpScheduler extends HttpScheduler<ThreadPoolExecutor> {
-	AsyncHttpScheduler(HttpCore httpCore, ClientOptions options) {
-		super(httpCore, new ThreadPoolExecutor(options.asyncHttpThreadpoolSize, options.asyncHttpThreadpoolSize, KEEP_ALIVE_TIME, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>()));
-		executor.allowsCoreThreadTimeOut();
-	}
+    AsyncHttpScheduler(HttpCore httpCore, ClientOptions options) {
+        super(
+            httpCore,
+            new ThreadPoolExecutor(
+                options.asyncHttpThreadpoolSize,
+                options.asyncHttpThreadpoolSize,
+                KEEP_ALIVE_TIME,
+                TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<Runnable>()
+            )
+        );
+        executor.allowsCoreThreadTimeOut();
+    }
 
-	public void dispose() {
-		ThreadPoolExecutor threadPoolExecutor = executor;
-		threadPoolExecutor.shutdown();
-		try {
-			threadPoolExecutor.awaitTermination(SHUTDOWN_TIME, TimeUnit.MILLISECONDS);
-		} catch (InterruptedException e) {
-			threadPoolExecutor.shutdownNow();
-		}
-	}
+    public void dispose() {
+        ThreadPoolExecutor threadPoolExecutor = executor;
+        threadPoolExecutor.shutdown();
+        try {
+            threadPoolExecutor.awaitTermination(SHUTDOWN_TIME, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            threadPoolExecutor.shutdownNow();
+        }
+    }
 
-	private static final long KEEP_ALIVE_TIME = 2000L;
-	private static final long SHUTDOWN_TIME = 5000L;
+    private static final long KEEP_ALIVE_TIME = 2000L;
+    private static final long SHUTDOWN_TIME = 5000L;
 
-	protected static final String TAG = AsyncHttpScheduler.class.getName();
+    protected static final String TAG = AsyncHttpScheduler.class.getName();
 }

--- a/lib/src/main/java/io/ably/lib/http/AsyncHttpScheduler.java
+++ b/lib/src/main/java/io/ably/lib/http/AsyncHttpScheduler.java
@@ -11,8 +11,8 @@ import java.util.concurrent.TimeUnit;
 /**
  * A HttpScheduler that uses a thread pool to run HTTP operations.
  */
-public class AsyncHttpScheduler extends HttpScheduler<ThreadPoolExecutor> {
-	public AsyncHttpScheduler(HttpCore httpCore, ClientOptions options) {
+class AsyncHttpScheduler extends HttpScheduler<ThreadPoolExecutor> {
+	AsyncHttpScheduler(HttpCore httpCore, ClientOptions options) {
 		super(httpCore, new ThreadPoolExecutor(options.asyncHttpThreadpoolSize, options.asyncHttpThreadpoolSize, KEEP_ALIVE_TIME, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>()));
 		executor.allowsCoreThreadTimeOut();
 	}

--- a/lib/src/main/java/io/ably/lib/http/Http.java
+++ b/lib/src/main/java/io/ably/lib/http/Http.java
@@ -2,6 +2,7 @@ package io.ably.lib.http;
 
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.Callback;
+import io.ably.lib.types.ClientOptions;
 import io.ably.lib.types.ErrorInfo;
 
 /**
@@ -11,9 +12,9 @@ public class Http {
 	private final AsyncHttpScheduler asyncHttp;
 	private final SyncHttpScheduler syncHttp;
 
-	public Http(AsyncHttpScheduler asyncHttp, SyncHttpScheduler syncHttp) {
-		this.asyncHttp = asyncHttp;
-		this.syncHttp = syncHttp;
+	public Http(HttpCore core, ClientOptions options) {
+		this.asyncHttp = new AsyncHttpScheduler(core, options);
+		this.syncHttp = new SyncHttpScheduler(core);
 	}
 
 	public class Request<Result> {

--- a/lib/src/main/java/io/ably/lib/http/HttpScheduler.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpScheduler.java
@@ -20,7 +20,7 @@ import io.ably.lib.util.Log;
  *
  * @param <Executor> The Executor that will run blocking operations.
  */
-public class HttpScheduler<Executor extends java.util.concurrent.Executor> {
+public abstract class HttpScheduler<Executor extends java.util.concurrent.Executor> {
 
 	/**
 	 * Async HTTP GET for Ably host, with fallbacks

--- a/lib/src/main/java/io/ably/lib/http/SyncHttpScheduler.java
+++ b/lib/src/main/java/io/ably/lib/http/SyncHttpScheduler.java
@@ -7,7 +7,7 @@ import io.ably.lib.util.CurrentThreadExecutor;
  */
 class SyncHttpScheduler extends HttpScheduler<CurrentThreadExecutor> {
 
-	SyncHttpScheduler(HttpCore httpCore) {
-		super(httpCore, CurrentThreadExecutor.INSTANCE);
-	}
+    SyncHttpScheduler(HttpCore httpCore) {
+        super(httpCore, CurrentThreadExecutor.INSTANCE);
+    }
 }

--- a/lib/src/main/java/io/ably/lib/http/SyncHttpScheduler.java
+++ b/lib/src/main/java/io/ably/lib/http/SyncHttpScheduler.java
@@ -5,9 +5,9 @@ import io.ably.lib.util.CurrentThreadExecutor;
 /**
  * A HttpScheduler that runs everything in the current thread.
  */
-public class SyncHttpScheduler extends HttpScheduler<CurrentThreadExecutor> {
+class SyncHttpScheduler extends HttpScheduler<CurrentThreadExecutor> {
 
-	public SyncHttpScheduler(HttpCore httpCore) {
+	SyncHttpScheduler(HttpCore httpCore) {
 		super(httpCore, CurrentThreadExecutor.INSTANCE);
 	}
 }

--- a/lib/src/main/java/io/ably/lib/rest/AblyBase.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyBase.java
@@ -3,11 +3,9 @@ package io.ably.lib.rest;
 import java.util.HashMap;
 
 import io.ably.annotation.Experimental;
-import io.ably.lib.http.AsyncHttpScheduler;
 import io.ably.lib.http.Http;
 import io.ably.lib.http.HttpCore;
 import io.ably.lib.http.HttpScheduler;
-import io.ably.lib.http.SyncHttpScheduler;
 import io.ably.lib.http.AsyncHttpPaginatedQuery;
 import io.ably.lib.http.AsyncPaginatedQuery;
 import io.ably.lib.http.HttpPaginatedQuery;
@@ -71,7 +69,7 @@ public abstract class AblyBase {
 
 		auth = new Auth(this, options);
 		httpCore = new HttpCore(options, auth);
-		http = new Http(new AsyncHttpScheduler(httpCore, options), new SyncHttpScheduler(httpCore));
+		http = new Http(httpCore, options);
 		channels = new Channels();
 		platform = new Platform();
 		push = new Push(this);
@@ -110,7 +108,7 @@ public abstract class AblyBase {
 	/**
 	 * Obtain the time from the Ably service.
 	 * This may be required on clients that do not have access
-	 * to a sufficiently well maintained time source, to provide 
+	 * to a sufficiently well maintained time source, to provide
 	 * timestamps for use in token requests
 	 * @return time in millis since the epoch
 	 * @throws AblyException
@@ -122,7 +120,7 @@ public abstract class AblyBase {
 	/**
 	 * Asynchronously obtain the time from the Ably service.
 	 * This may be required on clients that do not have access
-	 * to a sufficiently well maintained time source, to provide 
+	 * to a sufficiently well maintained time source, to provide
 	 * timestamps for use in token requests
 	 * @param callback
 	 */

--- a/lib/src/test/java/io/ably/lib/test/rest/HttpTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/HttpTest.java
@@ -135,7 +135,7 @@ public class HttpTest {
 			}
 		}.setUrlArgumentStack(urlHostArgumentStack);
 
-		Http http = new Http(new AsyncHttpScheduler(httpCore, options), new SyncHttpScheduler(httpCore));
+		Http http = new Http(httpCore, options);
 		try {
 			HttpHelpers.ablyHttpExecute(
 					http, "/path/to/fallback", /* Ignore path */
@@ -196,7 +196,7 @@ public class HttpTest {
 			}
 		}.setUrlArgumentStack(urlHostArgumentStack);
 
-		Http http = new Http(new AsyncHttpScheduler(httpCore, options), new SyncHttpScheduler(httpCore));
+		Http http = new Http(httpCore, options);
 		try {
 			HttpHelpers.ablyHttpExecute(
 					http, "/path/to/fallback", /* Ignore path */
@@ -265,7 +265,7 @@ public class HttpTest {
 						any(HttpCore.ResponseHandler.class) /* Ignore */
 				);
 
-		Http http = new Http(new AsyncHttpScheduler(httpCore, options), new SyncHttpScheduler(httpCore));
+		Http http = new Http(httpCore, options);
 		String responseActual = (String) HttpHelpers.ablyHttpExecute(
 				http, "", /* Ignore */
 				"", /* Ignore */
@@ -354,7 +354,7 @@ public class HttpTest {
 						any(HttpCore.ResponseHandler.class) /* Ignore */
 				);
 
-		Http http = new Http(new AsyncHttpScheduler(httpCore, options), new SyncHttpScheduler(httpCore));
+		Http http = new Http(httpCore, options);
 		try {
 			HttpHelpers.ablyHttpExecute(
 					http, "", /* Ignore */
@@ -450,7 +450,7 @@ public class HttpTest {
 						any(HttpCore.ResponseHandler.class) /* Ignore */
 				);
 
-		Http http = new Http(new AsyncHttpScheduler(httpCore, options), new SyncHttpScheduler(httpCore));
+		Http http = new Http(httpCore, options);
 		try {
 			HttpHelpers.ablyHttpExecute(
 					http, "", /* Ignore */
@@ -530,7 +530,7 @@ public class HttpTest {
 						any(HttpCore.ResponseHandler.class) /* Ignore */
 				);
 
-		Http http = new Http(new AsyncHttpScheduler(httpCore, options), new SyncHttpScheduler(httpCore));
+		Http http = new Http(httpCore, options);
 		String responseActual = (String) HttpHelpers.ablyHttpExecute(
 				http, "", /* Ignore */
 				"", /* Ignore */
@@ -599,7 +599,7 @@ public class HttpTest {
 			}
 		}.setUrlArgumentStack(urlHostArgumentStack);
 
-		Http http = new Http(new AsyncHttpScheduler(httpCore, options), new SyncHttpScheduler(httpCore));
+		Http http = new Http(httpCore, options);
 		try {
 			HttpHelpers.ablyHttpExecute(
 					http, "/path/to/fallback", /* Ignore path */
@@ -660,7 +660,7 @@ public class HttpTest {
 						any(HttpCore.ResponseHandler.class) /* Ignore */
 				);
 
-		Http http = new Http(new AsyncHttpScheduler(httpCore, new ClientOptions()), new SyncHttpScheduler(httpCore));
+		Http http = new Http(httpCore, new ClientOptions());
 		String responseActual = (String) HttpHelpers.ablyHttpExecute(
 				http, "", /* Ignore */
 				"", /* Ignore */
@@ -730,7 +730,7 @@ public class HttpTest {
 				);
 
 		/* Call method with real parameters */
-		Http http = new Http(new AsyncHttpScheduler(httpCore, new ClientOptions()), new SyncHttpScheduler(httpCore));
+		Http http = new Http(httpCore, new ClientOptions());
 		String responseActual = (String) HttpHelpers.ablyHttpExecute(
 				http, "", /* Ignore */
 				"", /* Ignore */
@@ -800,7 +800,7 @@ public class HttpTest {
 						any(HttpCore.ResponseHandler.class) /* Ignore */
 				);
 
-		Http http = new Http(new AsyncHttpScheduler(httpCore, new ClientOptions()), new SyncHttpScheduler(httpCore));
+		Http http = new Http(httpCore, new ClientOptions());
 		String responseActual = (String) HttpHelpers.ablyHttpExecute(
 				http, "", /* Ignore */
 				"", /* Ignore */
@@ -880,7 +880,7 @@ public class HttpTest {
 						any(HttpCore.ResponseHandler.class) /* Ignore */
 				);
 
-		Http http = new Http(new AsyncHttpScheduler(httpCore, new ClientOptions()), new SyncHttpScheduler(httpCore));
+		Http http = new Http(httpCore, new ClientOptions());
 		HttpHelpers.ablyHttpExecute(
 				http, "", /* Ignore */
 				"", /* Ignore */
@@ -967,7 +967,7 @@ public class HttpTest {
 						any(HttpCore.ResponseHandler.class) /* Ignore */
 				);
 
-		Http http = new Http(new AsyncHttpScheduler(httpCore, new ClientOptions()), new SyncHttpScheduler(httpCore));
+		Http http = new Http(httpCore, new ClientOptions());
 		HttpHelpers.ablyHttpExecute(
 				http, "", /* Ignore */
 				"", /* Ignore */
@@ -1058,7 +1058,7 @@ public class HttpTest {
 						any(HttpCore.ResponseHandler.class) /* Ignore */
 				);
 
-		Http http = new Http(new AsyncHttpScheduler(httpCore, new ClientOptions()), new SyncHttpScheduler(httpCore));
+		Http http = new Http(httpCore, new ClientOptions());
 		HttpHelpers.ablyHttpExecute(
 				http, "", /* Ignore */
 				"", /* Ignore */
@@ -1148,7 +1148,7 @@ public class HttpTest {
 		 */
 		thrown.expect(AblyException.HostFailedException.class);
 
-		Http http = new Http(new AsyncHttpScheduler(httpCore, new ClientOptions()), new SyncHttpScheduler(httpCore));
+		Http http = new Http(httpCore, new ClientOptions());
 		HttpHelpers.ablyHttpExecute(
 				http, "", /* Ignore */
 				"", /* Ignore */


### PR DESCRIPTION
For #516 

* made HttpScheduler abstract (as I understand it has to be extended always, in order for the Executor to be povided).

* made AsyncHttpScheduler and SyncHttpScheduler package protected

* refactored ``Http``'s constructor to accept ``HttpCore`` and ``ClientOptions`` from which it will build the encapsulated ``AsyncHttpScheduler`` and ``SyncHttpScheduler`` itself.