### PR TITLE
Add example of subscribing to a channel with deltas

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ channel.subscribe(events, new MessageListener() {
 
 ### Subscribing to a channel in delta mode ###
 
-Subscribing to a channel in delta mode enables delta compression. This is a way for a client to subscribe to a channel so that message payloads sent contain only the difference (ie the delta) between the present message and the previous message on the channel.
+Subscribing to a channel in delta mode enables [delta compression](https://www.ably.io/documentation/realtime/channels/channel-parameters/deltas). This is a way for a client to subscribe to a channel so that message payloads sent contain only the difference (ie the delta) between the present message and the previous message on the channel.
 
 Request a Vcdiff formatted delta stream using channel options when you get the channel:
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,22 @@ channel.subscribe(events, new MessageListener() {
 });
 ```
 
+### Subscribing to a channel with deltas ###
+
+Request a Vcdiff formatted delta stream using channel options when you get the channel:
+
+```java
+Map<String, String> params = new HashMap<>();
+params.put("delta", "vcdiff");
+ChannelOptions options = new ChannelOptions();
+options.params = params;
+Channel channel = ably.channels.get("test", options);
+```
+
+Beyond specifying channel options, the rest is transparent and requires no further changes to your application. The `message.data` instances that are delivered to your `MessageListener` continue to contain the values that were originally published.
+
+If you would like to inspect the `Message` instances in order to identify whether the `data` they present was rendered from a delta message from Ably then you can see if `extras.getDelta().getFormat()` equals `"vcdiff"`.
+
 ### Publishing to a channel ###
 
 ```java

--- a/README.md
+++ b/README.md
@@ -137,7 +137,9 @@ channel.subscribe(events, new MessageListener() {
 });
 ```
 
-### Subscribing to a channel with deltas ###
+### Subscribing to a channel in delta mode ###
+
+Subscribing to a channel in delta mode enables delta compression. This is a way for a client to subscribe to a channel so that message payloads sent contain only the difference (ie the delta) between the present message and the previous message on the channel.
 
 Request a Vcdiff formatted delta stream using channel options when you get the channel:
 


### PR DESCRIPTION
I think this does reveal that the channel options API could be slicker, but we've not got time to be changing it now.

I'm also a little disconcerted, if I'm brutally honest, that the `Message` instances still contain the `extras` telling us "this message is a delta" but still present data that is the final 'rendered' value (i.e. delta applied). This is also something we're not going to be changing right now (I expect) but does feel ugly to me. So, I've written that final paragraph around inspection of the instance to turn this in to a feature! Unless we consider it a bug?

cc/ @SimonWoolf @mattheworiordan 