### PR TITLE
Get AndroidPushTest to pass again

### DIFF
--- a/android/src/androidTest/java/io/ably/lib/test/android/AndroidPushTest.java
+++ b/android/src/androidTest/java/io/ably/lib/test/android/AndroidPushTest.java
@@ -194,7 +194,6 @@ public class AndroidPushTest extends AndroidTestCase {
 		LocalDevice device = activation.rest.push.getLocalDevice();
 		device.setDeviceIdentityToken("foo");
 
-		assertNotNull(device.id);
 		assertEquals("foo", device.deviceIdentityToken);
 
 		State state = new NotActivated(activation.machine);

--- a/android/src/androidTest/java/io/ably/lib/test/android/AndroidPushTest.java
+++ b/android/src/androidTest/java/io/ably/lib/test/android/AndroidPushTest.java
@@ -144,7 +144,7 @@ public class AndroidPushTest extends AndroidTestCase {
 	// RSH2a
 	public void test_push_activate() throws InterruptedException, AblyException {
 		TestActivation activation = new TestActivation();
-		BlockingQueue<Event> events = activation.machine.getEventReceiver(1);
+		BlockingQueue<Event> events = activation.machine.getEventReceiver(2); // CalledActivate + GotPushDeviceDetails
 		assertInstanceOf(ActivationStateMachine.NotActivated.class, activation.machine.current);
 		activation.rest.push.activate();
 		Event event = events.take();

--- a/android/src/androidTest/java/io/ably/lib/test/android/AndroidPushTest.java
+++ b/android/src/androidTest/java/io/ably/lib/test/android/AndroidPushTest.java
@@ -29,6 +29,7 @@ import io.ably.lib.push.ActivationStateMachine.WaitingForPushDeviceDetails;
 import io.ably.lib.push.ActivationStateMachine.WaitingForRegistrationUpdate;
 import io.ably.lib.push.ActivationStateMachine.UpdatingRegistrationFailed;
 import io.ably.lib.rest.DeviceDetails;
+import io.ably.lib.util.Base64Coder;
 import io.azam.ulidj.ULID;
 import junit.extensions.TestSetup;
 import junit.framework.TestSuite;
@@ -1247,7 +1248,7 @@ public class AndroidPushTest extends AndroidTestCase {
 														.add("transportType", "fcm")
 														.add("registrationToken", updatedRegistrationToken))).toJson().toString(),
 								Serialisation.msgpackToGson(request.requestBody.getEncoded()).toString());
-						String authToken = Helpers.tokenFromAuthHeader(request.authHeader);
+						String authToken = Base64Coder.decodeString(request.requestHeaders.get("X-Ably-DeviceToken").get(0));
 						assertEquals(testActivation.rest.push.getLocalDevice().deviceIdentityToken, authToken);
 					}
 

