### PR TITLE
[WIP] Fix some ConnectionManager tests

### DIFF
--- a/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
@@ -63,19 +63,18 @@ public class ConnectionManagerTest extends ParameterizedTest {
 	@Test
 	public void connectionmanager_fallback_none() throws AblyException {
 		ClientOptions opts = createOptions(testVars.keys[0].keyStr);
-		AblyRealtime ably = new AblyRealtime(opts);
-		ConnectionManager connectionManager = ably.connection.connectionManager;
+		try (AblyRealtime ably = new AblyRealtime(opts)) {
+			ConnectionManager connectionManager = ably.connection.connectionManager;
 
-		new Helpers.ConnectionWaiter(ably.connection).waitFor(ConnectionState.connected);
+			new Helpers.ConnectionWaiter(ably.connection).waitFor(ConnectionState.connected);
 
-		/* Verify that,
-		 *   - connectionManager is connected
-		 *   - connectionManager is connected to the host without any fallback
-		 */
-		assertThat(connectionManager.getConnectionState().state, is(ConnectionState.connected));
-		assertThat(connectionManager.getHost(), is(equalTo(opts.environment + "-realtime.ably.io")));
-
-		ably.close();
+			/* Verify that,
+			 *   - connectionManager is connected
+			 *   - connectionManager is connected to the host without any fallback
+			 */
+			assertThat(connectionManager.getConnectionState().state, is(ConnectionState.connected));
+			assertThat(connectionManager.getHost(), is(equalTo(opts.environment + "-realtime.ably.io")));
+		}
 	}
 
 	/**
@@ -94,19 +93,18 @@ public class ConnectionManagerTest extends ParameterizedTest {
 		ClientOptions opts = createOptions(testVars.keys[0].keyStr);
 		opts.realtimeHost = "un.reachable.host.example.com";
 		opts.environment = null;
-		AblyRealtime ably = new AblyRealtime(opts);
-		ConnectionManager connectionManager = ably.connection.connectionManager;
+		try(AblyRealtime ably = new AblyRealtime(opts)) {
+			ConnectionManager connectionManager = ably.connection.connectionManager;
 
-		new Helpers.ConnectionWaiter(ably.connection).waitFor(ConnectionState.disconnected);
+			new Helpers.ConnectionWaiter(ably.connection).waitFor(ConnectionState.disconnected);
 
-		/* Verify that,
-		 *   - connectionManager is disconnected
-		 *   - connectionManager's last host did not have any fallback
-		 */
-		assertThat(connectionManager.getConnectionState().state, is(ConnectionState.disconnected));
-		assertThat(connectionManager.getHost(), is(equalTo(opts.realtimeHost)));
-
-		ably.close();
+			/* Verify that,
+			 *   - connectionManager is disconnected
+			 *   - connectionManager's last host did not have any fallback
+			 */
+			assertThat(connectionManager.getConnectionState().state, is(ConnectionState.disconnected));
+			assertThat(connectionManager.getHost(), is(equalTo(opts.realtimeHost)));
+		}
 	}
 
 	/**
@@ -127,28 +125,29 @@ public class ConnectionManagerTest extends ParameterizedTest {
 		opts.realtimeHost = "un.reachable.host";
 		opts.environment = null;
 		opts.autoConnect = false;
-		AblyRealtime ably = new AblyRealtime(opts);
-		Connection connection = Mockito.mock(Connection.class);
+		try(AblyRealtime ably = new AblyRealtime(opts)) {
+			Connection connection = Mockito.mock(Connection.class);
 
-		ConnectionManager connectionManager = new ConnectionManager(ably, connection) {
-			@Override
-			protected boolean checkConnectivity() {
-				return false;
-			}
-		};
+			ConnectionManager connectionManager = new ConnectionManager(ably, connection) {
+				@Override
+				protected boolean checkConnectivity() {
+					return false;
+				}
+			};
 
-		connectionManager.connect();
+			connectionManager.connect();
 
-		new Helpers.ConnectionManagerWaiter(connectionManager).waitFor(ConnectionState.disconnected);
+			new Helpers.ConnectionManagerWaiter(connectionManager).waitFor(ConnectionState.disconnected);
 
-		/* Verify that,
-		 *   - connectionManager is disconnected
-		 *   - connectionManager did not apply any fallback behavior
-		 */
-		assertThat(connectionManager.getConnectionState().state, is(ConnectionState.disconnected));
-		assertThat(connectionManager.getHost(), is(equalTo(opts.realtimeHost)));
+			/* Verify that,
+			 *   - connectionManager is disconnected
+			 *   - connectionManager did not apply any fallback behavior
+			 */
+			assertThat(connectionManager.getConnectionState().state, is(ConnectionState.disconnected));
+			assertThat(connectionManager.getHost(), is(equalTo(opts.realtimeHost)));
 
