### PR TITLE
Bump protocol version to 1.2

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/Defaults.java
+++ b/lib/src/main/java/io/ably/lib/transport/Defaults.java
@@ -7,7 +7,7 @@ import java.text.DecimalFormat;
 
 public class Defaults {
 	/* versions */
-	public static final float ABLY_VERSION_NUMBER   = 1.0f;
+	public static final float ABLY_VERSION_NUMBER   = 1.2f;
 	public static final String ABLY_VERSION         = new DecimalFormat("0.0").format(ABLY_VERSION_NUMBER);
 	public static final String ABLY_LIB_VERSION     = String.format("%s-%s", BuildConfig.LIBRARY_NAME, BuildConfig.VERSION);
 

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeHttpHeaderTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeHttpHeaderTest.java
@@ -79,13 +79,19 @@ public class RealtimeHttpHeaderTest extends ParameterizedTest {
 			assertEquals("Verify correct key param", requestParameters.get("key"),
 					Collections.singletonList(key));
 
-			/* Spec RTN2f */
-			assertEquals("Verify correct version", requestParameters.get(Defaults.ABLY_VERSION_PARAM),
-					Collections.singletonList(Defaults.ABLY_VERSION));
+			/* Spec RTN2f
+			 * This test should not directly validate version against Defaults.ABLY_VERSION, nor
+			 * Defaults.ABLY_VERSION_PARAM, as ultimately the request param has been derived from those values.
+			 */
+			assertEquals("Verify correct version", requestParameters.get("v"),
+					Collections.singletonList("1.2"));
 
-			/* Spec RTN2g */
-			assertEquals("Verify correct lib version", requestParameters.get(Defaults.ABLY_LIB_PARAM),
-					Collections.singletonList(Defaults.ABLY_LIB_VERSION));
+			/* Spec RTN2g
+			 * This test should not directly validate version against Defaults.ABLY_LIB_VERSION, nor
+			 * Defaults.ABLY_LIB_PARAM, as ultimately the request param has been derived from those values.
+			 */
+			assertEquals("Verify correct lib version", requestParameters.get("lib"),
+					Collections.singletonList("java-1.2.1"));
 
 			/* Spec RTN2a */
 			assertEquals("Verify correct format", requestParameters.get("format"),

--- a/lib/src/test/java/io/ably/lib/test/rest/HttpHeaderTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/HttpHeaderTest.java
@@ -77,16 +77,14 @@ public class HttpHeaderTest extends ParameterizedTest {
 			/* Get last headers */
 			Map<String, String> headers = server.getHeaders();
 
-			/* Prepare checked header */
-			String ably_version_header = Defaults.ABLY_VERSION_HEADER.toLowerCase();
-			String ably_lib_header = Defaults.ABLY_LIB_HEADER.toLowerCase();
-
-			/* Check header */
+			/* Check header
+			 * This test should not directly validate version against Defaults.ABLY_VERSION, Defaults.ABLY_LIB_VERSION,
+			 * Defaults.ABLY_VERSION_HEADER, nor Defaults.ABLY_LIB_HEADER, as ultimately these headers have been derived
+			 * from those values.
+			 */
 			Assert.assertNotNull("Expected headers", headers);
-			Assert.assertTrue(String.format("Expected header %s", Defaults.ABLY_VERSION_HEADER), headers.containsKey(ably_version_header));
-			Assert.assertEquals(headers.get(ably_version_header), Defaults.ABLY_VERSION);
-			Assert.assertTrue(String.format("Expected header %s", Defaults.ABLY_LIB_HEADER), headers.containsKey(ably_lib_header));
-			Assert.assertEquals(headers.get(ably_lib_header), Defaults.ABLY_LIB_VERSION);
+			Assert.assertEquals(headers.get("x-ably-version"), "1.2");
+			Assert.assertEquals(headers.get("x-ably-lib"), "java-1.2.1");
 		} catch (AblyException e) {
 			e.printStackTrace();
 			Assert.fail("header_lib_channel_publish: Unexpected exception");

--- a/lib/src/test/java/io/ably/lib/transport/DefaultsTest.java
+++ b/lib/src/test/java/io/ably/lib/transport/DefaultsTest.java
@@ -1,0 +1,12 @@
+package io.ably.lib.transport;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DefaultsTest {
+	@Test
+	public void versions() {
+		assertEquals("1.2", Defaults.ABLY_VERSION);
+	}
+}


### PR DESCRIPTION
Matching the pull requests I've raised elsewhere. See:

- https://github.com/ably/ably-cocoa/pull/1058
- https://github.com/ably/ably-js/pull/673