### PR TITLE
Make Ably version more robust

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/Defaults.java
+++ b/lib/src/main/java/io/ably/lib/transport/Defaults.java
@@ -4,11 +4,13 @@ import io.ably.lib.BuildConfig;
 import io.ably.lib.types.ClientOptions;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 
 public class Defaults {
     /* versions */
     public static final float ABLY_VERSION_NUMBER   = 1.2f;
-    public static final String ABLY_VERSION         = new DecimalFormat("0.0").format(ABLY_VERSION_NUMBER);
+    public static final String ABLY_VERSION         = new DecimalFormat("0.0", new DecimalFormatSymbols(Locale.ENGLISH)).format(ABLY_VERSION_NUMBER);
     public static final String ABLY_LIB_VERSION     = String.format("%s-%s", BuildConfig.LIBRARY_NAME, BuildConfig.VERSION);
 
     /* params */


### PR DESCRIPTION
Some of the tests on my machine were failing due to the incorrect version - "1,2" instead of "1.2". The English locale was added to DecimalFormatter to enforce the proper format.