### PR TITLE
Pull in what's in the release 1.1.8 branch

### DIFF
--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeReauthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeReauthTest.java
@@ -262,8 +262,10 @@ public class RealtimeReauthTest extends ParameterizedTest {
 			try {
 				Auth.TokenDetails reauthTokenDetails = ablyRealtime.auth.authorize(null, authOptions);
 				assertFalse("Expecting exception", true);
+				System.out.println("Authorize failed to throw an exception");
 			} catch (AblyException e) {
 				assertEquals("Expecting failed", ConnectionState.failed, ablyRealtime.connection.state);
+				System.out.println("Got failed connection");
 			}
 
 			/**


### PR DESCRIPTION
This change introduces an event queue for serialisation of all
CM-related event handling. In general, state changes, associated
notifications, and other event processing, are performed without
the CM locked, to avoid the deadlocks that have been prevalent in
earlier releases. However, transport state changes that require
a synchronous change in CM behaviour - that is, transport
disconnections - are handled synchronously so that the transport
is not used when it is no longer viable.