### PR TITLE
Release/1.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [v1.2.6](https://github.com/ably/ably-java/tree/v1.2.6)
+
+[Full Changelog](https://github.com/ably/ably-java/compare/v1.2.5...v1.2.6)
+
+**Fixed bug:** channel presence members [\#669](https://github.com/ably/ably-java/pull/669) ([sacOO7](https://github.com/sacOO7))  
+An issue affecting only users calling `get(boolean wait)` on `Presence` with `wait` set to `true`.
+
 ## [v1.2.5](https://github.com/ably/ably-java/tree/v1.2.5)
 
 [Full Changelog](https://github.com/ably/ably-java/compare/v1.2.4...v1.2.5)

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ Include the library by adding an `implementation` reference to `dependencies` bl
 For [Java](https://mvnrepository.com/artifact/io.ably/ably-java/latest):
 
 ```
-implementation 'io.ably:ably-java:1.2.5'
+implementation 'io.ably:ably-java:1.2.6'
 ```
 
 For [Android](https://mvnrepository.com/artifact/io.ably/ably-android/latest):
 
 ```
-implementation 'io.ably:ably-android:1.2.5'
+implementation 'io.ably:ably-android:1.2.6'
 ```
 
 The library is hosted on [Maven Central](https://mvnrepository.com/repos/central), so you need to ensure that the repository is referenced also; IDEs will typically include this by default:
@@ -604,15 +604,15 @@ Configuration of Run/Debug configurations for running the unit tests on Android 
 
 This library uses [semantic versioning](http://semver.org/). For each release, the following needs to be done:
 
-1. Create a branch for the release, named like `release/1.2.5`
+1. Create a branch for the release, named like `release/1.2.6`
 2. Replace all references of the current version number with the new version number (check this file [README.md](./README.md) and [common.gradle](./common.gradle)) and commit the changes
 3. Run [`github_changelog_generator`](https://github.com/skywinder/Github-Changelog-Generator) to update the [CHANGELOG](./CHANGELOG.md):
-    * This might work: `github_changelog_generator -u ably -p ably-java --header-label="# Changelog" --release-branch=release/1.2.5 --future-release=v1.2.5`
-    * But your mileage may vary as it can error. Perhaps more reliable is something like: `github_changelog_generator -u ably -p ably-java --since-tag v1.2.4 --output delta.md` and then manually merge the delta contents in to the main change log
+    * This might work: `github_changelog_generator -u ably -p ably-java --header-label="# Changelog" --release-branch=release/1.2.6 --future-release=v1.2.6`
+    * But your mileage may vary as it can error. Perhaps more reliable is something like: `github_changelog_generator -u ably -p ably-java --since-tag v1.2.5 --output delta.md` and then manually merge the delta contents in to the main change log
 4. Commit [CHANGELOG](./CHANGELOG.md)
 5. Make a PR against `main`
 6. Once the PR is approved, merge it into `main`
-7. Add a tag and push to origin - e.g.: `git tag v1.2.5 && git push origin v1.2.5`
+7. Add a tag and push to origin - e.g.: `git tag v1.2.6 && git push origin v1.2.6`
 8. Create the release on Github including populating the release notes
 9. Assemble and Upload ([see below](#publishing-to-maven-central) for details) - but the overall order to follow is:
     1. Comment out local `repository` lines in the two `maven.gradle` files temporarily (this is horrible but is [to be fixed soon](https://github.com/ably/ably-java/issues/566))

--- a/common.gradle
+++ b/common.gradle
@@ -4,7 +4,7 @@ repositories {
 }
 
 group = 'io.ably'
-version = '1.2.5'
+version = '1.2.6'
 description = 'Ably java client library'
 
 tasks.withType(Javadoc) {

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeHttpHeaderTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeHttpHeaderTest.java
@@ -91,7 +91,7 @@ public class RealtimeHttpHeaderTest extends ParameterizedTest {
              * Defaults.ABLY_LIB_PARAM, as ultimately the request param has been derived from those values.
              */
             assertEquals("Verify correct lib version", requestParameters.get("lib"),
-                    Collections.singletonList("java-1.2.5"));
+                    Collections.singletonList("java-1.2.6"));
 
             /* Spec RTN2a */
             assertEquals("Verify correct format", requestParameters.get("format"),

--- a/lib/src/test/java/io/ably/lib/test/rest/HttpHeaderTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/HttpHeaderTest.java
@@ -84,7 +84,7 @@ public class HttpHeaderTest extends ParameterizedTest {
              */
             Assert.assertNotNull("Expected headers", headers);
             Assert.assertEquals(headers.get("x-ably-version"), "1.2");
-            Assert.assertEquals(headers.get("x-ably-lib"), "java-1.2.5");
+            Assert.assertEquals(headers.get("x-ably-lib"), "java-1.2.6");
         } catch (AblyException e) {
             e.printStackTrace();
             Assert.fail("header_lib_channel_publish: Unexpected exception");


### PR DESCRIPTION
Fixes a single bug, allowing us to unblock https://github.com/ably/ably-asset-tracking-android/pull/315.