### PR TITLE
Gradle conform and reformat

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,8 +9,7 @@ charset = utf-8
 indent_style = space
 indent_size = 2
 
-[*.java]
-indent_style = space
+[*.{java,groovy,gradle}]
 indent_size = 4
 
 [*.md]

--- a/README.md
+++ b/README.md
@@ -489,13 +489,28 @@ The Android-specific library AAR is built with:
 
 ## Code Standard
 
-We are introducing [Checkstyle](https://checkstyle.org/) to enforce code style and spot for transgressions and illogical constructs.
+### Checkstyle
+
+We use [Checkstyle](https://checkstyle.org/) to enforce code style and spot for transgressions and illogical constructs
+in our Java source files.
 The Gradle build has been configured to run these on `java:assembleRelease`.
 It does not run for the Android build yet.
 
 You can run just the Checkstyle rules on their own using:
 
     ./gradlew checkstyleMain
+
+### CodeNarc
+
+We use [CodeNarc](https://codenarc.org/) to enforce code style in our Gradle build scripts, which are all written in Groovy.
+
+You can run CodeNarc over all build scripts in this repository using:
+
+    ./gradlew checkWithCodenarc
+
+For more details see the [`gradle-lint`](gradle-lint) project.
+
+### IDE Support
 
 We have a root [`.editorconfig`](.editorconfig) file, supporting [EditorConfig](https://editorconfig.org/), which should be of assistance within most IDEs. e.g.:
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,7 +58,7 @@ android {
         main {
             java {
                 srcDirs = ['src/main/java', '../lib/src/main/java']
-           }
+            }
         }
         androidTest {
             java {

--- a/android/maven.gradle
+++ b/android/maven.gradle
@@ -11,21 +11,21 @@ def mavenPassword = hasProperty('ossrhPassword') ? ossrhPassword : ''
  * Task which signs and uploads the Android artifacts to Nexus OSSRH.
  */
 uploadArchives {
-	signing {
-		sign configurations.archives
-	}
+    signing {
+        sign configurations.archives
+    }
     repositories.mavenDeployer {
         logger.lifecycle('OSSRH auth with username: ' + mavenUser)
 
-		beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+        beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-		repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+        repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
             authentication(userName: mavenUser, password: mavenPassword)
-		}
+        }
 
-		snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+        snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
             authentication(userName: mavenUser, password: mavenPassword)
-		}
+        }
         pom.groupId = groupId
         pom.artifactId = artifactId
         pom.version = version
@@ -36,16 +36,16 @@ uploadArchives {
             description 'An Android Realtime and REST client library for [Ably.io](https://www.ably.io), the realtime messaging service.'
             packaging 'aar'
             inceptionYear '2015'
-			url 'https://www.github.com/ably/ably-java'
-			developers {
-				developer {
-					name 'Paddy Byers'
-					email 'paddy@ably.io'
-					url 'https://github.com/paddybyers'
-					id 'paddybyers'
-				}
-			}
-			scm {
+            url 'https://www.github.com/ably/ably-java'
+            developers {
+                developer {
+                    name 'Paddy Byers'
+                    email 'paddy@ably.io'
+                    url 'https://github.com/paddybyers'
+                    id 'paddybyers'
+                }
+            }
+            scm {
                 url 'scm:git:https://github.com/ably/ably-java'
                 connection 'scm:git:https://github.com/ably/ably-java'
                 developerConnection 'scm:git:git@github.com:ably/ably-java'
@@ -67,24 +67,24 @@ uploadArchives {
             }
         }
 
-        pom.whenConfigured {
-            p -> p.dependencies = p.dependencies.findAll {
-                // Exclude dependency on lib subproject.
+        pom.whenConfigured { p ->
+            p.dependencies = p.dependencies.findAll {
+                    // Exclude dependency on lib subproject.
                 dep -> dep.artifactId != "lib"
             }.findAll {
-                // Exclude Google services since we don't want to impose a particular
-                // version on users. Ideally we would specify a version range,
-                // but the Google services Gradle plugin doesn't seem to
-                // support that.
-                // TODO: Make sure this works when installing from Maven!
+                    // Exclude Google services since we don't want to impose a particular
+                    // version on users. Ideally we would specify a version range,
+                    // but the Google services Gradle plugin doesn't seem to
+                    // support that.
+                    // TODO: Make sure this works when installing from Maven!
                 dep -> dep.artifactId != 'play-services-gcm' && dep.artifactId != 'firebase-messaging'
             }
         }
 
-		// Export to local Maven cache
+        // Export to local Maven cache
         // COMMENT OUT THIS LINE AND THE ONE BELOW IN ORDER TO RELEASE TO SONATYPE NEXUS STAGING
         // TODO https://github.com/ably/ably-java/issues/566
-		repository(url: repositories.mavenLocal().url)
+        repository(url: repositories.mavenLocal().url)
 
         // Export files to local storage
         // COMMENT OUT THIS LINE AND THE ONE ABOVE IN ORDER TO RELEASE TO SONATYPE NEXUS STAGING
@@ -112,25 +112,25 @@ tasks.whenTaskAdded { task ->
 }
 
 task sourcesJar(type: Jar) {
-     classifier = 'sources'
-     from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+    from android.sourceSets.main.java.srcDirs
 }
 
 task javadoc(type: Javadoc) {
-     source = android.sourceSets.main.java.srcDirs
-     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-     failOnError false
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    failOnError false
 }
 
 afterEvaluate {
-     javadoc.classpath += files(android.libraryVariants.collect { variant ->
-         variant.javaCompile.classpath.files
-     })
+    javadoc.classpath += files(android.libraryVariants.collect { variant ->
+        variant.javaCompile.classpath.files
+    })
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-     classifier = 'javadoc'
-     from javadoc.destinationDir
+    classifier = 'javadoc'
+    from javadoc.destinationDir
 }
 
 artifacts {

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
+plugins {
+  id 'io.codearte.nexus-staging' version '0.21.1'
+}
+
 repositories {
-    google()
+  google()
+  mavenCentral()
 }
-buildscript {
-    repositories {
-        google()
-		mavenCentral()
-	}
-	dependencies {
-		classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.1'
-	}
-}
-apply plugin: 'io.codearte.nexus-staging'
 
 nexusStaging {
 	packageGroup = "io.ably"

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-  id 'io.codearte.nexus-staging' version '0.21.1'
+    id 'io.codearte.nexus-staging' version '0.21.1'
 }
 
 repositories {
-  google()
-  mavenCentral()
+    google()
+    mavenCentral()
 }
 
 nexusStaging {
-	packageGroup = "io.ably"
+    packageGroup = "io.ably"
 }

--- a/common.gradle
+++ b/common.gradle
@@ -1,6 +1,6 @@
 repositories {
-  jcenter()
-  mavenCentral()
+    jcenter()
+    mavenCentral()
 }
 
 group = 'io.ably'
@@ -8,6 +8,6 @@ version = '1.2.2'
 description = """Ably java client library"""
 
 tasks.withType(Javadoc) {
-  // To prevent javadoc warnings with Java 8
-  options.addStringOption('Xdoclint:none', '-quiet')
+    // To prevent javadoc warnings with Java 8
+    options.addStringOption('Xdoclint:none', '-quiet')
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,16 +1,16 @@
 // These dependencies have to be in lib/build.gradle for compilation _and_
 // in java/build.gradle and android/build.gradle for maven.
 dependencies {
-  implementation 'org.msgpack:msgpack-core:0.8.11'
-  implementation 'org.java-websocket:Java-WebSocket:1.4.0'
-  implementation 'com.google.code.gson:gson:2.8.6'
-  implementation 'com.davidehrmann.vcdiff:vcdiff-core:0.1.1'
-  testImplementation 'org.hamcrest:hamcrest-all:1.3'
-  testImplementation 'junit:junit:4.12'
-  testImplementation 'org.nanohttpd:nanohttpd:2.3.0'
-  testImplementation 'org.nanohttpd:nanohttpd-nanolets:2.3.0'
-  testImplementation 'org.nanohttpd:nanohttpd-websocket:2.3.0'
-  testImplementation 'org.mockito:mockito-core:1.10.19'
-  testImplementation 'net.jodah:concurrentunit:0.4.2'
-  testImplementation 'org.slf4j:slf4j-simple:1.7.30'
+    implementation 'org.msgpack:msgpack-core:0.8.11'
+    implementation 'org.java-websocket:Java-WebSocket:1.4.0'
+    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'com.davidehrmann.vcdiff:vcdiff-core:0.1.1'
+    testImplementation 'org.hamcrest:hamcrest-all:1.3'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.nanohttpd:nanohttpd:2.3.0'
+    testImplementation 'org.nanohttpd:nanohttpd-nanolets:2.3.0'
+    testImplementation 'org.nanohttpd:nanohttpd-websocket:2.3.0'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
+    testImplementation 'net.jodah:concurrentunit:0.4.2'
+    testImplementation 'org.slf4j:slf4j-simple:1.7.30'
 }

--- a/gradle-lint/build.gradle
+++ b/gradle-lint/build.gradle
@@ -1,0 +1,86 @@
+plugins {
+    id 'codenarc'
+
+    // This project needs the groovy plugin so that it will recognise groovy source sets,
+    // which is a requirement of using the codenarc plugin.
+    id 'groovy'
+}
+
+repositories {
+    jcenter()
+}
+
+sourceSets {
+    // delegate: https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/SourceSetContainer.html
+    // a.k.a. NamedDomainObjectContainer<SourceSet>
+    // TODO: find canonical reference for how the named domain object container translates to Groovy Gradle DSL
+    // and document that here for future reference.
+    // But, basically, gradleScripts is a name we've made up for this source set. User-defined, if you will.
+
+    /**
+     * Ably-defined name for the source set that encapsulates all Gradle build script files in this repository.
+     * The CodeNarc plugin creates an implicit task called codenarcGradleScripts, based on this name, however
+     * that tasks doesn't pick up the .gradle files. Presumably it filters to process only files with a .groovy
+     * extension. This is why we are invoking CodeNarc by extending the CodeNarc task - see checkWithCodenarc.
+     */
+    gradleScripts {
+        // groovy is a method added by the groovy plugin
+        groovy {
+            // delegate: https://docs.gradle.org/current/dsl/org.gradle.api.file.SourceDirectorySet.html
+            // srcDir "${project.rootProject.files('.')}"
+            srcDir '..'
+            include '**/*.gradle'
+            exclude '**/bin/**'
+        }
+    }
+}
+
+// https://docs.gradle.org/current/dsl/org.gradle.api.plugins.quality.CodeNarcExtension.html
+// We could move configFile to the configuration phase of our runCodenarc task and that works ok.
+// However, reportFormat is not understood there and the reports block that is documented for that block's
+// delegate doesn't seem to have an obvious way to generate output to the console.
+// For this reason the decision has been made to configure the overall nature for CodeNarc in this block,
+// while the specification of which files it lints is made in our ablyCodenarc task.
+codenarc {
+    configFile = file('src/main/groovy/build-script-rules.groovy')
+    reportFormat 'console'
+}
+
+dependencies {
+    // To use the groovy plugin we have to tell it where to get Groovy from.
+    // As this project is checking build scripts used by Gradle projects in this repository,
+    // including this project, the local Groovy instance is exactly what we need.
+    implementation localGroovy()
+}
+
+/**
+ * This task is informational, here to help with debugging issues with our use of codenarc.
+ */
+tasks.register('listBuildScriptsCheckedWithCodenarc') {
+    group = 'Ably'
+    description = 'Lists the build script files which will be checked by the checkWithCodenarc task.'
+
+    doLast {
+        sourceSets.each { sourceSet ->
+            println("$sourceSet:")
+            boolean noSourceFound = true
+            sourceSet.allSource.each { file ->
+                println("\t$file")
+                noSourceFound = false
+            }
+            if (noSourceFound) {
+                println('\tNo source files captured by this source set.')
+            }
+        }
+    }
+}
+
+tasks.register('checkWithCodenarc', CodeNarc) { cn ->
+    // delegate: https://docs.gradle.org/current/dsl/org.gradle.api.plugins.quality.CodeNarc.html
+    group = 'Ably'
+    description = 'Checks the build script files in this repository using CodeNarc.'
+
+    sourceSets.each { sourceSet ->
+        cn.source sourceSet.allSource
+    }
+}

--- a/gradle-lint/src/main/groovy/build-script-rules.groovy
+++ b/gradle-lint/src/main/groovy/build-script-rules.groovy
@@ -1,0 +1,9 @@
+ruleset {
+    ruleset('rulesets/formatting.xml') {
+        // This rule requires a space before the colon, which is unnecessary and less human-readable - especially in our JSON-rich world.
+        exclude 'SpaceAroundMapEntryColon'
+
+        // Arbitrary, ending up forcing developers to contort code unecessarily - especially for string definitions.
+        exclude 'LineLength'
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/java/maven.gradle
+++ b/java/maven.gradle
@@ -20,7 +20,7 @@ uploadArchives {
 
         beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-	    repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+        repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
             authentication(userName: mavenUser, password: mavenPassword)
         }
 
@@ -38,15 +38,15 @@ uploadArchives {
             description 'A Java Realtime and REST client library for [Ably.io](https://www.ably.io), the realtime messaging service.'
             packaging 'jar'
             inceptionYear '2015'
-			url 'https://www.github.com/ably/ably-java'
-			developers {
-				developer {
-					name 'Paddy Byers'
-					email 'paddy@ably.io'
-					url 'https://github.com/paddybyers'
-					id 'paddybyers'
-				}
-			}
+            url 'https://www.github.com/ably/ably-java'
+            developers {
+                developer {
+                    name 'Paddy Byers'
+                    email 'paddy@ably.io'
+                    url 'https://github.com/paddybyers'
+                    id 'paddybyers'
+                }
+            }
             scm {
                 url 'scm:git:https://github.com/ably/ably-java'
                 connection 'scm:git:https://github.com/ably/ably-java'
@@ -70,8 +70,8 @@ uploadArchives {
         }
 
         // Exclude test dependencies
-        pom.whenConfigured {
-            p -> p.dependencies = p.dependencies.findAll {
+        pom.whenConfigured { p ->
+            p.dependencies = p.dependencies.findAll {
                 dep -> dep.scope == 'runtime'
             }
         }
@@ -99,13 +99,13 @@ task assembleRelease {
 }
 
 task sourcesJar(type: Jar) {
-     classifier = 'sources'
-     from sourceSets.main.allSource
+    classifier = 'sources'
+    from sourceSets.main.allSource
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-     classifier = 'javadoc'
-     from javadoc.destinationDir
+    classifier = 'javadoc'
+    from javadoc.destinationDir
 }
 
 artifacts {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,8 @@
 rootProject.name = 'ably-java'
 include 'java'
 
-if(System.getenv('ANDROID_HOME')) {
-  include 'android'
+if (System.getenv('ANDROID_HOME')) {
+    include 'android'
 }
+
+include 'gradle-lint'


### PR DESCRIPTION
This is the first eager step I'm taking towards refactoring our Gradle files.

For now I am just enabling the formatting rules so there is quite a lot of noise here in respect of the necessary fixes in respect of indentation and tabs to spaces etc.. The meat lies in the files within `gradle-lint`.

## The Journey

Getting to this point was a little bit arduous. The CodeNarc plugin adds some default tasks for checking source sets (e.g. `codenarcMain`), however I simply could not get them to check anything but files with a `.groovy` extension, even when I categorically knew the source set was capturing the Groovy-based files I wanted (just all with `.gradle` extension).

For this reason the way CodeNarc is integrated here is breaking with convention based upon how most projects use it, in that we have an Ably-specific task called `checkWithCodenarc`. I am completely comfortable with this, however, because I am yet to find an example "in the wild" of anybody using CodeNarc in the way that I am here to introspect on Gradle build script files. Most projects are using it to inspect source code for a library or application that itself has been written in Groovy.