-		connectionManager.close();
+			connectionManager.close();
+		}
 	}
 
 	/**
@@ -175,19 +174,18 @@ public class ConnectionManagerTest extends ParameterizedTest {
 		 * instead of taking 15s to time out at each fallback host. */
 		opts.tls = true;
 		opts.tlsPort = 80;
-		AblyRealtime ably = new AblyRealtime(opts);
-		ConnectionManager connectionManager = ably.connection.connectionManager;
+		try(AblyRealtime ably = new AblyRealtime(opts)) {
+			ConnectionManager connectionManager = ably.connection.connectionManager;
 
-		new Helpers.ConnectionWaiter(ably.connection).waitFor(ConnectionState.disconnected);
+			new Helpers.ConnectionWaiter(ably.connection).waitFor(ConnectionState.disconnected);
 
-		/* Verify that,
-		 *   - connectionManager is disconnected
-		 *   - connectionManager's last host was a fallback host
-		 */
-		assertThat(connectionManager.getConnectionState().state, is(ConnectionState.disconnected));
-		assertThat(connectionManager.getHost(), is(not(equalTo(opts.realtimeHost))));
-
-		ably.close();
+			/* Verify that,
+			 *   - connectionManager is disconnected
+			 *   - connectionManager's last host was a fallback host
+			 */
+			assertThat(connectionManager.getConnectionState().state, is(ConnectionState.disconnected));
+			assertThat(connectionManager.getHost(), is(not(equalTo(opts.realtimeHost))));
+		}
 	}
 
 	/**
@@ -209,38 +207,37 @@ public class ConnectionManagerTest extends ParameterizedTest {
 		 * instead of taking 15s to time out at each fallback host. */
 		opts.tls = true;
 		opts.tlsPort = 80;
