### PR TITLE
Replace use of StandardCharsets

### DIFF
--- a/lib/src/main/java/io/ably/lib/http/HttpUtils.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpUtils.java
@@ -8,7 +8,6 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -147,7 +146,7 @@ public class HttpUtils {
 			return null;
 		}
 
-		byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
+		byte[] bytes = str.getBytes(Charset.forName("UTF-8"));
 		StringBuilder builder = new StringBuilder(bytes.length);
 
 		for (byte c : bytes) {

--- a/lib/src/main/java/io/ably/lib/types/DecodingContext.java
+++ b/lib/src/main/java/io/ably/lib/types/DecodingContext.java
@@ -1,7 +1,6 @@
 package io.ably.lib.types;
 
-import java.util.Map;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 
 public class DecodingContext {
 
@@ -18,7 +17,7 @@ public class DecodingContext {
 		if(lastMessageBinary != null)
 			return lastMessageBinary;
 		else if(lastMessageString != null) {
-			return lastMessageString.getBytes(StandardCharsets.UTF_8);
+			return lastMessageString.getBytes(Charset.forName("UTF-8"));
 		}
 		else
 			return null;


### PR DESCRIPTION
Fixes #596 

I'm concerned that the build tools didn't pick this up as, from what I can see, we have the minimum SDK API Level set for Android... I've opened #600 to look at that later.

Also removed an unrelated, unused import in this PR (`Map`).