### PR TITLE
Add unit test for idempotentRestPublishing in ClientOptions

### DIFF
--- a/lib/src/test/java/io/ably/lib/types/ClientOptionsTest.java
+++ b/lib/src/test/java/io/ably/lib/types/ClientOptionsTest.java
@@ -1,0 +1,16 @@
+package io.ably.lib.types;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ClientOptionsTest {
+
+    private final ClientOptions clientOptions = new ClientOptions();
+
+    @Test
+    public void should_support_idempotent_rest_publishing() {
+        // Then
+        assertTrue(clientOptions.idempotentRestPublishing);
+    }
+}


### PR DESCRIPTION
Fixes #590 

This issue was resolved in the past, but I've added one unit test to verify the behaviour.