-		AblyRealtime ably = new AblyRealtime(opts);
-		ConnectionManager connectionManager = ably.connection.connectionManager;
+		try(AblyRealtime ably = new AblyRealtime(opts)) {
+			ConnectionManager connectionManager = ably.connection.connectionManager;
 
-		System.out.println("waiting for disconnected");
-		new Helpers.ConnectionWaiter(ably.connection).waitFor(ConnectionState.disconnected);
-		System.out.println("got disconnected");
+			System.out.println("waiting for disconnected");
+			new Helpers.ConnectionWaiter(ably.connection).waitFor(ConnectionState.disconnected);
+			System.out.println("got disconnected");
 
-		/* Verify that,
-		 *   - connectionManager is disconnected
-		 *   - connectionManager's last host was a fallback host
-		 */
-		assertThat(connectionManager.getConnectionState().state, is(ConnectionState.disconnected));
-		assertThat(connectionManager.getHost(), is(not(equalTo("realtime.ably.io"))));
+			/* Verify that,
+			 *   - connectionManager is disconnected
+			 *   - connectionManager's last host was a fallback host
+			 */
+			assertThat(connectionManager.getConnectionState().state, is(ConnectionState.disconnected));
+			assertThat(connectionManager.getHost(), is(not(equalTo("realtime.ably.io"))));
 
-		/* Reconnect */
-		ably.options.tlsPort = Defaults.TLS_PORT;
-		System.out.println("about to connect");
-		ably.connection.connect();
+			/* Reconnect */
+			ably.options.tlsPort = Defaults.TLS_PORT;
+			System.out.println("about to connect");
+			ably.connection.connect();
 
-		new Helpers.ConnectionWaiter(ably.connection).waitFor(ConnectionState.failed);
+			new Helpers.ConnectionWaiter(ably.connection).waitFor(ConnectionState.failed);
 
-		/* Verify that,
-		 *   - connectionManager is failed, because we are using an application key
-		 *     that only works on sandbox;
-		 *   - connectionManager first tried to connect to the original host, not a fallback one.
-		 */
-		System.out.println("waiting for failed");
-		assertThat(connectionManager.getConnectionState().state, is(ConnectionState.failed));
-		System.out.println("got failed");
-		assertThat(connectionManager.getHost(), is(equalTo("realtime.ably.io")));
-
-		ably.close();
+			/* Verify that,
+			 *   - connectionManager is failed, because we are using an application key
+			 *     that only works on sandbox;
+			 *   - connectionManager first tried to connect to the original host, not a fallback one.
+			 */
+			System.out.println("waiting for failed");
+			assertThat(connectionManager.getConnectionState().state, is(ConnectionState.failed));
+			System.out.println("got failed");
+			assertThat(connectionManager.getHost(), is(equalTo("realtime.ably.io")));
+		}
 	}
 
 	/**
@@ -260,22 +257,21 @@ public class ConnectionManagerTest extends ParameterizedTest {
 		 * instead of taking 15s to time out at each fallback host. */
 		opts.tls = true;
 		opts.tlsPort = 80;
-		AblyRealtime ably = new AblyRealtime(opts);
-		ConnectionManager connectionManager = ably.connection.connectionManager;
+		try(AblyRealtime ably = new AblyRealtime(opts)) {
+			ConnectionManager connectionManager = ably.connection.connectionManager;
 
-		System.out.println("waiting for disconnected");
-		new Helpers.ConnectionWaiter(ably.connection).waitFor(ConnectionState.disconnected);
-		System.out.println("got disconnected");
-		ably.close();
+			System.out.println("waiting for disconnected");
+			new Helpers.ConnectionWaiter(ably.connection).waitFor(ConnectionState.disconnected);
+			System.out.println("got disconnected");
+			ably.close();
 
-		/* Verify that,
-		 *   - connectionManager is disconnected
-		 *   - connectionManager's last host was a fallback host
-		 */
-		assertThat(connectionManager.getConnectionState().state, is(ConnectionState.disconnected));
-		assertThat(connectionManager.getHost(), is(not(equalTo(opts.realtimeHost))));
-
-		ably.close();
+			/* Verify that,
+			 *   - connectionManager is disconnected
+			 *   - connectionManager's last host was a fallback host
+			 */
+			assertThat(connectionManager.getConnectionState().state, is(ConnectionState.disconnected));
+			assertThat(connectionManager.getHost(), is(not(equalTo(opts.realtimeHost))));
+		}
 	}
 
 	/**
@@ -283,31 +279,26 @@ public class ConnectionManagerTest extends ParameterizedTest {
 	 * verify that the closed state is reached, and the connectionmanager thread has exited
 	 */
 	@Test