--- a/android/src/main/java/io/ably/lib/push/ActivationContext.java
+++ b/android/src/main/java/io/ably/lib/push/ActivationContext.java
@@ -29,7 +29,6 @@ public class ActivationContext {
 
 	public synchronized LocalDevice getLocalDevice() {
 		if(localDevice == null) {
-
 			localDevice = new LocalDevice(this);
 		}
 		return localDevice;

--- a/android/src/main/java/io/ably/lib/push/ActivationContext.java
+++ b/android/src/main/java/io/ably/lib/push/ActivationContext.java
@@ -3,6 +3,11 @@ package io.ably.lib.push;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.firebase.iid.InstanceIdResult;
 import io.ably.lib.rest.AblyRest;
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.ErrorInfo;
@@ -24,6 +29,7 @@ public class ActivationContext {
 
 	public synchronized LocalDevice getLocalDevice() {
 		if(localDevice == null) {
+
 			localDevice = new LocalDevice(this);
 		}
 		return localDevice;
@@ -119,6 +125,11 @@ public class ActivationContext {
 			}
 		}
 		return activationContext;
+	}
+
+	void getRegistrationToken(OnCompleteListener<InstanceIdResult> listener) {
+		FirebaseInstanceId.getInstance().getInstanceId()
+				.addOnCompleteListener(listener);
 	}
 
 	protected AblyRest ably;

--- a/android/src/main/java/io/ably/lib/push/ActivationStateMachine.java
+++ b/android/src/main/java/io/ably/lib/push/ActivationStateMachine.java
@@ -368,21 +368,20 @@ public class ActivationStateMachine {
 	}
 
 	private static void getRegistrationToken(final ActivationStateMachine machine) {
-		FirebaseInstanceId.getInstance().getInstanceId()
-				.addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
-					@Override
-					public void onComplete(Task<InstanceIdResult> task) {
-						if(task.isSuccessful()) {
-							/* Get new Instance ID token */
-							String token = task.getResult().getToken();
-							Log.i(TAG, "getInstanceId completed with new token");
-							machine.activationContext.onNewRegistrationToken(RegistrationToken.Type.FCM, token);
-						} else {
-							Log.e(TAG, "getInstanceId failed", task.getException());
-							machine.handleEvent(new ActivationStateMachine.GettingPushDeviceDetailsFailed(ErrorInfo.fromThrowable(task.getException())));
-						}
-					}
-				});
+		machine.activationContext.getRegistrationToken(new OnCompleteListener<InstanceIdResult>() {
+			@Override
+			public void onComplete(Task<InstanceIdResult> task) {
+				if(task.isSuccessful()) {
+					/* Get new Instance ID token */
+					String token = task.getResult().getToken();
+					Log.i(TAG, "getInstanceId completed with new token");
+					machine.activationContext.onNewRegistrationToken(RegistrationToken.Type.FCM, token);
+				} else {
+					Log.e(TAG, "getInstanceId failed", task.getException());
+					machine.handleEvent(new ActivationStateMachine.GettingPushDeviceDetailsFailed(ErrorInfo.fromThrowable(task.getException())));
+				}
+			}
+		});
 	}
 
 	private static void updateRegistration(final ActivationStateMachine machine) {

--- a/android/src/main/java/io/ably/lib/push/LocalDevice.java
+++ b/android/src/main/java/io/ably/lib/push/LocalDevice.java
@@ -33,11 +33,7 @@ public class LocalDevice extends DeviceDetails {
 		this.formFactor = isTablet(activationContext.getContext()) ? "tablet" : "phone";
 		this.activationContext = activationContext;
 		this.push = new DeviceDetails.Push();
-		try {
-			loadPersisted();
-		} catch(AblyException e) {
-			Log.e(TAG, "unable to load local device state");
-		}
+		loadPersisted();
 	}
 
 	public JsonObject toJsonObject() {
@@ -49,14 +45,14 @@ public class LocalDevice extends DeviceDetails {
 		return o;
 	}
 
-	private void loadPersisted() throws AblyException {
+	private void loadPersisted() {
 		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activationContext.getContext());
 
 		String id = prefs.getString(SharedPrefKeys.DEVICE_ID, null);
 		this.id = id;
 		if(id != null) {
 			Log.v(TAG, "loadPersisted(): existing deviceId found; id: " + id);
-			clientId = prefs.getString(SharedPrefKeys.CLIENT_ID, activationContext.clientId);
+			clientId = prefs.getString(SharedPrefKeys.CLIENT_ID, null);
 			deviceSecret = prefs.getString(SharedPrefKeys.DEVICE_SECRET, null);
 		}
 		this.deviceIdentityToken = prefs.getString(SharedPrefKeys.DEVICE_TOKEN, null);

--- a/android/src/main/java/io/ably/lib/push/PushChannel.java
+++ b/android/src/main/java/io/ably/lib/push/PushChannel.java
@@ -90,7 +90,7 @@ public class PushChannel {
 		}
 	}
 
-	public void unsubscribeDevice(Context context) throws AblyException {
+	public void unsubscribeDevice() throws AblyException {
 		unsubscribeDeviceImpl().sync();
 	}
 

--- a/android/src/main/java/io/ably/lib/types/RegistrationToken.java
+++ b/android/src/main/java/io/ably/lib/types/RegistrationToken.java
@@ -10,7 +10,7 @@ public class RegistrationToken {
 	}
 
 	public enum Type {
-		GCM,
+		@Deprecated GCM,
 		FCM;
 
 		public static Type fromOrdinal(int i) {

--- a/lib/src/main/java/io/ably/lib/rest/AblyBase.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyBase.java
@@ -28,7 +28,6 @@ import io.ably.lib.util.Serialisation;
 public abstract class AblyBase {
 
 	public final ClientOptions options;
-	final String clientId;
 	public final Http http;
 	public final HttpCore httpCore;
 
@@ -67,7 +66,6 @@ public abstract class AblyBase {
 		Log.setLevel(options.logLevel);
 		Log.setHandler(options.logHandler);
 		Log.i(getClass().getName(), "started");
-		this.clientId = options.clientId;
 
 		auth = new Auth(this, options);
 		httpCore = new HttpCore(options, auth);
@@ -110,7 +108,7 @@ public abstract class AblyBase {
 	/**
 	 * Obtain the time from the Ably service.
 	 * This may be required on clients that do not have access
-	 * to a sufficiently well maintained time source, to provide 
+	 * to a sufficiently well maintained time source, to provide
 	 * timestamps for use in token requests
 	 * @return time in millis since the epoch
 	 * @throws AblyException
@@ -122,7 +120,7 @@ public abstract class AblyBase {
 	/**
 	 * Asynchronously obtain the time from the Ably service.
 	 * This may be required on clients that do not have access
-	 * to a sufficiently well maintained time source, to provide 
+	 * to a sufficiently well maintained time source, to provide
 	 * timestamps for use in token requests
 	 * @param callback
 	 */

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -568,7 +568,7 @@ public class Auth {
 
 		/* Spec: RSA7d */
 		if(params.clientId == null) {
-			params.clientId = ably.clientId;
+			params.clientId = ably.options.clientId;
 		}
 		params.capability = Capability.c14n(params.capability);
 
@@ -736,7 +736,7 @@ public class Auth {
 		String capabilityText = (request.capability == null) ? "" : request.capability;
 
 		/* clientId */
-		if (request.clientId == null) request.clientId = ably.clientId;
+		if (request.clientId == null) request.clientId = ably.options.clientId;
 		String clientIdText = (request.clientId == null) ? "" : request.clientId;
 
 		/* timestamp */
@@ -1017,6 +1017,11 @@ public class Auth {
 	 * @throws AblyException
 	 */
 	public void setClientId(String clientId) throws AblyException {
+		if(clientId == null) {
+			/* do nothing - we received a token without a clientId */
+			return;
+		}
+
 		if(this.clientId == null) {
 			/* RSA12a, RSA12b, RSA7b2, RSA7b3, RSA7b4: the given clientId is now our clientId */
 			this.clientId = clientId;

--- a/lib/src/test/java/io/ably/lib/test/rest/RestPushTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestPushTest.java
@@ -100,7 +100,7 @@ public class RestPushTest extends ParameterizedTest {
 				.add("metadata", JsonUtils.object())
 				.add("push", JsonUtils.object()
 						.add("recipient", JsonUtils.object()
-								.add("transportType", "gcm")
+								.add("transportType", "fcm")
 								.add("registrationToken", "qux")))
 				.toJson());
 
@@ -112,7 +112,7 @@ public class RestPushTest extends ParameterizedTest {
 				.add("metadata", JsonUtils.object())
 				.add("push", JsonUtils.object()
 						.add("recipient", JsonUtils.object()
-								.add("transportType", "gcm")
+								.add("transportType", "fcm")
 								.add("registrationToken", "qux")))
 				.toJson());
 
@@ -124,7 +124,7 @@ public class RestPushTest extends ParameterizedTest {
 				.add("metadata", JsonUtils.object())
 				.add("push", JsonUtils.object()
 						.add("recipient", JsonUtils.object()
-								.add("transportType", "gcm")
+								.add("transportType", "fcm")
 								.add("registrationToken", "qux")))
 				.toJson());
 
@@ -136,7 +136,7 @@ public class RestPushTest extends ParameterizedTest {
 				.add("metadata", JsonUtils.object())
 				.add("push", JsonUtils.object()
 						.add("recipient", JsonUtils.object()
-								.add("transportType", "gcm")
+								.add("transportType", "fcm")
 								.add("registrationToken", "qux")))
 				.toJson());
 


### PR DESCRIPTION
This includes some changes unrelated to https://github.com/ably/docs/pull/786 extracted from https://github.com/ably/ably-java/pull/543 that were making review there a bit difficult, plus a few more fixes. Now AndroidPushTest should pass and we can build https://github.com/ably/ably-java/pull/543 cleanly on top.