### PR TITLE
Remove unnecessary calls to the toString method

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -59,7 +59,7 @@ public class WebSocketTransport implements ITransport {
         try {
             boolean isTls = params.options.tls;
             String wsScheme = isTls ? "wss://" : "ws://";
-            wsUri = wsScheme + params.host + ':' + String.valueOf(params.port) + "/";
+            wsUri = wsScheme + params.host + ':' + params.port + "/";
             Param[] authParams = connectionManager.ably.auth.getAuthParams();
             Param[] connectParams = params.getConnectParams(authParams);
             if(connectParams.length > 0)

--- a/lib/src/main/java/io/ably/lib/types/ErrorInfo.java
+++ b/lib/src/main/java/io/ably/lib/types/ErrorInfo.java
@@ -183,7 +183,7 @@ public class ErrorInfo {
                 (message == other.message || (message != null && message.equals(other.message)));
     }
 
-    private static String href(int code) { return HREF_BASE + String.valueOf(code); }
+    private static String href(int code) { return HREF_BASE + code; }
     private static final String HREF_BASE = "https://help.ably.io/error/";
     private static final String TAG = ErrorInfo.class.getName();
 }

--- a/lib/src/test/java/io/ably/lib/test/common/Helpers.java
+++ b/lib/src/test/java/io/ably/lib/test/common/Helpers.java
@@ -429,7 +429,7 @@ public class Helpers {
                 Log.d(TAG, "waitFor timed out: current state=" + currentState().getConnectionEvent().name());
             } else {
                 Log.d(TAG, "waitFor done: state=" + currentState().getConnectionEvent().name() +
-                        ", count=" + Integer.toString(stateCount));
+                        ", count=" + stateCount);
             }
             return stateCount >= count;
         }

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelHistoryTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelHistoryTest.java
@@ -263,7 +263,7 @@ public class RealtimeChannelHistoryTest extends ParameterizedTest {
      * Connect twice to the service, each using the default (binary) protocol.
      * Publish messages on one connection to a given channel; then attach
      * the second connection to the same channel and verify a complete message
-     * history can be obtained. 
+     * history can be obtained.
      */
     @Test
     public void channelhistory_second_channel() {
@@ -860,7 +860,7 @@ public class RealtimeChannelHistoryTest extends ParameterizedTest {
 
             /* verify message order */
             for(int i = 0; i < 10; i++)
-                expectedMessageHistory[i] = messageContents.get("history" + String.valueOf(i + 10));
+                expectedMessageHistory[i] = messageContents.get("history" + (i + 10));
             Assert.assertArrayEquals("Expect messages in forward order", messages.items(), expectedMessageHistory);
 
             /* get next page */
@@ -874,7 +874,7 @@ public class RealtimeChannelHistoryTest extends ParameterizedTest {
 
             /* verify message order */
             for(int i = 0; i < 10; i++)
-                expectedMessageHistory[i] = messageContents.get("history" + String.valueOf(i + 20));
+                expectedMessageHistory[i] = messageContents.get("history" + (i + 20));
             Assert.assertArrayEquals("Expect messages in forward order", messages.items(), expectedMessageHistory);
 
         } catch (AblyException e) {
@@ -934,7 +934,7 @@ public class RealtimeChannelHistoryTest extends ParameterizedTest {
             /* verify message order */
             Message[] expectedMessageHistory = new Message[10];
             for(int i = 0; i < 10; i++)
-                expectedMessageHistory[i] = messageContents.get("history" + String.valueOf(49 - i));
+                expectedMessageHistory[i] = messageContents.get("history" + (49 - i));
             Assert.assertArrayEquals("Expect messages in forward order", messages.items(), expectedMessageHistory);
 
             /* get next page */
@@ -948,7 +948,7 @@ public class RealtimeChannelHistoryTest extends ParameterizedTest {
 
             /* verify message order */
             for(int i = 0; i < 10; i++)
-                expectedMessageHistory[i] = messageContents.get("history" + String.valueOf(39 - i));
+                expectedMessageHistory[i] = messageContents.get("history" + (39 - i));
             Assert.assertArrayEquals("Expect messages in forward order", messages.items(), expectedMessageHistory);
 
             /* get next page */
@@ -962,7 +962,7 @@ public class RealtimeChannelHistoryTest extends ParameterizedTest {
 
             /* verify message order */
             for(int i = 0; i < 10; i++)
-                expectedMessageHistory[i] = messageContents.get("history" + String.valueOf(29 - i));
+                expectedMessageHistory[i] = messageContents.get("history" + (29 - i));
             Assert.assertArrayEquals("Expect messages in forward order", messages.items(), expectedMessageHistory);
 
         } catch (AblyException e) {
@@ -1036,7 +1036,7 @@ public class RealtimeChannelHistoryTest extends ParameterizedTest {
 
             /* verify message order */
             for(int i = 0; i < 10; i++)
-                expectedMessageHistory[i] = messageContents.get("history" + String.valueOf(i + 10));
+                expectedMessageHistory[i] = messageContents.get("history" + (i + 10));
             Assert.assertArrayEquals("Expect messages in forward order", messages.items(), expectedMessageHistory);
 
             /* get first page */
@@ -1050,7 +1050,7 @@ public class RealtimeChannelHistoryTest extends ParameterizedTest {
 
             /* verify message order */
             for(int i = 0; i < 10; i++)
-                expectedMessageHistory[i] = messageContents.get("history" + String.valueOf(i));
+                expectedMessageHistory[i] = messageContents.get("history" + i);
             Assert.assertArrayEquals("Expect messages in forward order", messages.items(), expectedMessageHistory);
 
         } catch (AblyException e) {
@@ -1110,7 +1110,7 @@ public class RealtimeChannelHistoryTest extends ParameterizedTest {
             /* verify message order */
             Message[] expectedMessageHistory = new Message[10];
             for(int i = 0; i < 10; i++)
-                expectedMessageHistory[i] = messageContents.get("history" + String.valueOf(49 - i));
+                expectedMessageHistory[i] = messageContents.get("history" + (49 - i));
             Assert.assertArrayEquals("Expect messages in forward order", messages.items(), expectedMessageHistory);
 
             /* get next page */
@@ -1124,7 +1124,7 @@ public class RealtimeChannelHistoryTest extends ParameterizedTest {
 
             /* verify message order */
             for(int i = 0; i < 10; i++)
-                expectedMessageHistory[i] = messageContents.get("history" + String.valueOf(39 - i));
+                expectedMessageHistory[i] = messageContents.get("history" + (39 - i));
             Assert.assertArrayEquals("Expect messages in forward order", messages.items(), expectedMessageHistory);
 
             /* get first page */
@@ -1138,7 +1138,7 @@ public class RealtimeChannelHistoryTest extends ParameterizedTest {
 
             /* verify message order */
             for(int i = 0; i < 10; i++)
-                expectedMessageHistory[i] = messageContents.get("history" + String.valueOf(49 - i));
+                expectedMessageHistory[i] = messageContents.get("history" + (49 - i));
             Assert.assertArrayEquals("Expect messages in forward order", messages.items(), expectedMessageHistory);
 
         } catch (AblyException e) {
@@ -1154,7 +1154,7 @@ public class RealtimeChannelHistoryTest extends ParameterizedTest {
      * Connect twice to the service, each using the default (binary) protocol.
      * Publish messages on one connection to a given channel; while in progress,
      * attach the second connection to the same channel and verify a message
-     * history up to the point of attachment can be obtained. 
+     * history up to the point of attachment can be obtained.
      */
     @Test
     @Ignore("Fails due to issues in sandbox. See https://github.com/ably/realtime/issues/1834 for details.")
@@ -1166,16 +1166,16 @@ public class RealtimeChannelHistoryTest extends ParameterizedTest {
             ClientOptions rxOpts = createOptions(testVars.keys[0].keyStr);
             rxAbly = new AblyRealtime(rxOpts);
             String channelName = "persisted:channelhistory_from_attach_" + testParams.name;
-    
+
             /* create a channel */
             final Channel txChannel = txAbly.channels.get(channelName);
             final Channel rxChannel = rxAbly.channels.get(channelName);
-    
+
             /* attach sender */
             txChannel.attach();
             (new ChannelWaiter(txChannel)).waitFor(ChannelState.attached);
             assertEquals("Verify attached state reached", txChannel.state, ChannelState.attached);
-    
+
             /* publish messages to the channel */
             final CompletionSet msgComplete = new CompletionSet();
             Thread publisherThread = new Thread() {

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimePresenceTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimePresenceTest.java
@@ -2049,7 +2049,7 @@ public class RealtimePresenceTest extends ParameterizedTest {
             opts.transportFactory = mockTransport;
 
             for (int i=0; i<2; i++) {
-                final String channelName = "presence_suspended_reenter" + testParams.name + String.valueOf(i);
+                final String channelName = "presence_suspended_reenter" + testParams.name + i;
 
                 mockTransport.allowSend();
 

--- a/lib/src/test/java/io/ably/lib/test/rest/RestChannelHistoryTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestChannelHistoryTest.java
@@ -383,7 +383,7 @@ public class RestChannelHistoryTest extends ParameterizedTest {
 
             /* verify message order */
             for(int i = 0; i < 10; i++)
-                expectedMessageHistory[i] = messageContents.get("history" + String.valueOf(i + 10));
+                expectedMessageHistory[i] = messageContents.get("history" + (i + 10));
             Assert.assertArrayEquals("Expect messages in forward order", messages.items(), expectedMessageHistory);
 
             /* get next page */
@@ -397,7 +397,7 @@ public class RestChannelHistoryTest extends ParameterizedTest {
 
             /* verify message order */
             for(int i = 0; i < 10; i++)
-                expectedMessageHistory[i] = messageContents.get("history" + String.valueOf(i + 20));
+                expectedMessageHistory[i] = messageContents.get("history" + (i + 20));
             Assert.assertArrayEquals("Expect messages in forward order", messages.items(), expectedMessageHistory);
 
         } catch (AblyException e) {
@@ -437,7 +437,7 @@ public class RestChannelHistoryTest extends ParameterizedTest {
             /* verify message order */
             Message[] expectedMessageHistory = new Message[10];
             for(int i = 0; i < 10; i++)
-                expectedMessageHistory[i] = messageContents.get("history" + String.valueOf(49 - i));
+                expectedMessageHistory[i] = messageContents.get("history" + (49 - i));
             Assert.assertArrayEquals("Expect messages in forward order", messages.items(), expectedMessageHistory);
 
             /* get next page */
@@ -451,7 +451,7 @@ public class RestChannelHistoryTest extends ParameterizedTest {
 
             /* verify message order */
             for(int i = 0; i < 10; i++)
-                expectedMessageHistory[i] = messageContents.get("history" + String.valueOf(39 - i));
+                expectedMessageHistory[i] = messageContents.get("history" + (39 - i));
             Assert.assertArrayEquals("Expect messages in forward order", messages.items(), expectedMessageHistory);
 
             /* get next page */
@@ -465,7 +465,7 @@ public class RestChannelHistoryTest extends ParameterizedTest {
 
             /* verify message order */
             for(int i = 0; i < 10; i++)
-                expectedMessageHistory[i] = messageContents.get("history" + String.valueOf(29 - i));
+                expectedMessageHistory[i] = messageContents.get("history" + (29 - i));
             Assert.assertArrayEquals("Expect messages in forward order", messages.items(), expectedMessageHistory);
 
         } catch (AblyException e) {
@@ -519,7 +519,7 @@ public class RestChannelHistoryTest extends ParameterizedTest {
 
             /* verify message order */
             for(int i = 0; i < 10; i++)
-                expectedMessageHistory[i] = messageContents.get("history" + String.valueOf(i + 10));
+                expectedMessageHistory[i] = messageContents.get("history" + (i + 10));
             Assert.assertArrayEquals("Expect messages in forward order", messages.items(), expectedMessageHistory);
 
             /* get first page */
@@ -533,7 +533,7 @@ public class RestChannelHistoryTest extends ParameterizedTest {
 
             /* verify message order */
             for(int i = 0; i < 10; i++)
-                expectedMessageHistory[i] = messageContents.get("history" + String.valueOf(i));
+                expectedMessageHistory[i] = messageContents.get("history" + i);
             Assert.assertArrayEquals("Expect messages in forward order", messages.items(), expectedMessageHistory);
 
         } catch (AblyException e) {
@@ -573,7 +573,7 @@ public class RestChannelHistoryTest extends ParameterizedTest {
             /* verify message order */
             Message[] expectedMessageHistory = new Message[10];
             for(int i = 0; i < 10; i++)
-                expectedMessageHistory[i] = messageContents.get("history" + String.valueOf(49 - i));
+                expectedMessageHistory[i] = messageContents.get("history" + (49 - i));
             Assert.assertArrayEquals("Expect messages in forward order", messages.items(), expectedMessageHistory);
 
             /* get next page */
@@ -587,7 +587,7 @@ public class RestChannelHistoryTest extends ParameterizedTest {
 
             /* verify message order */
             for(int i = 0; i < 10; i++)
-                expectedMessageHistory[i] = messageContents.get("history" + String.valueOf(39 - i));
+                expectedMessageHistory[i] = messageContents.get("history" + (39 - i));
             Assert.assertArrayEquals("Expect messages in forward order", messages.items(), expectedMessageHistory);
 
             /* get first page */
@@ -601,7 +601,7 @@ public class RestChannelHistoryTest extends ParameterizedTest {
 
             /* verify message order */
             for(int i = 0; i < 10; i++)
-                expectedMessageHistory[i] = messageContents.get("history" + String.valueOf(49 - i));
+                expectedMessageHistory[i] = messageContents.get("history" + (49 - i));
             Assert.assertArrayEquals("Expect messages in forward order", messages.items(), expectedMessageHistory);
 
         } catch (AblyException e) {

--- a/lib/src/test/java/io/ably/lib/test/rest/RestErrorTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestErrorTest.java
@@ -129,7 +129,7 @@ public class RestErrorTest extends ParameterizedTest {
         }
     }
 
-    private static String href(int code) { return HREF_BASE + String.valueOf(code); }
+    private static String href(int code) { return HREF_BASE + code; }
     private static final String HREF_BASE = "https://help.ably.io/error/";
 
     private static class SessionHandlerNanoHTTPD extends NanoHTTPD {

--- a/lib/src/test/java/io/ably/lib/test/util/TimeHandler.java
+++ b/lib/src/test/java/io/ably/lib/test/util/TimeHandler.java
@@ -31,7 +31,7 @@ public class TimeHandler extends RouterNanoHTTPD.DefaultStreamHandler {
             Thread.sleep(delay);
         } catch(InterruptedException ie) {}
 
-        return newFixedLengthResponse(NanoHTTPD.Response.Status.OK, getMimeType(), "[" + String.valueOf(System.currentTimeMillis()) + "]");
+        return newFixedLengthResponse(NanoHTTPD.Response.Status.OK, getMimeType(), "[" + System.currentTimeMillis() + "]");
     }
 
 }


### PR DESCRIPTION
Simplify the code by removing unnecessary calls