### PR TITLE
Remove empty capability query parameter

### DIFF
--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -708,8 +708,7 @@ public class Auth {
         options = (options == null) ? this.authOptions : options.copy();
         params = (params == null) ? this.tokenParams : params.copy();
 
-        if(params.capability != null)
-            params.capability = Capability.c14n(params.capability);
+        params.capability = Capability.c14n(params.capability);
         TokenRequest request = new TokenRequest(params);
 
         String key = options.key;

--- a/lib/src/main/java/io/ably/lib/types/Capability.java
+++ b/lib/src/main/java/io/ably/lib/types/Capability.java
@@ -27,7 +27,7 @@ public class Capability {
      * (if for example it is not valid JSON)
      */
     public static String c14n(String capability) throws AblyException {
-        if (capability == null || capability.isEmpty()) return capability;
+        if (capability == null || capability.isEmpty()) return null;
         try {
             JsonObject json = (JsonObject)gsonParser.parse(capability);
             return (new Capability(json)).toString();

--- a/lib/src/main/java/io/ably/lib/types/Capability.java
+++ b/lib/src/main/java/io/ably/lib/types/Capability.java
@@ -19,21 +19,19 @@ import com.google.gson.JsonParser;
 public class Capability {
 
     /**
-     * Convenience method to canonicalise a JSON capability expression
+     * Convenience method to canonicalise a JSON capability expression.
      *
      * @param capability a capability string, which is the JSON text for the capability
      * @return a capability string which has been canonicalised
      * @throws AblyException if there is an error processing the given string
      * (if for example it is not valid JSON)
      */
-    public static final String c14n(String capability) throws AblyException {
-        if(capability == null || capability.isEmpty()) return "";
+    public static String c14n(String capability) throws AblyException {
+        if (capability == null || capability.isEmpty()) return capability;
         try {
             JsonObject json = (JsonObject)gsonParser.parse(capability);
             return (new Capability(json)).toString();
-        } catch(ClassCastException e) {
-            throw AblyException.fromThrowable(e);
-        } catch(JsonParseException e) {
+        } catch(ClassCastException | JsonParseException e) {
             throw AblyException.fromThrowable(e);
         }
     }

--- a/lib/src/test/java/io/ably/lib/types/CapabilityTest.java
+++ b/lib/src/test/java/io/ably/lib/types/CapabilityTest.java
@@ -1,0 +1,23 @@
+package io.ably.lib.types;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class CapabilityTest {
+
+    @Test
+    public void c14n_sendNull_returnsNull() throws AblyException {
+        String returnedValue = Capability.c14n(null);
+
+        assertNull(returnedValue);
+    }
+
+    @Test
+    public void c14n_sendEmptyString_returnsEmptyString() throws AblyException {
+        String returnedValue = Capability.c14n("");
+
+        assertEquals("", returnedValue);
+    }
+}

--- a/lib/src/test/java/io/ably/lib/types/CapabilityTest.java
+++ b/lib/src/test/java/io/ably/lib/types/CapabilityTest.java
@@ -1,6 +1,5 @@
 package io.ably.lib.types;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
@@ -18,6 +17,6 @@ public class CapabilityTest {
     public void c14n_sendEmptyString_returnsEmptyString() throws AblyException {
         String returnedValue = Capability.c14n("");
 
-        assertEquals("", returnedValue);
+        assertNull(returnedValue);
     }
 }


### PR DESCRIPTION
Fixes #647 

The check was extended to transparently handle null and empty strings. If the value is null we should also return null and in this case, it shouldn't add this query parameter.