### PR TITLE
RealtimeChannelTest.transient_publish_connected: fix regression…

### DIFF
--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -847,8 +847,8 @@ public class RealtimeChannelTest extends ParameterizedTest {
 
 			/* create a channel and subscribe */
 			final Channel subChannel = subAbly.channels.get(channelName);
-			new ChannelWaiter(subChannel).waitFor(ChannelState.attached);
 			Helpers.MessageWaiter messageWaiter = new Helpers.MessageWaiter(subChannel);
+			new ChannelWaiter(subChannel).waitFor(ChannelState.attached);
 
 			pubAbly = new AblyRealtime(opts);
 			new ConnectionWaiter(pubAbly.connection).waitFor(ConnectionState.connected);


### PR DESCRIPTION
…introduced by last commit (https://github.com/ably/ably-java/commit/1ef01eea8d7b0c5f1b8b8a264158fe7a3d3a6b8d)

Feel free either just to merge this as-is, or squash with the earlier commit somehow.