-	public void close_from_connectionmanager() {
+	public void close_from_connectionmanager() throws AblyException {
+		ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+		final AblyRealtime ably = new AblyRealtime(opts);
+		final Thread[] threadContainer = new Thread[1];
+		ably.connection.on(ConnectionEvent.connected, new ConnectionStateListener() {
+			@Override
+			public void onConnectionStateChanged(ConnectionStateChange state) {
+				ably.close();
+				threadContainer[0] = Thread.currentThread();
+			}
+		});
+
+		/* wait for cm thread to exit */
 		try {
-			ClientOptions opts = createOptions(testVars.keys[0].keyStr);
-			final AblyRealtime ably = new AblyRealtime(opts);
-			final Thread[] threadContainer = new Thread[1];
-			ably.connection.on(ConnectionEvent.connected, new ConnectionStateListener() {
-				@Override
-				public void onConnectionStateChanged(ConnectionStateChange state) {
-					ably.close();
-					threadContainer[0] = Thread.currentThread();
-				}
-			});
+			Thread.sleep(2000L);
+		} catch(InterruptedException e) {}
 
-			/* wait for cm thread to exit */
-			try {
-				Thread.sleep(2000L);
-			} catch(InterruptedException e) {}
-
-			assertEquals("Verify closed state is reached", ConnectionState.closed, ably.connection.state);
-			Thread.State cmThreadState = threadContainer[0].getState();
-			assertEquals("Verify cm thread has exited", cmThreadState, Thread.State.TERMINATED);
-		} catch (AblyException e) {
-			e.printStackTrace();
-			fail("init0: Unexpected exception instantiating library");
-		}
+		assertEquals("Verify closed state is reached", ConnectionState.closed, ably.connection.state);
+		Thread.State cmThreadState = threadContainer[0].getState();
+		assertEquals("Verify cm thread has exited", cmThreadState, Thread.State.TERMINATED);
 	}
 
 	/**
@@ -316,150 +307,133 @@ public class ConnectionManagerTest extends ParameterizedTest {
 	 * reconnect; verify that it reconnects successfully
 	 */
 	@Test
