### PR TITLE
Rest.publishBatch: support overloaded method that takes params

### DIFF
--- a/lib/src/main/java/io/ably/lib/rest/AblyBase.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyBase.java
@@ -239,25 +239,25 @@ public abstract class AblyBase {
      */
     @Experimental
     public PublishResponse[] publishBatch(Message.Batch[] pubSpecs, ChannelOptions channelOptions) throws AblyException {
-		return publishBatchImpl(pubSpecs, channelOptions, null).sync();
-	}
+        return publishBatchImpl(pubSpecs, channelOptions, null).sync();
+    }
 
-	@Experimental
-	public PublishResponse[] publishBatch(Message.Batch[] pubSpecs, ChannelOptions channelOptions, Param[] params) throws AblyException {
-		return publishBatchImpl(pubSpecs, channelOptions, params).sync();
+    @Experimental
+    public PublishResponse[] publishBatch(Message.Batch[] pubSpecs, ChannelOptions channelOptions, Param[] params) throws AblyException {
+        return publishBatchImpl(pubSpecs, channelOptions, params).sync();
     }
 
     @Experimental
     public void publishBatchAsync(Message.Batch[] pubSpecs, ChannelOptions channelOptions, final Callback<PublishResponse[]> callback) throws AblyException {
-		publishBatchImpl(pubSpecs, channelOptions, null).async(callback);
-	}
-
-	@Experimental
-	public void publishBatchAsync(Message.Batch[] pubSpecs, ChannelOptions channelOptions, Param[] params, final Callback<PublishResponse[]> callback) throws AblyException {
-		publishBatchImpl(pubSpecs, channelOptions, null).async(callback);
+        publishBatchImpl(pubSpecs, channelOptions, null).async(callback);
     }
 
-	private Http.Request<PublishResponse[]> publishBatchImpl(final Message.Batch[] pubSpecs, ChannelOptions channelOptions, final Param[] params) throws AblyException {
+    @Experimental
+    public void publishBatchAsync(Message.Batch[] pubSpecs, ChannelOptions channelOptions, Param[] params, final Callback<PublishResponse[]> callback) throws AblyException {
+        publishBatchImpl(pubSpecs, channelOptions, null).async(callback);
+    }
+
+    private Http.Request<PublishResponse[]> publishBatchImpl(final Message.Batch[] pubSpecs, ChannelOptions channelOptions, final Param[] params) throws AblyException {
         boolean hasClientSuppliedId = false;
         for(Message.Batch spec : pubSpecs) {
             for(Message message : spec.messages) {
@@ -280,7 +280,7 @@ public abstract class AblyBase {
             @Override
             public void execute(HttpScheduler http, final Callback<PublishResponse[]> callback) throws AblyException {
                 HttpCore.RequestBody requestBody = options.useBinaryProtocol ? MessageSerializer.asMsgpackRequest(pubSpecs) : MessageSerializer.asJSONRequest(pubSpecs);
-				http.post("/messages", HttpUtils.defaultAcceptHeaders(options.useBinaryProtocol), params, requestBody, new HttpCore.ResponseHandler<PublishResponse[]>() {
+                http.post("/messages", HttpUtils.defaultAcceptHeaders(options.useBinaryProtocol), params, requestBody, new HttpCore.ResponseHandler<PublishResponse[]>() {
                     @Override
                     public PublishResponse[] handleResponse(HttpCore.Response response, ErrorInfo error) throws AblyException {
                         if(error != null && error.code != 40020) {

--- a/lib/src/main/java/io/ably/lib/rest/AblyBase.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyBase.java
@@ -239,15 +239,25 @@ public abstract class AblyBase {
      */
     @Experimental
     public PublishResponse[] publishBatch(Message.Batch[] pubSpecs, ChannelOptions channelOptions) throws AblyException {
-        return publishBatchImpl(pubSpecs, channelOptions).sync();
+		return publishBatchImpl(pubSpecs, channelOptions, null).sync();
+	}
+
+	@Experimental
+	public PublishResponse[] publishBatch(Message.Batch[] pubSpecs, ChannelOptions channelOptions, Param[] params) throws AblyException {
+		return publishBatchImpl(pubSpecs, channelOptions, params).sync();
     }
 
     @Experimental
     public void publishBatchAsync(Message.Batch[] pubSpecs, ChannelOptions channelOptions, final Callback<PublishResponse[]> callback) throws AblyException {
-        publishBatchImpl(pubSpecs, channelOptions).async(callback);
+		publishBatchImpl(pubSpecs, channelOptions, null).async(callback);
+	}
+
+	@Experimental
+	public void publishBatchAsync(Message.Batch[] pubSpecs, ChannelOptions channelOptions, Param[] params, final Callback<PublishResponse[]> callback) throws AblyException {
+		publishBatchImpl(pubSpecs, channelOptions, null).async(callback);
     }
 
-    private Http.Request<PublishResponse[]> publishBatchImpl(final Message.Batch[] pubSpecs, ChannelOptions channelOptions) throws AblyException {
+	private Http.Request<PublishResponse[]> publishBatchImpl(final Message.Batch[] pubSpecs, ChannelOptions channelOptions, final Param[] params) throws AblyException {
         boolean hasClientSuppliedId = false;
         for(Message.Batch spec : pubSpecs) {
             for(Message message : spec.messages) {
@@ -270,7 +280,7 @@ public abstract class AblyBase {
             @Override
             public void execute(HttpScheduler http, final Callback<PublishResponse[]> callback) throws AblyException {
                 HttpCore.RequestBody requestBody = options.useBinaryProtocol ? MessageSerializer.asMsgpackRequest(pubSpecs) : MessageSerializer.asJSONRequest(pubSpecs);
-                http.post("/messages", HttpUtils.defaultAcceptHeaders(options.useBinaryProtocol), null, requestBody, new HttpCore.ResponseHandler<PublishResponse[]>() {
+				http.post("/messages", HttpUtils.defaultAcceptHeaders(options.useBinaryProtocol), params, requestBody, new HttpCore.ResponseHandler<PublishResponse[]>() {
                     @Override
                     public PublishResponse[] handleResponse(HttpCore.Response response, ErrorInfo error) throws AblyException {
                         if(error != null && error.code != 40020) {

--- a/lib/src/main/java/io/ably/lib/rest/AblyBase.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyBase.java
@@ -254,7 +254,7 @@ public abstract class AblyBase {
 
     @Experimental
     public void publishBatchAsync(Message.Batch[] pubSpecs, ChannelOptions channelOptions, Param[] params, final Callback<PublishResponse[]> callback) throws AblyException {
-        publishBatchImpl(pubSpecs, channelOptions, null).async(callback);
+        publishBatchImpl(pubSpecs, channelOptions, params).async(callback);
     }
 
     private Http.Request<PublishResponse[]> publishBatchImpl(final Message.Batch[] pubSpecs, ChannelOptions channelOptions, final Param[] params) throws AblyException {

--- a/lib/src/test/java/io/ably/lib/test/rest/RestChannelBulkPublishTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestChannelBulkPublishTest.java
@@ -18,7 +18,7 @@ public class RestChannelBulkPublishTest extends ParameterizedTest  {
 
     /**
      * Publish a single message on multiple channels
-     * 
+     *
      * The payload constructed has the form
      * [
      *   {
@@ -26,7 +26,7 @@ public class RestChannelBulkPublishTest extends ParameterizedTest  {
      *     message: [{ data: <message text> }]
      *   }
      * ]
-     * 
+     *
      * It publishes the given message on all of the given channels.
      */
     @Test
@@ -69,54 +69,54 @@ public class RestChannelBulkPublishTest extends ParameterizedTest  {
         }
     }
 
-	/**
-	 * As above but with the param method
-	 */
-	@Test
-	public void bulk_publish_multiple_channels_param() {
-		try {
-			/* setup library instance */
-			ClientOptions opts = createOptions(testVars.keys[0].keyStr);
-			AblyRest ably = new AblyRest(opts);
+    /**
+     * As above but with the param method
+     */
+    @Test
+    public void bulk_publish_multiple_channels_param() {
+        try {
+            /* setup library instance */
+            ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+            AblyRest ably = new AblyRest(opts);
 
-			/* first, publish some messages */
-			int channelCount = 5;
-			ArrayList<String> channelIds = new ArrayList<String>();
-			for(int i = 0; i < channelCount; i++) {
-				channelIds.add("persisted:" + randomString());
-			}
+            /* first, publish some messages */
+            int channelCount = 5;
+            ArrayList<String> channelIds = new ArrayList<String>();
+            for (int i = 0; i < channelCount; i++) {
+                channelIds.add("persisted:" + randomString());
+            }
 
-			Message message = new Message(null, "bulk_publish_multiple_channels_param");
-			String messageId = message.id = randomString();
-			Message.Batch payload = new Message.Batch(channelIds, Collections.singleton(message));
+            Message message = new Message(null, "bulk_publish_multiple_channels_param");
+            String messageId = message.id = randomString();
+            Message.Batch payload = new Message.Batch(channelIds, Collections.singleton(message));
 
-			Param[] params = new Param[] { new Param("quickAck", "true") };
+            Param[] params = new Param[]{new Param("quickAck", "true")};
 
-			PublishResponse[] result = ably.publishBatch(new Message.Batch[] { payload }, null, params);
-			for(PublishResponse response : result) {
-				assertEquals("Verify expected response id", response.messageId, messageId);
-				assertTrue("Verify expected channel name", channelIds.contains(response.channelId));
-				assertNull("Verify no publish error", response.error);
-			}
+            PublishResponse[] result = ably.publishBatch(new Message.Batch[]{payload}, null, params);
+            for (PublishResponse response : result) {
+                assertEquals("Verify expected response id", response.messageId, messageId);
+                assertTrue("Verify expected channel name", channelIds.contains(response.channelId));
+                assertNull("Verify no publish error", response.error);
+            }
 
-			/* get the history for this channel */
-			for(String channel : channelIds) {
-				PaginatedResult<Message> messages = ably.channels.get(channel).history(null);
-				assertNotNull("Expected non-null messages", messages);
-				assertEquals("Expected 1 message", messages.items().length, 1);
-				/* verify message contents */
-				assertEquals("Expect message data to be expected String", messages.items()[0].data, message.data);
-			}
-		} catch (AblyException e) {
-			e.printStackTrace();
-			fail("bulk_publish_multiple_channels_param: Unexpected exception");
-			return;
-		}
-	}
+            /* get the history for this channel */
+            for (String channel : channelIds) {
+                PaginatedResult<Message> messages = ably.channels.get(channel).history(null);
+                assertNotNull("Expected non-null messages", messages);
+                assertEquals("Expected 1 message", messages.items().length, 1);
+                /* verify message contents */
+                assertEquals("Expect message data to be expected String", messages.items()[0].data, message.data);
+            }
+        } catch (AblyException e) {
+            e.printStackTrace();
+            fail("bulk_publish_multiple_channels_param: Unexpected exception");
+            return;
+        }
+    }
 
     /**
      * Publish a multiple messages on multiple channels
-     * 
+     *
      * The payload constructed has the form
      * [
      *   {
@@ -139,7 +139,7 @@ public class RestChannelBulkPublishTest extends ParameterizedTest  {
      *   },
      *   ...
      * ]
-     * 
+     *
      * It publishes the given messages on the associated channels.
      */
     @Test


### PR DESCRIPTION
Was going to do this super-quickly since looked like it should be easy, but the relevant tests fail and I don't have time to figure out why right now, so I'm just going to leave this here and hope someone better than me at java picks it up and fixes it up properly.

[context](https://ably-real-time.slack.com/archives/CDLTXNZL2/p1600359183016400?thread_ts=1600285651.006200&cid=CDLTXNZL2)