### PR TITLE
Update references from 1 -> l to match client spec

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/Defaults.java
+++ b/lib/src/main/java/io/ably/lib/transport/Defaults.java
@@ -33,9 +33,9 @@ public class Defaults {
     public static int TIMEOUT_DISCONNECT            = 15000;
     public static int TIMEOUT_CHANNEL_RETRY         = 15000;
 
-    /* TO313 */
+    /* TO3l3 */
     public static int TIMEOUT_HTTP_OPEN = 4000;
-    /* TO314 */
+    /* TO3l4 */
     public static int TIMEOUT_HTTP_REQUEST = 15000;
     /* DF1b */
     public static long realtimeRequestTimeout = 10000L;


### PR DESCRIPTION
👋 Hopefully a small one. I was looking at the client spec and it appears these should actually be `l` instead of `1`:
* https://www.ably.io/documentation/client-lib-development-guide/features#TO3l3
* https://www.ably.io/documentation/client-lib-development-guide/features#TO3l4