### PR TITLE
Fix SLF4J proguard warnings #529

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,3 @@
-// These dependencies have to be in lib/build.gradle for compilation _and_
-// in java/build.gradle and android/build.gradle for maven.
 dependencies {
   implementation 'org.msgpack:msgpack-core:0.8.11'
   implementation 'org.java-websocket:Java-WebSocket:1.4.0'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 dependencies {
   implementation 'org.msgpack:msgpack-core:0.8.11'
-  implementation 'org.java-websocket:Java-WebSocket:1.4.0'
+  implementation 'org.java-websocket:Java-WebSocket:1.3.9'
   implementation 'com.google.code.gson:gson:2.5'
   testImplementation 'org.hamcrest:hamcrest-all:1.3'
   testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
PR for #529 
It was 1.4.0 of Java-Websocket that introduced SLF4J in a 'breaking change'.

As a temporary fix to rid us of the proguard warnings, this rolls us back to 1.3.9 of Java-Websocket dependency.

We can re-upgrade to 1.4.0 later when we've got the time to look at the proguard configuration at the same time.