-	public void connectionmanager_restart_race() {
-		try {
-			ClientOptions opts = createOptions(testVars.keys[0].keyStr);
-			final AblyRealtime ably = new AblyRealtime(opts);
-			ConnectionWaiter connectionWaiter = new ConnectionWaiter(ably.connection);
+	public void connectionmanager_restart_race() throws AblyException {
+		ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+		final AblyRealtime ably = new AblyRealtime(opts);
+		ConnectionWaiter connectionWaiter = new ConnectionWaiter(ably.connection);
 
-			ably.connection.once(ConnectionEvent.connected, new ConnectionStateListener() {
-				@Override
-				public void onConnectionStateChanged(ConnectionStateChange state) {
+		ably.connection.once(ConnectionEvent.connected, new ConnectionStateListener() {
+			@Override
+			public void onConnectionStateChanged(ConnectionStateChange state) {
+				ably.close();
+			}
+		});
+
+		connectionWaiter.waitFor(ConnectionState.closed);
+		assertEquals("Verify closed state is reached", ConnectionState.closed, ably.connection.state);
+		connectionWaiter.reset();
+
+		/* reconnect */
+		ably.connect();
+
+		/* verify the connection is reestablished */
+		connectionWaiter.waitFor(ConnectionState.connected);
+		assertEquals("Verify connected state is reached", ConnectionState.connected, ably.connection.state);
+
+		/* close the connection */
+		ably.close();
+		connectionWaiter.waitFor(ConnectionState.closed);
+		assertEquals("Verify closed state is reached", ConnectionState.closed, ably.connection.state);
+	}
+
+	/**
+	 * Connect, and then perform a close() from the calling ConnectionManager context;
+	 * verify that the closed state is reached, and the connectionmanager thread has exited
+	 */
+	@Test
+	public void open_from_dedicated_thread() throws AblyException {
+		ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+		opts.autoConnect = false;
+		final AblyRealtime ably = new AblyRealtime(opts);
+		final Thread[] threadContainer = new Thread[1];
+		ably.connection.on(ConnectionEvent.connected, new ConnectionStateListener() {
+			@Override
+			public void onConnectionStateChanged(ConnectionStateChange state) {
+				threadContainer[0] = Thread.currentThread();
+			}
+		});
+
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		executor.submit(new Runnable() {
+			public void run() {
+				try {
+					ably.connection.connect();
+				} catch (Throwable t) {
+					t.printStackTrace();
+				}
+			}
+		});
+
+		ConnectionWaiter connectionWaiter = new ConnectionWaiter(ably.connection);
+
+		connectionWaiter.waitFor(ConnectionState.connected);
+		assertEquals("Verify connected state is reached", ConnectionState.connected, ably.connection.state);
+		assertTrue("Not expecting token auth", ably.auth.getAuthMethod() == AuthMethod.basic);
+
+		ably.close();
+		connectionWaiter.waitFor(ConnectionState.closed);
+		assertEquals("Verify closed state is reached", ConnectionState.closed, ably.connection.state);
+
+		/* wait for cm thread to exit */
+		try {
+			Thread.sleep(2000L);
+		} catch(InterruptedException e) {}
+
+		Thread.State cmThreadState = threadContainer[0].getState();
+		assertEquals("Verify cm thread has exited", cmThreadState, Thread.State.TERMINATED);
+	}
+
+	/**
+	 * Connect, and then perform a close() from the calling ConnectionManager context;
+	 * verify that the closed state is reached, and the connectionmanager thread has exited
+	 */
+	@Test
+	public void close_from_dedicated_thread() throws AblyException {
+		ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+		opts.autoConnect = false;
+		final AblyRealtime ably = new AblyRealtime(opts);
+		final Thread[] threadContainer = new Thread[1];
+		ably.connection.on(ConnectionEvent.connected, new ConnectionStateListener() {
+			@Override
+			public void onConnectionStateChanged(ConnectionStateChange state) {
+				threadContainer[0] = Thread.currentThread();
+			}
+		});
+
+		ably.connection.connect();
+		final ConnectionWaiter connectionWaiter = new ConnectionWaiter(ably.connection);
+		connectionWaiter.waitFor(ConnectionState.connected);
+		assertEquals("Verify connected state is reached", ConnectionState.connected, ably.connection.state);
+
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		executor.submit(new Runnable() {
+			public void run() {
+				try {
 					ably.close();
-				}
-			});
+					connectionWaiter.waitFor(ConnectionState.closed);
+					assertEquals("Verify closed state is reached", ConnectionState.closed, ably.connection.state);
 
-			connectionWaiter.waitFor(ConnectionState.closed);
-			assertEquals("Verify closed state is reached", ConnectionState.closed, ably.connection.state);
-			connectionWaiter.reset();
-
-			/* reconnect */
-			ably.connect();
-
-			/* verify the connection is reestablished */
-			connectionWaiter.waitFor(ConnectionState.connected);
-			assertEquals("Verify connected state is reached", ConnectionState.connected, ably.connection.state);
-
-			/* close the connection */
-			ably.close();
-			connectionWaiter.waitFor(ConnectionState.closed);
-			assertEquals("Verify closed state is reached", ConnectionState.closed, ably.connection.state);
-		} catch (AblyException e) {
-			e.printStackTrace();
-			fail("init0: Unexpected exception instantiating library");
-		}
-	}
-
-	/**
-	 * Connect, and then perform a close() from the calling ConnectionManager context;
-	 * verify that the closed state is reached, and the connectionmanager thread has exited
-	 */
-	@Test
-	public void open_from_dedicated_thread() {
-		try {
-			ClientOptions opts = createOptions(testVars.keys[0].keyStr);
-			opts.autoConnect = false;
-			final AblyRealtime ably = new AblyRealtime(opts);
-			final Thread[] threadContainer = new Thread[1];
-			ably.connection.on(ConnectionEvent.connected, new ConnectionStateListener() {
-				@Override
-				public void onConnectionStateChanged(ConnectionStateChange state) {
-					threadContainer[0] = Thread.currentThread();
-				}
-			});
-
-			ExecutorService executor = Executors.newSingleThreadExecutor();
-			executor.submit(new Runnable() {
-				public void run() {
+					/* wait for cm thread to exit */
 					try {
-						ably.connection.connect();
-					} catch (Throwable t) {
-						t.printStackTrace();
-					}
+						Thread.sleep(2000L);
+					} catch(InterruptedException e) {}
+
+					Thread.State cmThreadState = threadContainer[0].getState();
+					assertEquals("Verify cm thread has exited", cmThreadState, Thread.State.TERMINATED);
+				} catch (Throwable t) {
+					t.printStackTrace();
 				}
-			});
-
-			ConnectionWaiter connectionWaiter = new ConnectionWaiter(ably.connection);
-
-			connectionWaiter.waitFor(ConnectionState.connected);
-			assertEquals("Verify connected state is reached", ConnectionState.connected, ably.connection.state);
-			assertTrue("Not expecting token auth", ably.auth.getAuthMethod() == AuthMethod.basic);
-
-			ably.close();
-			connectionWaiter.waitFor(ConnectionState.closed);
-			assertEquals("Verify closed state is reached", ConnectionState.closed, ably.connection.state);
-
-			/* wait for cm thread to exit */
-			try {
-				Thread.sleep(2000L);
-			} catch(InterruptedException e) {}
-
-			Thread.State cmThreadState = threadContainer[0].getState();
-			assertEquals("Verify cm thread has exited", cmThreadState, Thread.State.TERMINATED);
-		} catch (AblyException e) {
-			e.printStackTrace();
-			fail("init0: Unexpected exception instantiating library");
-		}
-	}
-
-	/**
-	 * Connect, and then perform a close() from the calling ConnectionManager context;
-	 * verify that the closed state is reached, and the connectionmanager thread has exited
-	 */
-	@Test
-	public void close_from_dedicated_thread() {
-		try {
-			ClientOptions opts = createOptions(testVars.keys[0].keyStr);
-			opts.autoConnect = false;
-			final AblyRealtime ably = new AblyRealtime(opts);
-			final Thread[] threadContainer = new Thread[1];
-			ably.connection.on(ConnectionEvent.connected, new ConnectionStateListener() {
-				@Override
-				public void onConnectionStateChanged(ConnectionStateChange state) {
-					threadContainer[0] = Thread.currentThread();
-				}
-			});
-
-			ably.connection.connect();
-			final ConnectionWaiter connectionWaiter = new ConnectionWaiter(ably.connection);
-			connectionWaiter.waitFor(ConnectionState.connected);
-			assertEquals("Verify connected state is reached", ConnectionState.connected, ably.connection.state);
-
-			ExecutorService executor = Executors.newSingleThreadExecutor();
-			executor.submit(new Runnable() {
-				public void run() {
-					try {
-						ably.close();
-						connectionWaiter.waitFor(ConnectionState.closed);
-						assertEquals("Verify closed state is reached", ConnectionState.closed, ably.connection.state);
-
-						/* wait for cm thread to exit */
-						try {
-							Thread.sleep(2000L);
-						} catch(InterruptedException e) {}
-
-						Thread.State cmThreadState = threadContainer[0].getState();
-						assertEquals("Verify cm thread has exited", cmThreadState, Thread.State.TERMINATED);
-					} catch (Throwable t) {
-						t.printStackTrace();
-					}
-				}
-			});
-
-		} catch (AblyException e) {
-			e.printStackTrace();
-			fail("init0: Unexpected exception instantiating library");
-		}
+			}
+		});
 	}
 
 	/**
 	 * Connect and then verify that the connection manager has the default value for connectionStateTtl;
 	 */
 	@Test
-	public void connection_details_has_ttl() {
-		try {
-			ClientOptions opts = createOptions(testVars.keys[0].keyStr);
-			final AblyRealtime ably = new AblyRealtime(opts);
+	public void connection_details_has_ttl() throws AblyException {
+		ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+		try (final AblyRealtime ably = new AblyRealtime(opts)) {
 			final boolean[] callbackWasRun = new boolean[1];
 			ably.connection.on(ConnectionEvent.connected, new ConnectionStateListener() {
 				@Override
@@ -469,17 +443,13 @@ public class ConnectionManagerTest extends ParameterizedTest {
 						Field field = ably.connection.connectionManager.getClass().getDeclaredField("connectionStateTtl");
 						field.setAccessible(true);
 						assertEquals("Verify connectionStateTtl has the default value", field.get(ably.connection.connectionManager), 120000L);
-					} catch (NoSuchFieldException|IllegalAccessException e) {
+					} catch (NoSuchFieldException | IllegalAccessException e) {
 						fail("Unexpected exception in checking connectionStateTtl");
 					}
 				}
 			});
 			new Helpers.ConnectionWaiter(ably.connection).waitFor(ConnectionState.connected);
 			assertTrue("Connected callback was not run", callbackWasRun[0]);
-			ably.close();
-		} catch (AblyException e) {
-			e.printStackTrace();
-			fail("init0: Unexpected exception instantiating library");
 		}
 	}
 
@@ -488,11 +458,10 @@ public class ConnectionManagerTest extends ParameterizedTest {
 	 * check that the connection is a new one;
 	 */
 	@Test
-	public void connection_has_new_id_when_reconnecting_after_statettl_plus_idleinterval_has_passed() {
-		try {
-			ClientOptions opts = createOptions(testVars.keys[0].keyStr);
-			opts.realtimeRequestTimeout = 2000L;
-			final AblyRealtime ably = new AblyRealtime(opts);
+	public void connection_has_new_id_when_reconnecting_after_statettl_plus_idleinterval_has_passed() throws AblyException {
+		ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+		opts.realtimeRequestTimeout = 2000L;
+		try(final AblyRealtime ably = new AblyRealtime(opts)) {
 			final long newTtl = 1000L;
 			final long newIdleInterval = 1000L;
 			/* We want this greater than newTtl + newIdleInterval */
@@ -508,7 +477,7 @@ public class ConnectionManagerTest extends ParameterizedTest {
 						Field maxIdleField = ably.connection.connectionManager.getClass().getDeclaredField("maxIdleInterval");
 						maxIdleField.setAccessible(true);
 						maxIdleField.setLong(ably.connection.connectionManager, newIdleInterval);
-					} catch (NoSuchFieldException|IllegalAccessException e) {
+					} catch (NoSuchFieldException | IllegalAccessException e) {
 						fail("Unexpected exception in checking connectionStateTtl");
 					}
 				}
@@ -523,14 +492,17 @@ public class ConnectionManagerTest extends ParameterizedTest {
 				Method method = ably.connection.connectionManager.getClass().getDeclaredMethod("disconnectAndSuppressRetries");
 				method.setAccessible(true);
 				method.invoke(ably.connection.connectionManager);
-			} catch (NoSuchMethodException|IllegalAccessException|InvocationTargetException e) {
+			} catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
 				fail("Unexpected exception in suppressing retries");
 			}
 			connectionWaiter.waitFor(ConnectionState.disconnected);
 			assertEquals("Disconnected state was not reached", ConnectionState.disconnected, ably.connection.state);
 
 			/* Wait for the connection to go stale, then reconnect */
-			try { Thread.sleep(waitInDisconnectedState); } catch(InterruptedException e) {}
+			try {
+				Thread.sleep(waitInDisconnectedState);
+			} catch (InterruptedException e) {
+			}
 			ably.connection.connect();
 			connectionWaiter.waitFor(ConnectionState.connected);
 			assertEquals("Connected state was not reached", ConnectionState.connected, ably.connection.state);
@@ -538,10 +510,6 @@ public class ConnectionManagerTest extends ParameterizedTest {
 			/* Verify the connection is new */
 			assertNotNull(ably.connection.id);
 			assertNotEquals("Connection has the same id", firstConnectionId, ably.connection.id);
-			ably.close();
-		} catch (AblyException e) {
-			e.printStackTrace();
-			fail("init0: Unexpected exception instantiating library");
 		}
 	}
 
@@ -550,11 +518,9 @@ public class ConnectionManagerTest extends ParameterizedTest {
 	 * check that the connection is the same;
 	 */
 	@Test
-	public void connection_has_same_id_when_reconnecting_before_statettl_plus_idleinterval_has_passed() {
-		try {
-			ClientOptions opts = createOptions(testVars.keys[0].keyStr);
-			final AblyRealtime ably = new AblyRealtime(opts);
-
+	public void connection_has_same_id_when_reconnecting_before_statettl_plus_idleinterval_has_passed() throws AblyException {
+		ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+		try(final AblyRealtime ably = new AblyRealtime(opts)) {
 			ConnectionWaiter connectionWaiter = new ConnectionWaiter(ably.connection);
 			connectionWaiter.waitFor(ConnectionState.connected);
 			String firstConnectionId = ably.connection.id;
@@ -566,10 +532,6 @@ public class ConnectionManagerTest extends ParameterizedTest {
 			String secondConnectionId = ably.connection.id;
 			assertNotNull(secondConnectionId);
 			assertEquals("connection has the same id", firstConnectionId, secondConnectionId);
-			ably.close();
-		} catch (AblyException e) {
-			e.printStackTrace();
-			fail("init0: Unexpected exception instantiating library");
 		}
 	}
 
@@ -579,10 +541,9 @@ public class ConnectionManagerTest extends ParameterizedTest {
 	 * connection are correctly reattached;
 	 */
 	@Test
-	public void channels_are_reattached_after_reconnecting_when_statettl_plus_idleinterval_has_passed() {
-		try {
-			ClientOptions opts = createOptions(testVars.keys[0].keyStr);
-			final AblyRealtime ably = new AblyRealtime(opts);
+	public void channels_are_reattached_after_reconnecting_when_statettl_plus_idleinterval_has_passed() throws AblyException {
+		ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+		try(final AblyRealtime ably = new AblyRealtime(opts)) {
 			final long newTtl = 1000L;
 			final long newIdleInterval = 1000L;
 			/* We want this greater than newTtl + newIdleInterval */
@@ -601,7 +562,7 @@ public class ConnectionManagerTest extends ParameterizedTest {
 						Field maxIdleField = ably.connection.connectionManager.getClass().getDeclaredField("maxIdleInterval");
 						maxIdleField.setAccessible(true);
 						maxIdleField.setLong(ably.connection.connectionManager, newIdleInterval);
-					} catch (NoSuchFieldException|IllegalAccessException e) {
+					} catch (NoSuchFieldException | IllegalAccessException e) {
 						fail("Unexpected exception in checking connectionStateTtl");
 					}
 				}
@@ -639,14 +600,17 @@ public class ConnectionManagerTest extends ParameterizedTest {
 				Method method = ably.connection.connectionManager.getClass().getDeclaredMethod("disconnectAndSuppressRetries");
 				method.setAccessible(true);
 				method.invoke(ably.connection.connectionManager);
-			} catch (NoSuchMethodException|IllegalAccessException|InvocationTargetException e) {
+			} catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
 				fail("Unexpected exception in suppressing retries");
 			}
 			connectionWaiter.waitFor(ConnectionState.disconnected);
 			assertEquals("Disconnected state was not reached", ConnectionState.disconnected, ably.connection.state);
 
 			/* Wait for the connection to go stale, then reconnect */
-			try { Thread.sleep(waitInDisconnectedState); } catch(InterruptedException e) {}
+			try {
+				Thread.sleep(waitInDisconnectedState);
+			} catch (InterruptedException e) {
+			}
 			ably.connection.connect();
 			connectionWaiter.waitFor(ConnectionState.connected);
 			assertEquals("Connected state was not reached", ConnectionState.connected, ably.connection.state);
@@ -668,10 +632,6 @@ public class ConnectionManagerTest extends ParameterizedTest {
 			suspendedChannelWaiter.waitFor(ChannelState.attached);
 			assertEquals("Attached channel histories do not match", attachedChannelHistory, expectedAttachedChannelHistory);
 			assertEquals("Suspended channel histories do not match", suspendedChannelHistory, expectedSuspendedChannelHistory);
-			ably.close();
-		} catch (AblyException e) {
-			e.printStackTrace();
-			fail("init0: Unexpected exception instantiating library");
 		}
 	}
 }


### PR DESCRIPTION
Fixes #524 ; work in progress.

Changes:

* 39e69ef 
    - make all tests throw ``AblyException`` to avoid useless ``try/catch``
    - make tests use ``AblyRealtime`` into ``try-with-resources`` so we're sure it's closed at the end (this is except a few tests where the behaviour of ``ably.close()`` is part of the test case).

* ...more to come