### PR TITLE
Fix transient pub race

### DIFF
--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -847,6 +847,7 @@ public class RealtimeChannelTest extends ParameterizedTest {
 
 			/* create a channel and subscribe */
 			final Channel subChannel = subAbly.channels.get(channelName);
+			new ChannelWaiter(subChannel).waitFor(ChannelState.attached);
 			Helpers.MessageWaiter messageWaiter = new Helpers.MessageWaiter(subChannel);
 
 			pubAbly = new AblyRealtime(opts);


### PR DESCRIPTION
This PR aims to fix an occasional test failure of `transient_publish_connected()` whereby the test publishes a message before the listener is subscribed.