### PR TITLE
Changing Capability.addResource() to take varargs as last parameter

### DIFF
--- a/lib/src/main/java/io/ably/lib/types/Capability.java
+++ b/lib/src/main/java/io/ably/lib/types/Capability.java
@@ -59,37 +59,15 @@ public class Capability {
      * it is wholly replaced by the given set of operations.
      *
      * @param resource the resource string
-     * @param ops a String[] of the operations permitted for this resource;
-     * the array does not need to be sorted
+     * @param ops a String varargs of the operations permitted for this resource;
+     * the arguments do not need to be sorted
      */
-    public void addResource(String resource, String[] ops) {
+    public void addResource(String resource, String... ops) {
         JsonArray jsonOps = (JsonArray)gson.toJsonTree(ops);
         json.add(resource, jsonOps);
         dirty = true;
     }
 
-    /**
-     * Add a resource to an existing Capability instance with the
-     * given single operation. If the resource already exists,
-     * it is wholly replaced by the given set of operations.
-     *
-     * @param resource the resource string
-     * @param op a single operation String to be permitted for this resource;
-     */
-    public void addResource(String resource, String op) {
-        addResource(resource, new String[]{op});
-    }
-
-    /**
-     * Add a resource to an existing Capability instance with an
-     * empty set of operations. If the resource already exists,
-     * the effect is to reset its set of operations to empty.
-     *
-     * @param resource the resource string
-     */
-    public void addResource(String resource) {
-        addResource(resource, new String[0]);
-    }
     /**
      * Remove a resource from an existing Capability instance
      *

--- a/lib/src/test/java/io/ably/lib/test/rest/RestCapabilityTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestCapabilityTest.java
@@ -106,7 +106,7 @@ public class RestCapabilityTest extends ParameterizedTest {
     }
 
     /**
-     * Non-empty ops intersection 
+     * Non-empty ops intersection
      */
     @Test
     public void authcapability4() {
@@ -116,7 +116,7 @@ public class RestCapabilityTest extends ParameterizedTest {
             authOptions.key = key.keyStr;
             TokenParams tokenParams = new TokenParams();
             Capability requestedCapability = new Capability();
-            requestedCapability.addResource("channel2", new String[]{"presence", "subscribe"});
+            requestedCapability.addResource("channel2", "presence", "subscribe");
             tokenParams.capability = requestedCapability.toString();
             TokenDetails tokenDetails = ably.auth.requestToken(tokenParams, authOptions);
             Capability expectedCapability = new Capability();
@@ -130,7 +130,7 @@ public class RestCapabilityTest extends ParameterizedTest {
     }
 
     /**
-     * Non-empty paths intersection 
+     * Non-empty paths intersection
      */
     @Test
     public void authcapability5() {
@@ -140,8 +140,8 @@ public class RestCapabilityTest extends ParameterizedTest {
             authOptions.key = key.keyStr;
             TokenParams tokenParams = new TokenParams();
             Capability requestedCapability = new Capability();
-            requestedCapability.addResource("channel2", new String[]{"presence", "subscribe"});
-            requestedCapability.addResource("channelx", new String[]{"presence", "subscribe"});
+            requestedCapability.addResource("channel2", "presence", "subscribe");
+            requestedCapability.addResource("channelx", "presence", "subscribe");
             tokenParams.capability = requestedCapability.toString();
             TokenDetails tokenDetails = ably.auth.requestToken(tokenParams, authOptions);
             Capability expectedCapability = new Capability();
@@ -155,7 +155,7 @@ public class RestCapabilityTest extends ParameterizedTest {
     }
 
     /**
-     * Wildcard ops intersection 
+     * Wildcard ops intersection
      */
     @Test
     public void authcapability6() {
@@ -169,7 +169,7 @@ public class RestCapabilityTest extends ParameterizedTest {
             tokenParams.capability = requestedCapability.toString();
             TokenDetails tokenDetails = ably.auth.requestToken(tokenParams, authOptions);
             Capability expectedCapability = new Capability();
-            expectedCapability.addResource("channel2", new String[]{"publish", "subscribe"});
+            expectedCapability.addResource("channel2", "publish", "subscribe");
             assertNotNull("Expected token value", tokenDetails.token);
             assertEquals("Unexpected capability", tokenDetails.capability, expectedCapability.toString());
         } catch (AblyException e) {
@@ -185,11 +185,11 @@ public class RestCapabilityTest extends ParameterizedTest {
             authOptions.key = key.keyStr;
             TokenParams tokenParams = new TokenParams();
             Capability requestedCapability = new Capability();
-            requestedCapability.addResource("channel6", new String[]{"publish", "subscribe"});
+            requestedCapability.addResource("channel6", "publish", "subscribe");
             tokenParams.capability = requestedCapability.toString();
             TokenDetails tokenDetails = ably.auth.requestToken(tokenParams, authOptions);
             Capability expectedCapability = new Capability();
-            expectedCapability.addResource("channel6", new String[]{"publish", "subscribe"});
+            expectedCapability.addResource("channel6", "publish", "subscribe");
             assertNotNull("Expected token value", tokenDetails.token);
             assertEquals("Unexpected capability", tokenDetails.capability, expectedCapability.toString());
         } catch (AblyException e) {
@@ -199,7 +199,7 @@ public class RestCapabilityTest extends ParameterizedTest {
     }
 
     /**
-     * Wildcard resources intersection 
+     * Wildcard resources intersection
      */
     @Test
     public void authcapability8() {
@@ -276,7 +276,7 @@ public class RestCapabilityTest extends ParameterizedTest {
     public void authinvalid1() {
         TokenParams tokenParams = new TokenParams();
         Capability invalidCapability = new Capability();
-        invalidCapability.addResource("channel0", new String[]{"*", "publish"});
+        invalidCapability.addResource("channel0", "*", "publish");
         tokenParams.capability = invalidCapability.toString();
         try {
             ably.auth.requestToken(tokenParams, null);
@@ -289,7 +289,7 @@ public class RestCapabilityTest extends ParameterizedTest {
     public void authinvalid2() {
         TokenParams tokenParams = new TokenParams();
         Capability invalidCapability = new Capability();
-        invalidCapability.addResource("channel0", new String[0]);
+        invalidCapability.addResource("channel0");
         tokenParams.capability = invalidCapability.toString();
         try {
             ably.auth.requestToken(tokenParams, null);


### PR DESCRIPTION
Before this change, there were three methods:

* `addResource(String resource)`
  * Example: `addResource("foo")`
* `addResource(String resource, String op)`
  * Example: `addResource("foo", "bar")"`
* `addResource(String resource, String[] ops)`
  * Example: `addResource("foo", new String[] {"bar", "baz"})"`

With this change, all three are replaced with:

* `addResource(String resource, String... ops)`

Which allows the user to do all three of the above without modifications to their code:
* `addResource("foo")`
* `addResource("foo", "bar")"`
* `addResource("foo", new String[] {"bar", "baz"})"`

While also allowing:
* `addResource("foo", "bar", "baz")"`

This will not break any existing code. It's also makes it consistent with other methods in this project such as `EventEmitter.emit(Event, Object...)`