### PR TITLE
Fix param and return javadoc statements

### DIFF
--- a/android/src/main/java/io/ably/lib/rest/AblyRest.java
+++ b/android/src/main/java/io/ably/lib/rest/AblyRest.java
@@ -12,7 +12,7 @@ public class AblyRest extends AblyBase {
      * This is simply a convenience constructor for the
      * simplest case of instancing the library with a key
      * for basic authentication and no other options.
-     * @param key; String key (obtained from application dashboard)
+     * @param key String key (obtained from application dashboard)
      * @throws AblyException
      */
     public AblyRest(String key) throws AblyException {
@@ -21,7 +21,7 @@ public class AblyRest extends AblyBase {
 
     /**
      * Instance the Ably library with the given options.
-     * @param options: see {@link io.ably.lib.types.ClientOptions} for options
+     * @param options see {@link io.ably.lib.types.ClientOptions} for options
      * @throws AblyException
      */
     public AblyRest(ClientOptions options) throws AblyException {

--- a/lib/src/main/java/io/ably/lib/http/AsyncPaginatedQuery.java
+++ b/lib/src/main/java/io/ably/lib/http/AsyncPaginatedQuery.java
@@ -15,11 +15,11 @@ public class AsyncPaginatedQuery<T> {
     /**
      * Construct a PaginatedQuery
      *
-     * @param http. the httpCore instance
-     * @param path. the path of the resource being queried
-     * @param headers. headers to pass into the first and all relative queries
-     * @param params. params to pass into the initial query
-     * @param bodyHandler. handler to parse response bodies for first and all relative queries
+     * @param http the httpCore instance
+     * @param path the path of the resource being queried
+     * @param headers headers to pass into the first and all relative queries
+     * @param params params to pass into the initial query
+     * @param bodyHandler handler to parse response bodies for first and all relative queries
      */
     public AsyncPaginatedQuery(Http http, String path, Param[] headers, Param[] params, HttpCore.BodyHandler<T> bodyHandler) {
         this(http, path, headers, params, null, bodyHandler);
@@ -28,11 +28,11 @@ public class AsyncPaginatedQuery<T> {
     /**
      * Construct a PaginatedQuery
      *
-     * @param http. the http instance
-     * @param path. the path of the resource being queried
-     * @param headers. headers to pass into the first and all relative queries
-     * @param params. params to pass into the initial query
-     * @param bodyHandler. handler to parse response bodies for first and all relative queries
+     * @param http the http instance
+     * @param path the path of the resource being queried
+     * @param headers headers to pass into the first and all relative queries
+     * @param params params to pass into the initial query
+     * @param bodyHandler handler to parse response bodies for first and all relative queries
      */
     public AsyncPaginatedQuery(Http http, String path, Param[] headers, Param[] params, HttpCore.RequestBody requestBody, HttpCore.BodyHandler<T> bodyHandler) {
         base = new BasePaginatedQuery<T>(http, path, headers, params, requestBody, bodyHandler);
@@ -40,7 +40,7 @@ public class AsyncPaginatedQuery<T> {
 
     /**
      * Get the result of the first query
-     * @param callback. On success returns A PaginatedResult<T> giving the
+     * @param callback On success returns A PaginatedResult<T> giving the
      * first page of results together with any available links to related results pages.
      */
     public void get(Callback<AsyncPaginatedResult<T>> callback) {

--- a/lib/src/main/java/io/ably/lib/http/BasePaginatedQuery.java
+++ b/lib/src/main/java/io/ably/lib/http/BasePaginatedQuery.java
@@ -27,11 +27,11 @@ public class BasePaginatedQuery<T> implements HttpCore.ResponseHandler<BasePagin
     /**
      * Construct a PaginatedQuery
      *
-     * @param http. the http instance
-     * @param path. the path of the resource being queried
-     * @param headers. headers to pass into the first and all relative queries
-     * @param params. params to pass into the initial query
-     * @param bodyHandler. handler to parse response bodies for first and all relative queries
+     * @param http the http instance
+     * @param path the path of the resource being queried
+     * @param headers headers to pass into the first and all relative queries
+     * @param params params to pass into the initial query
+     * @param bodyHandler handler to parse response bodies for first and all relative queries
      */
     public BasePaginatedQuery(Http http, String path, Param[] headers, Param[] params, HttpCore.BodyHandler<T> bodyHandler) {
         this(http, path, headers, params, null, bodyHandler);
@@ -40,11 +40,11 @@ public class BasePaginatedQuery<T> implements HttpCore.ResponseHandler<BasePagin
     /**
      * Construct a PaginatedQuery
      *
-     * @param http. the http instance
-     * @param path. the path of the resource being queried
-     * @param headers. headers to pass into the first and all relative queries
-     * @param params. params to pass into the initial query
-     * @param bodyHandler. handler to parse response bodies for first and all relative queries
+     * @param http the http instance
+     * @param path the path of the resource being queried
+     * @param headers headers to pass into the first and all relative queries
+     * @param params params to pass into the initial query
+     * @param bodyHandler handler to parse response bodies for first and all relative queries
      */
     public BasePaginatedQuery(Http http, String path, Param[] headers, Param[] params, HttpCore.RequestBody requestBody, HttpCore.BodyHandler<T> bodyHandler) {
         this.http = http;

--- a/lib/src/main/java/io/ably/lib/http/PaginatedQuery.java
+++ b/lib/src/main/java/io/ably/lib/http/PaginatedQuery.java
@@ -15,11 +15,11 @@ public class PaginatedQuery<T>  {
     /**
      * Construct a PaginatedQuery
      *
-     * @param http. the http instance
-     * @param path. the path of the resource being queried
-     * @param headers. headers to pass into the first and all relative queries
-     * @param params. params to pass into the initial query
-     * @param bodyHandler. handler to parse response bodies for first and all relative queries
+     * @param http the http instance
+     * @param path the path of the resource being queried
+     * @param headers headers to pass into the first and all relative queries
+     * @param params params to pass into the initial query
+     * @param bodyHandler handler to parse response bodies for first and all relative queries
      */
     public PaginatedQuery(Http http, String path, Param[] headers, Param[] params, HttpCore.BodyHandler<T> bodyHandler) {
         this(http, path, headers, params, null, bodyHandler);
@@ -28,11 +28,11 @@ public class PaginatedQuery<T>  {
     /**
      * Construct a PaginatedQuery
      *
-     * @param http. the http instance
-     * @param path. the path of the resource being queried
-     * @param headers. headers to pass into the first and all relative queries
-     * @param params. params to pass into the initial query
-     * @param bodyHandler. handler to parse response bodies for first and all relative queries
+     * @param http the http instance
+     * @param path the path of the resource being queried
+     * @param headers headers to pass into the first and all relative queries
+     * @param params params to pass into the initial query
+     * @param bodyHandler handler to parse response bodies for first and all relative queries
      */
     public PaginatedQuery(Http http, String path, Param[] headers, Param[] params, HttpCore.RequestBody requestBody, HttpCore.BodyHandler<T> bodyHandler) {
         base = new BasePaginatedQuery<T>(http, path, headers, params, requestBody, bodyHandler);

--- a/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
+++ b/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
@@ -36,7 +36,7 @@ public class AblyRealtime extends AblyRest implements AutoCloseable {
      * This is simply a convenience constructor for the
      * simplest case of instancing the library with a key
      * for basic authentication and no other options.
-     * @param key; String key (obtained from application dashboard)
+     * @param key String key (obtained from application dashboard)
      * @throws AblyException
      */
     public AblyRealtime(String key) throws AblyException {
@@ -45,7 +45,7 @@ public class AblyRealtime extends AblyRest implements AutoCloseable {
 
     /**
      * Instance the Ably library with the given options.
-     * @param options: see {@link io.ably.lib.types.ClientOptions} for options
+     * @param options see {@link io.ably.lib.types.ClientOptions} for options
      * @throws AblyException
      */
     public AblyRealtime(ClientOptions options) throws AblyException {
@@ -61,7 +61,7 @@ public class AblyRealtime extends AblyRest implements AutoCloseable {
                 channels.clear();
             }
         });
-        
+
         if(options.autoConnect) connection.connect();
     }
 

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -603,7 +603,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Subscribe for messages on this channel. This implicitly attaches the channel if
      * not already attached.
-     * @param listener: the MessageListener
+     * @param listener the MessageListener
      * @throws AblyException
      */
     public synchronized void subscribe(MessageListener listener) throws AblyException {
@@ -614,7 +614,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
 
     /**
      * Unsubscribe a previously subscribed listener from this channel.
-     * @param listener: the previously subscribed listener.
+     * @param listener the previously subscribed listener.
      */
     public synchronized void unsubscribe(MessageListener listener) {
         Log.v(TAG, "unsubscribe(); channel = " + this.name);
@@ -627,8 +627,8 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Subscribe for messages with a specific event name on this channel.
      * This implicitly attaches the channel if not already attached.
-     * @param name: the event name
-     * @param listener: the MessageListener
+     * @param name the event name
+     * @param listener the MessageListener
      * @throws AblyException
      */
     public synchronized void subscribe(String name, MessageListener listener) throws AblyException {
@@ -639,8 +639,8 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
 
     /**
      * Unsubscribe a previously subscribed event listener from this channel.
-     * @param name: the event name
-     * @param listener: the previously subscribed listener.
+     * @param name the event name
+     * @param listener the previously subscribed listener.
      */
     public synchronized void unsubscribe(String name, MessageListener listener) {
         Log.v(TAG, "unsubscribe(); channel = " + this.name + "; event = " + name);
@@ -650,8 +650,8 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Subscribe for messages with an array of event names on this channel.
      * This implicitly attaches the channel if not already attached.
-     * @param names: the event names
-     * @param listener: the MessageListener
+     * @param names the event names
+     * @param listener the MessageListener
      * @throws AblyException
      */
     public synchronized void subscribe(String[] names, MessageListener listener) throws AblyException {
@@ -663,8 +663,8 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
 
     /**
      * Unsubscribe a previously subscribed event listener from this channel.
-     * @param names: the event names
-     * @param listener: the previously subscribed listener.
+     * @param names the event names
+     * @param listener the previously subscribed listener.
      */
     public synchronized void unsubscribe(String[] names, MessageListener listener) {
         Log.v(TAG, "unsubscribe(); channel = " + this.name + "; (multiple events)");
@@ -815,8 +815,8 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Publish a message on this channel. This implicitly attaches the channel if
      * not already attached.
-     * @param name: the event name
-     * @param data: the message payload
+     * @param name the event name
+     * @param data the message payload
      * @throws AblyException
      */
     public void publish(String name, Object data) throws AblyException {
@@ -826,7 +826,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Publish a message on this channel. This implicitly attaches the channel if
      * not already attached.
-     * @param message: the message
+     * @param message the message
      * @throws AblyException
      */
     public void publish(Message message) throws AblyException {
@@ -836,7 +836,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Publish an array of messages on this channel. This implicitly attaches the channel if
      * not already attached.
-     * @param messages: the message
+     * @param messages the message
      * @throws AblyException
      */
     public void publish(Message[] messages) throws AblyException {
@@ -846,9 +846,9 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Publish a message on this channel. This implicitly attaches the channel if
      * not already attached.
-     * @param name: the event name
-     * @param data: the message payload. See {@link io.ably.types.Data} for supported datatypes
-     * @param listener: a listener to be notified of the outcome of this message.
+     * @param name the event name
+     * @param data the message payload. See {@link io.ably.types.Data} for supported datatypes
+     * @param listener a listener to be notified of the outcome of this message.
      * @throws AblyException
      */
     public void publish(String name, Object data, CompletionListener listener) throws AblyException {
@@ -859,8 +859,8 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Publish a message on this channel. This implicitly attaches the channel if
      * not already attached.
-     * @param message: the message
-     * @param listener: a listener to be notified of the outcome of this message.
+     * @param message the message
+     * @param listener a listener to be notified of the outcome of this message.
      * @throws AblyException
      */
     public void publish(Message message, CompletionListener listener) throws AblyException {
@@ -871,8 +871,8 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Publish an array of messages on this channel. This implicitly attaches the channel if
      * not already attached.
-     * @param messages: the message
-     * @param listener: a listener to be notified of the outcome of this message.
+     * @param messages the message
+     * @param listener a listener to be notified of the outcome of this message.
      * @throws AblyException
      */
     public synchronized void publish(Message[] messages, CompletionListener listener) throws AblyException {
@@ -1005,9 +1005,9 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
      * Obtain recent history for this channel using the REST API.
      * The history provided relqtes to all clients of this application,
      * not just this instance.
-     * @param params: the request params. See the Ably REST API
+     * @param params the request params. See the Ably REST API
      * documentation for more details.
-     * @return: an array of Messgaes for this Channel.
+     * @return an array of Messgaes for this Channel.
      * @throws AblyException
      */
     public PaginatedResult<Message> history(Param[] params) throws AblyException {

--- a/lib/src/main/java/io/ably/lib/realtime/CompletionListener.java
+++ b/lib/src/main/java/io/ably/lib/realtime/CompletionListener.java
@@ -16,7 +16,7 @@ public interface CompletionListener {
 
     /**
      * Called when the associated operation completes with an error.
-     * @param reason: information about the error.
+     * @param reason information about the error.
      */
     void onError(ErrorInfo reason);
 

--- a/lib/src/main/java/io/ably/lib/realtime/Connection.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Connection.java
@@ -55,7 +55,7 @@ public class Connection extends EventEmitter<ConnectionEvent, ConnectionStateLis
 
     /**
      * Send a heartbeat message to the Ably service and await a response.
-     * @param listener: a listener to be notified of the outcome of this message.
+     * @param listener a listener to be notified of the outcome of this message.
      */
     public void ping(CompletionListener listener) {
         connectionManager.ping(listener);

--- a/lib/src/main/java/io/ably/lib/realtime/Presence.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Presence.java
@@ -100,7 +100,7 @@ public class Presence {
     /**
      * Subscribe to presence events on the associated Channel. This implicitly
      * attaches the Channel if it is not already attached.
-     * @param listener: the listener to me notified on arrival of presence messages.
+     * @param listener the listener to me notified on arrival of presence messages.
      * @param completionListener listener to be called on success/failure
      * @throws AblyException
      */
@@ -118,7 +118,7 @@ public class Presence {
 
     /**
      * Unsubscribe a previously subscribed presence listener for this channel.
-     * @param listener: the previously subscribed listener.
+     * @param listener the previously subscribed listener.
      */
     public void unsubscribe(PresenceListener listener) {
         listeners.remove(listener);
@@ -390,9 +390,9 @@ public class Presence {
     /**
      * Enter this client into this channel. This client will be added to the presence set
      * and presence subscribers will see an enter message for this client.
-     * @param data: optional data (eg a status message) for this member.
+     * @param data optional data (eg a status message) for this member.
      * See {@link io.ably.types.Data} for the supported data types.
-     * @param listener: a listener to be notified on completion of the operation.
+     * @param listener a listener to be notified on completion of the operation.
      * @throws AblyException
      */
     public void enter(Object data, CompletionListener listener) throws AblyException {
@@ -404,9 +404,9 @@ public class Presence {
      * Update the presence data for this client. If the client is not already a member of
      * the presence set it will be added, and presence subscribers will see an enter or
      * update message for this client.
-     * @param data: optional data (eg a status message) for this member.
+     * @param data optional data (eg a status message) for this member.
      * See {@link io.ably.types.Data} for the supported data types.
-     * @param listener: a listener to be notified on completion of the operation.
+     * @param listener a listener to be notified on completion of the operation.
      * @throws AblyException
      */
     public void update(Object data, CompletionListener listener) throws AblyException {
@@ -417,9 +417,9 @@ public class Presence {
     /**
      * Leave this client from this channel. This client will be removed from the presence
      * set and presence subscribers will see a leave message for this client.
-     * @param data: optional data (eg a status message) for this member.
+     * @param data optional data (eg a status message) for this member.
      * See {@link io.ably.types.Data} for the supported data types.
-     * @param listener: a listener to be notified on completion of the operation.
+     * @param listener a listener to be notified on completion of the operation.
      * @throws AblyException
      */
     public void leave(Object data, CompletionListener listener) throws AblyException {
@@ -430,7 +430,7 @@ public class Presence {
     /**
      * Leave this client from this channel. This client will be removed from the presence
      * set and presence subscribers will see a leave message for this client.
-     * @param listener: a listener to be notified on completion of the operation.
+     * @param listener a listener to be notified on completion of the operation.
      * @throws AblyException
      */
     public void leave(CompletionListener listener) throws AblyException {
@@ -445,7 +445,7 @@ public class Presence {
      * server instances) that act on behalf of multiple clientIds. In order to be able to
      * enter the channel with this method, the client library must have been instanced
      * either with a key, or with a token bound to the wildcard clientId.
-     * @param clientId: the id of the client.
+     * @param clientId the id of the client.
      */
     public void enterClient(String clientId) throws AblyException {
         enterClient(clientId, null);
@@ -458,8 +458,8 @@ public class Presence {
      * server instances) that act on behalf of multiple clientIds. In order to be able to
      * enter the channel with this method, the client library must have been instanced
      * either with a key, or with a token bound to the wildcard clientId.
-     * @param clientId: the id of the client.
-     * @param data: optional data (eg a status message) for this member.
+     * @param clientId the id of the client.
+     * @param data optional data (eg a status message) for this member.
      * @throws AblyException
      */
     public void enterClient(String clientId, Object data) throws AblyException {
@@ -473,9 +473,9 @@ public class Presence {
      * server instances) that act on behalf of multiple clientIds. In order to be able to
      * enter the channel with this method, the client library must have been instanced
      * either with a key, or with a token bound to the wildcard clientId.
-     * @param clientId: the id of the client.
-     * @param data: optional data (eg a status message) for this member.
-     * @param listener: a listener to be notified on completion of the operation.
+     * @param clientId the id of the client.
+     * @param data optional data (eg a status message) for this member.
+     * @param listener a listener to be notified on completion of the operation.
      * @throws AblyException
      */
     public void enterClient(String clientId, Object data, CompletionListener listener) throws AblyException {
@@ -497,7 +497,7 @@ public class Presence {
      * and presence subscribers will see a corresponding presence message
      * with an empty data payload. As for #enterClient above, the connection
      * must be authenticated in a way that enables it to represent an arbitrary clientId.
-     * @param clientId: the id of the client.
+     * @param clientId the id of the client.
      * @throws AblyException
      */
     public void updateClient(String clientId) throws AblyException {
@@ -510,8 +510,8 @@ public class Presence {
      * presence subscribers will see an enter or update message for this client.
      * As for #enterClient above, the connection must be authenticated in a way that
      * enables it to represent an arbitrary clientId.
-     * @param clientId: the id of the client.
-     * @param data: optional data (eg a status message) for this member.
+     * @param clientId the id of the client.
+     * @param data optional data (eg a status message) for this member.
      * @throws AblyException
      */
     public void updateClient(String clientId, Object data) throws AblyException {
@@ -524,9 +524,9 @@ public class Presence {
      * presence subscribers will see an enter or update message for this client.
      * As for #enterClient above, the connection must be authenticated in a way that
      * enables it to represent an arbitrary clientId.
-     * @param clientId: the id of the client.
-     * @param data: optional data (eg a status message) for this member.
-     * @param listener: a listener to be notified on completion of the operation.
+     * @param clientId the id of the client.
+     * @param data optional data (eg a status message) for this member.
+     * @param listener a listener to be notified on completion of the operation.
      * @throws AblyException
      */
     public void updateClient(String clientId, Object data, CompletionListener listener) throws AblyException {
@@ -546,7 +546,7 @@ public class Presence {
      * Leave a given client from this channel. This client will be removed from the
      * presence set and presence subscribers will see a corresponding presence message
      * with an empty data payload.
-     * @param clientId: the id of the client.
+     * @param clientId the id of the client.
      * @throws AblyException
      */
     public void leaveClient(String clientId) throws AblyException {
@@ -556,8 +556,8 @@ public class Presence {
     /**
      * Leave a given client from this channel. This client will be removed from the
      * presence set and presence subscribers will see a leave message for this client.
-     * @param clientId: the id of the client.
-     * @param data: optional data (eg a status message) for this member.
+     * @param clientId the id of the client.
+     * @param data optional data (eg a status message) for this member.
      * @throws AblyException
      */
     public void leaveClient(String clientId, Object data) throws AblyException {
@@ -567,9 +567,9 @@ public class Presence {
     /**
      * Leave a given client from this channel. This client will be removed from the
      * presence set and presence subscribers will see a leave message for this client.
-     * @param clientId: the id of the client.
-     * @param data: optional data (eg a status message) for this member.
-     * @param listener: a listener to be notified on completion of the operation.
+     * @param clientId the id of the client.
+     * @param data optional data (eg a status message) for this member.
+     * @param listener a listener to be notified on completion of the operation.
      * @throws AblyException
      */
     public void leaveClient(String clientId, Object data, CompletionListener listener) throws AblyException {
@@ -589,8 +589,8 @@ public class Presence {
      * Update the presence for this channel with a given PresenceMessage update.
      * The connection must be authenticated in a way that enables it to represent
      * the clientId in the message.
-     * @param msg: the presence message
-     * @param listener: a listener to be notified on completion of the operation.
+     * @param msg the presence message
+     * @param listener a listener to be notified on completion of the operation.
      * @throws AblyException
      */
     public void updatePresence(PresenceMessage msg, CompletionListener listener) throws AblyException {
@@ -637,9 +637,9 @@ public class Presence {
      * Obtain recent history for this channel using the REST API.
      * The history provided relates to all clients of this application,
      * not just this instance.
-     * @param params: the request params. See the Ably REST API
+     * @param params the request params. See the Ably REST API
      * documentation for more details.
-     * @return: an array of Messgaes for this Channel.
+     * @return an array of Messgaes for this Channel.
      * @throws AblyException
      */
     public PaginatedResult<PresenceMessage> history(Param[] params) throws AblyException {

--- a/lib/src/main/java/io/ably/lib/rest/AblyBase.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyBase.java
@@ -57,7 +57,7 @@ public abstract class AblyBase {
      * This is simply a convenience constructor for the
      * simplest case of instancing the library with a key
      * for basic authentication and no other options.
-     * @param key; String key (obtained from application dashboard)
+     * @param key String key (obtained from application dashboard)
      * @throws AblyException
      */
     public AblyBase(String key) throws AblyException {
@@ -66,7 +66,7 @@ public abstract class AblyBase {
 
     /**
      * Instance the Ably library with the given options.
-     * @param options: see {@link io.ably.lib.types.ClientOptions} for options
+     * @param options see {@link io.ably.lib.types.ClientOptions} for options
      * @throws AblyException
      */
     public AblyBase(ClientOptions options) throws AblyException {
@@ -190,7 +190,7 @@ public abstract class AblyBase {
 
     /**
      * Asynchronously obtain usage statistics for this application using the REST API.
-     * @param params: the request params. See the Ably REST API
+     * @param params the request params. See the Ably REST API
      * @param callback
      * @return
      */
@@ -201,8 +201,8 @@ public abstract class AblyBase {
     /**
      * Make a generic HTTP request against an endpoint representing a collection
      * of some type; this is to provide a forward compatibility path for new APIs.
-     * @param method: the HTTP method to use (see constants in io.ably.lib.httpCore.HttpCore)
-     * @param path: the path component of the resource URI
+     * @param method the HTTP method to use (see constants in io.ably.lib.httpCore.HttpCore)
+     * @param path the path component of the resource URI
      * @param params (optional; may be null): any parameters to send with the request; see API-specific documentation
      * @param body (optional; may be null): an instance of RequestBody; either a JSONRequestBody or ByteArrayRequestBody
      * @param headers (optional; may be null): any additional headers to send; see API-specific documentation
@@ -217,12 +217,12 @@ public abstract class AblyBase {
     /**
      * Make an async generic HTTP request against an endpoint representing a collection
      * of some type; this is to provide a forward compatibility path for new APIs.
-     * @param method: the HTTP method to use (see constants in io.ably.lib.httpCore.HttpCore)
-     * @param path: the path component of the resource URI
+     * @param method the HTTP method to use (see constants in io.ably.lib.httpCore.HttpCore)
+     * @param path the path component of the resource URI
      * @param params (optional; may be null): any parameters to send with the request; see API-specific documentation
      * @param body (optional; may be null): an instance of RequestBody; either a JSONRequestBody or ByteArrayRequestBody
      * @param headers (optional; may be null): any additional headers to send; see API-specific documentation
-     * @param callback: called with the asynchronous result
+     * @param callback called with the asynchronous result
      */
     public void requestAsync(String method, String path, Param[] params, HttpCore.RequestBody body, Param[] headers, final AsyncHttpPaginatedResponse.Callback callback)  {
         headers = HttpUtils.mergeHeaders(HttpUtils.defaultAcceptHeaders(false), headers);

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -123,7 +123,7 @@ public class Auth {
         /**
          * Convenience constructor, to create an AuthOptions based
          * on the key string obtained from the application dashboard.
-         * @param key: the full key string as obtained from the dashboard
+         * @param key the full key string as obtained from the dashboard
          * @throws AblyException
          */
         public AuthOptions(String key) throws AblyException {
@@ -555,7 +555,7 @@ public class Auth {
      * has a valid token. It would typically be used to issue tokens for use by other clients.
      * @param params : see {@link #authorize} for params
      * @param tokenOptions : see {@link #authorize} for options
-     * @return: the TokenDetails
+     * @return the TokenDetails
      * @throws AblyException
      */
     public TokenDetails requestToken(TokenParams params, AuthOptions tokenOptions) throws AblyException {
@@ -700,7 +700,7 @@ public class Auth {
      * signed requests for submission by another client.
      * @param params : see {@link #authorize} for params
      * @param options : see {@link #authorize} for options
-     * @return: the params augmented with the mac.
+     * @return the params augmented with the mac.
      * @throws AblyException
      */
     public TokenRequest createTokenRequest(TokenParams params, AuthOptions options) throws AblyException {
@@ -1041,8 +1041,8 @@ public class Auth {
      * Verify that a message, possibly containing a clientId,
      * is compatible with Auth.clientId if it is set
      * @param msg
-     * @param allowNullClientId: true if it is ok for there to be no resolved clientId
-     * @param connected: true if connected; if false it is ok for the library to be unidentified
+     * @param allowNullClientId true if it is ok for there to be no resolved clientId
+     * @param connected true if connected; if false it is ok for the library to be unidentified
      * @return the resolved clientId
      * @throws AblyException
      */

--- a/lib/src/main/java/io/ably/lib/rest/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/rest/ChannelBase.java
@@ -42,8 +42,8 @@ public class ChannelBase {
      * Publish a message on this channel using the REST API.
      * Since the REST API is stateless, this request is made independently
      * of any other request on this or any other channel.
-     * @param name: the event name
-     * @param data: the message payload; see {@link io.ably.types.Data} for
+     * @param name the event name
+     * @param data the message payload; see {@link io.ably.types.Data} for
      * details of supported data types.
      * @throws AblyException
      */
@@ -55,8 +55,8 @@ public class ChannelBase {
      * Publish a message on this channel using the REST API.
      * Since the REST API is stateless, this request is made independently
      * of any other request on this or any other channel.
-     * @param name: the event name
-     * @param data: the message payload; see {@link io.ably.types.Data} for
+     * @param name the event name
+     * @param data the message payload; see {@link io.ably.types.Data} for
      * @param listener
      */
     public void publishAsync(String name, Object data, CompletionListener listener) {
@@ -72,7 +72,7 @@ public class ChannelBase {
      * multiple messages to be sent, it is more efficient to use this
      * method to publish them in a single request, as compared with
      * publishing via multiple independent requests.
-     * @param messages: array of messages to publish.
+     * @param messages array of messages to publish.
      * @throws AblyException
      */
     public void publish(final Message[] messages) throws AblyException {
@@ -120,9 +120,9 @@ public class ChannelBase {
      * Obtain recent history for this channel using the REST API.
      * The history provided relqtes to all clients of this application,
      * not just this instance.
-     * @param params: the request params. See the Ably REST API
+     * @param params the request params. See the Ably REST API
      * documentation for more details.
-     * @return: an array of Messages for this Channel.
+     * @return an array of Messages for this Channel.
      * @throws AblyException
      */
     public PaginatedResult<Message> history(Param[] params) throws AblyException {
@@ -131,7 +131,7 @@ public class ChannelBase {
 
     /**
      * Asynchronously obtain recent history for this channel using the REST API.
-     * @param params: the request params. See the Ably REST API
+     * @param params the request params. See the Ably REST API
      * @param callback
      * @return
      */
@@ -154,8 +154,8 @@ public class ChannelBase {
 
         /**
          * Get the presence state for this Channel.
-         * @return: the current present members.
-         * @throws AblyException 
+         * @return the current present members.
+         * @throws AblyException
          */
         public PaginatedResult<PresenceMessage> get(Param[] params) throws AblyException {
             return getImpl(params).sync();
@@ -163,7 +163,7 @@ public class ChannelBase {
 
         /**
          * Asynchronously get the presence state for this Channel.
-         * @param callback: on success returns the currently present members.
+         * @param callback on success returns the currently present members.
          */
         public void getAsync(Param[] params, Callback<AsyncPaginatedResult<PresenceMessage>> callback) {
             getImpl(params).async(callback);
@@ -178,7 +178,7 @@ public class ChannelBase {
          * Asynchronously obtain presence history for this channel using the REST API.
          * The history provided relqtes to all clients of this application,
          * not just this instance.
-         * @param params: the request params. See the Ably REST API
+         * @param params the request params. See the Ably REST API
          * documentation for more details.
          */
         public PaginatedResult<PresenceMessage> history(Param[] params) throws AblyException {
@@ -187,7 +187,7 @@ public class ChannelBase {
 
         /**
          * Asynchronously obtain recent history for this channel using the REST API.
-         * @param params: the request params. See the Ably REST API
+         * @param params the request params. See the Ably REST API
          * @param callback
          * @return
          */
@@ -204,7 +204,7 @@ public class ChannelBase {
 
     /******************
      * internal
-     * @throws AblyException 
+     * @throws AblyException
      ******************/
 
     ChannelBase(AblyBase ably, String name, ChannelOptions options) throws AblyException {

--- a/lib/src/main/java/io/ably/lib/types/AsyncHttpPaginatedResponse.java
+++ b/lib/src/main/java/io/ably/lib/types/AsyncHttpPaginatedResponse.java
@@ -37,7 +37,7 @@ public abstract class AsyncHttpPaginatedResponse {
 
         /**
          * Called when the associated operation completes with an error.
-         * @param reason: information about the error.
+         * @param reason information about the error.
          */
         void onError(ErrorInfo reason);
     }

--- a/lib/src/main/java/io/ably/lib/types/Callback.java
+++ b/lib/src/main/java/io/ably/lib/types/Callback.java
@@ -14,7 +14,7 @@ public interface Callback<T> {
 
     /**
      * Called when the associated operation completes with an error.
-     * @param reason: information about the error.
+     * @param reason information about the error.
      */
     void onError(ErrorInfo reason);
 

--- a/lib/src/main/java/io/ably/lib/types/Capability.java
+++ b/lib/src/main/java/io/ably/lib/types/Capability.java
@@ -20,8 +20,8 @@ public class Capability {
 
     /**
      * Convenience method to canonicalise a JSON capability expression
-     * 
-     * @param capability: a capability string, which is the JSON text for the capability
+     *
+     * @param capability a capability string, which is the JSON text for the capability
      * @return a capability string which has been canonicalised
      * @throws AblyException if there is an error processing the given string
      * (if for example it is not valid JSON)
@@ -150,7 +150,7 @@ public class Capability {
             }
         /* removal doesn't break sort order, so dirty can remain false */
     }
-    
+
     /**
      * Get the canonicalised String text for a Capability instance.
      * The json object and its members are sorted if the object has been modified

--- a/lib/src/main/java/io/ably/lib/types/ClientOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ClientOptions.java
@@ -21,7 +21,7 @@ public class ClientOptions extends AuthOptions {
     /**
      * Construct an options with a single key string. The key string is obtained
      * from the application dashboard.
-     * @param key: the key string
+     * @param key the key string
      * @throws AblyException if the key is not in a valid format
      */
     public ClientOptions(String key) throws AblyException {


### PR DESCRIPTION
This fix helps to limit the number of warnings displayed while building the Android-specific library

```
...\java\io\ably\lib\types\Callback.java:19: warning - @param argument "reason:" is not a parameter name.
...\java\io\ably\lib\types\Capability.java:29: warning - @param argument "capability:" is not a parameter name.
...\java\io\ably\lib\types\ClientOptions.java:27: warning - @param argument "key:" is not a parameter name.

```