### PR TITLE
Channels visibility improvements

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
+++ b/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
@@ -98,7 +98,7 @@ public class AblyRealtime extends AblyRest implements AutoCloseable {
 		 * @param channelName the name of the channel
 		 * @return the channel
 		 */
-		public Channel get(String channelName);
+		Channel get(String channelName);
 
 		/**
 		 * Get the named channel and set the given options, creating it
@@ -108,7 +108,7 @@ public class AblyRealtime extends AblyRest implements AutoCloseable {
 		 * @return the channel
 		 * @throws AblyException
 		 */
-		public Channel get(String channelName, ChannelOptions channelOptions) throws AblyException;
+		Channel get(String channelName, ChannelOptions channelOptions) throws AblyException;
 
 		/**
 		 * Remove this channel from this AblyRealtime instance. This detaches from the channel
@@ -116,7 +116,7 @@ public class AblyRealtime extends AblyRest implements AutoCloseable {
 		 * This silently does nothing if the channel does not already exist.
 		 * @param channelName the name of the channel
 		 */
-		public void release(String channelName);
+		void release(String channelName);
 	}
 
 	private class InternalChannels implements Channels, ConnectionManager.Channels {

--- a/lib/src/main/java/io/ably/lib/realtime/Connection.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Connection.java
@@ -76,10 +76,10 @@ public class Connection extends EventEmitter<ConnectionEvent, ConnectionStateLis
 	 * internal
 	 *****************/
 
-	Connection(AblyRealtime ably) throws AblyException {
+	Connection(AblyRealtime ably, ConnectionManager.Channels channels) throws AblyException {
 		this.ably = ably;
 		this.state = ConnectionState.initialized;
-		this.connectionManager = new ConnectionManager(ably, this);
+		this.connectionManager = new ConnectionManager(ably, this, channels);
 	}
 
 	public void onConnectionStateChange(ConnectionStateChange stateChange) {

--- a/lib/src/main/java/io/ably/lib/rest/AblyBase.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyBase.java
@@ -18,6 +18,7 @@ import io.ably.lib.platform.Platform;
 import io.ably.lib.push.Push;
 import io.ably.lib.types.*;
 import io.ably.lib.util.Crypto;
+import io.ably.lib.util.InternalMap;
 import io.ably.lib.util.Log;
 import io.ably.lib.util.Serialisation;
 
@@ -81,14 +82,18 @@ public abstract class AblyBase {
 	/**
 	 * A collection of Channels associated with an Ably instance.
 	 */
-	public interface Channels {
+	public interface Channels extends ReadOnlyMap<String, Channel> {
 		Channel get(String channelName);
 		Channel get(String channelName, ChannelOptions channelOptions) throws AblyException;
 		void release(String channelName);
+		int size();
+		Iterable<Channel> values();
 	}
 
-	private class InternalChannels implements Channels {
-		private final Map<String, Channel> map = new HashMap<>();
+	private class InternalChannels extends InternalMap<String, Channel> implements Channels {
+		public InternalChannels() {
+			super(new HashMap<String, Channel>());
+		}
 		
 		@Override
 		public Channel get(String channelName) {

--- a/lib/src/main/java/io/ably/lib/rest/AblyBase.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyBase.java
@@ -82,9 +82,9 @@ public abstract class AblyBase {
 	 * A collection of Channels associated with an Ably instance.
 	 */
 	public interface Channels {
-		public Channel get(String channelName);
-		public Channel get(String channelName, ChannelOptions channelOptions) throws AblyException;
-		public void release(String channelName);
+		Channel get(String channelName);
+		Channel get(String channelName, ChannelOptions channelOptions) throws AblyException;
+		void release(String channelName);
 	}
 
 	private class InternalChannels implements Channels {

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -60,7 +60,7 @@ public class ConnectionManager implements ConnectListener {
 	public interface Channels {
 		void onMessage(ProtocolMessage msg);
 		void suspendAll(ErrorInfo error, boolean notifyStateChange);
-		Iterable<Channel> getAll();
+		Iterable<Channel> values();
 	}
 
 	/***********************************
@@ -147,7 +147,7 @@ public class ConnectionManager implements ConnectListener {
 				} else if(!queueEvents) {
 					failQueuedMessages(stateIndication.reason);
 				}
-				for(final Channel channel : channels.getAll()) {
+				for(final Channel channel : channels.values()) {
 					enactForChannel(stateIndication, change, channel);
 				}
 			}

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1033,7 +1033,7 @@ public class ConnectionManager implements ConnectListener {
 			if (connection.key != null)
 				connection.recoveryKey = connection.key + ":" + message.connectionSerial;
 		}
-		channels.onMessage(transport, message);
+		channels.onMessage(message);
 	}
 
 	private synchronized void onConnected(ProtocolMessage message) {

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -53,6 +53,16 @@ public class ConnectionManager implements ConnectListener {
 	static ErrorInfo REASON_REFUSED = new ErrorInfo("Access refused", 401, 40100);
 	static ErrorInfo REASON_TOO_BIG = new ErrorInfo("Connection closed; message too large", 400, 40000);
 
+	/**
+	 * Methods on the channels map owned by the {@link AblyRealtime} instance
+	 * which the {@link ConnectionManager} needs access to.
+	 */
+	public interface Channels {
+		void onMessage(ProtocolMessage msg);
+		void suspendAll(ErrorInfo error, boolean notifyStateChange);
+		Iterable<Channel> getAll();
+	}
+
 	/***********************************
 	 * a class encapsulating information
 	 * associated with a currentState change
@@ -137,7 +147,7 @@ public class ConnectionManager implements ConnectListener {
 				} else if(!queueEvents) {
 					failQueuedMessages(stateIndication.reason);
 				}
-				for(Channel channel : ably.channels.values()) {
+				for(final Channel channel : channels.getAll()) {
 					enactForChannel(stateIndication, change, channel);
 				}
 			}
@@ -677,9 +687,10 @@ public class ConnectionManager implements ConnectListener {
 	 * ConnectionManager
 	 ***********************/
 
-	public ConnectionManager(final AblyRealtime ably, Connection connection) throws AblyException {
+	public ConnectionManager(final AblyRealtime ably, final Connection connection, final Channels channels) throws AblyException {
 		this.ably = ably;
 		this.connection = connection;
+		this.channels = channels;
 
 		ClientOptions options = ably.options;
 		this.hosts = new Hosts(options.realtimeHost, Defaults.HOST_REALTIME, options);
@@ -1022,7 +1033,7 @@ public class ConnectionManager implements ConnectListener {
 			if (connection.key != null)
 				connection.recoveryKey = connection.key + ":" + message.connectionSerial;
 		}
-		ably.channels.onChannelMessage(transport, message);
+		channels.onMessage(transport, message);
 	}
 
 	private synchronized void onConnected(ProtocolMessage message) {
@@ -1042,7 +1053,7 @@ public class ConnectionManager implements ConnectListener {
 			if(error == null) {
 				error = REASON_SUSPENDED;
 			}
-			ably.channels.suspendAll(error, false);
+			channels.suspendAll(error, false);
 		}
 
 		/* set the new connection id */
@@ -1652,6 +1663,7 @@ public class ConnectionManager implements ConnectListener {
 	 ******************/
 
 	final AblyRealtime ably;
+	private final Channels channels;
 	private final Connection connection;
 	private final ITransport.Factory transportFactory;
 	private final List<QueuedMessage> queuedMessages = new ArrayList<>();

--- a/lib/src/main/java/io/ably/lib/types/ReadOnlyMap.java
+++ b/lib/src/main/java/io/ably/lib/types/ReadOnlyMap.java
@@ -1,0 +1,23 @@
+package io.ably.lib.types;
+
+import java.util.Map;
+
+/**
+ * Exposes a subset of the Map interface, providing read only access only, removing mutating interfaces.
+ * Used in the Ably API where we have previously overexposed the full Map interface, providing a
+ * level of acceptable support for users who had relied upon this overexposure for valid reasons
+ * including testing and runtime inspection (e.g. iterating channels, counting channels, etc..).
+ * 
+ * Developers should not rely upon any methods in this interface as they will eventually
+ * be remove from the Ably API, after a period of deprecation.
+ */
+public interface ReadOnlyMap<K, V> {
+    boolean containsKey(Object key);
+    boolean containsValue(Object value);
+    Iterable<Map.Entry<K, V>> entrySet();
+    V get(Object key);
+    boolean isEmpty();
+    Iterable<K> keySet();
+    int size();
+    Iterable<V> values();
+}

--- a/lib/src/main/java/io/ably/lib/util/InternalMap.java
+++ b/lib/src/main/java/io/ably/lib/util/InternalMap.java
@@ -1,0 +1,54 @@
+package io.ably.lib.util;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+import io.ably.lib.types.ReadOnlyMap;
+
+public abstract class InternalMap<K, V> implements ReadOnlyMap<K, V> {
+    protected final Map<K, V> map;
+
+    public InternalMap(final Map<K, V> map) {
+        this.map = map;
+    }
+
+    @Override
+    public final boolean containsKey(final Object key) {
+        return map.containsKey(key);
+    }
+
+    @Override
+    public final boolean containsValue(final Object value) {
+        return map.containsValue(value);
+    }
+
+    @Override
+    public final Iterable<Entry<K, V>> entrySet() {
+        return map.entrySet();
+    }
+
+    @Override
+    public final V get(final Object key) {
+        return map.get(key);
+    }
+
+    @Override
+    public final boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    @Override
+    public final Iterable<K> keySet() {
+        return map.keySet();
+    }
+
+    @Override
+    public final int size() {
+        return map.size();
+    }
+
+    @Override
+    public final Iterable<V> values() {
+        return map.values();
+    }
+}

--- a/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
@@ -131,8 +131,9 @@ public class ConnectionManagerTest extends ParameterizedTest {
 		opts.autoConnect = false;
 		try(AblyRealtime ably = new AblyRealtime(opts)) {
 			Connection connection = Mockito.mock(Connection.class);
+			final ConnectionManager.Channels channels = Mockito.mock(ConnectionManager.Channels.class);
 
-			ConnectionManager connectionManager = new ConnectionManager(ably, connection) {
+			ConnectionManager connectionManager = new ConnectionManager(ably, connection, channels) {
 				@Override
 				protected boolean checkConnectivity() {
 					return false;

--- a/lib/src/test/java/io/ably/lib/test/rest/RestChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestChannelTest.java
@@ -8,12 +8,8 @@ import io.ably.lib.rest.AblyRest;
 import io.ably.lib.rest.Channel;
 import io.ably.lib.test.common.Setup;
 import io.ably.lib.types.AblyException;
-import io.ably.lib.types.ChannelOptions;
 import io.ably.lib.types.ClientOptions;
 import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Iterator;
 
 /**
  * Test for basic Channel operation not related to publish or history
@@ -38,11 +34,10 @@ public class RestChannelTest {
 		assertNotEquals("Verify channel objects are different if different names are requested", channel1, channel2);
 
 		/* Test channel enumeration */
-		assertEquals("Verify total number of channels", ablyRest.channels.values().size(), 2);
+		assertEquals("Verify total number of channels", ablyRest.channels.size(), 2);
 		assertTrue("Verify there is channel 1 in the list", ablyRest.channels.containsKey("channel_1"));
 		assertTrue("Verify there is channel 2 in the list", ablyRest.channels.containsKey("channel_2"));
-		for (Iterator<Channel> iterator=ablyRest.channels.values().iterator(); iterator.hasNext(); ) {
-			Channel channel = iterator.next();
+		for (final Channel channel : ablyRest.channels.values()) {
 			assertTrue("Verify correct channels are in the hashmap",
 					channel == channel1 || channel == channel2);
 		}


### PR DESCRIPTION
The quick win was making the `channels` field on realtime instances `final` - preventing that reference from being trampled.

The larger change was a bit more complex, involving (both) the `Channels` interfaces we have. They were classes but are now interfaces with private implementations, solving the following accessibility issues:

1. **Constructor**: It should never have been accessible, however it was also causing an issue for Kotlin developers because the lack of a `new` keyword makes it less obvious that you're creating an instance of an inner class.
2. **Underlying map implementation**: Allowing anybody in possession of a Channels reference to mutate the channels map without the Ably implementation knowing.
3. **Internal methods**: Called by the connection manager but could equally be called by anybody in possession of a Channels reference without the connection manager knowing.

### Aside

I wanted to push further and deprecate the `channels` fields on both `AblyRealtime` and `AblyBase`, however because `AblyRealtime` is a subclass of `AblyBase` it was not as easy as just creating a `getChannels()` method. The problem is that fields can shadow superclass fields and change their type at the same time, even to an incompatible type, but methods can't. And the `Channels` returned by base are of a completely different class to the `Channels` returned by realtime (due to the fact that we also have two forks of `ChannelBase` upon which each is ultimately reliant!).