### PR TITLE
Remove redundant semicolons

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -10,5 +10,9 @@
 
 	<module name="TreeWalker">
 		<module name="RedundantModifier"/>
+		<module name="UnnecessarySemicolonAfterOuterTypeDeclaration"/>
+		<module name="UnnecessarySemicolonAfterTypeMemberDeclaration"/>
+		<module name="UnnecessarySemicolonInEnumeration"/>
+		<module name="UnnecessarySemicolonInTryWithResources"/>
 	</module>
 </module>

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 checkstyle {
-	toolVersion '8.36.2'
+    toolVersion '8.36.2'
 }
 
 apply plugin: 'java'

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -9,6 +9,10 @@ plugins {
     id 'checkstyle'
 }
 
+checkstyle {
+	toolVersion '8.36.2'
+}
+
 apply plugin: 'java'
 apply plugin: 'idea'
 apply from: '../common.gradle'

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -43,7 +43,7 @@ public class Auth {
 	 */
 	public enum AuthMethod {
 		basic,
-		token;
+		token
 	}
 
 	/**

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -43,7 +43,7 @@ public class Auth {
      */
     public enum AuthMethod {
         basic,
-        token;
+        token,
     }
 
     /**

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -1910,5 +1910,5 @@ public class RealtimeChannelTest extends ParameterizedTest {
 				theChannel.state = ChannelState.attaching;
 			}
 		}
-	};
+	}
 }

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -1910,5 +1910,5 @@ public class RealtimeChannelTest extends ParameterizedTest {
                 theChannel.state = ChannelState.attaching;
             }
         }
-    };
+    }
 }

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
@@ -188,7 +188,7 @@ public class RealtimeConnectFailTest extends ParameterizedTest {
 				}
 				public int getCbCount() { return cbCount; }
 				private int cbCount = 0;
-			};
+			}
 
 			TokenGenerator authCallback = new TokenGenerator();
 

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
@@ -188,7 +188,7 @@ public class RealtimeConnectFailTest extends ParameterizedTest {
                 }
                 public int getCbCount() { return cbCount; }
                 private int cbCount = 0;
-            };
+            }
 
             TokenGenerator authCallback = new TokenGenerator();
 

--- a/lib/src/test/java/io/ably/lib/test/rest/RestAuthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestAuthTest.java
@@ -801,7 +801,7 @@ public class RestAuthTest extends ParameterizedTest {
                 }
                 public int getCbCount() { return cbCount; }
                 private int cbCount = 0;
-            };
+            }
 
             TokenGenerator authCallback = new TokenGenerator();
 

--- a/lib/src/test/java/io/ably/lib/test/rest/RestAuthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestAuthTest.java
@@ -801,7 +801,7 @@ public class RestAuthTest extends ParameterizedTest {
 				}
 				public int getCbCount() { return cbCount; }
 				private int cbCount = 0;
-			};
+			}
 
 			TokenGenerator authCallback = new TokenGenerator();
 


### PR DESCRIPTION
The removed semicolons are redundant and it is better to remove them