### PR TITLE
Checking if error code is 403 and failing connection

### DIFF
--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -658,7 +658,7 @@ public class Auth {
                     authUrlResponse = HttpHelpers.getUri(ably.httpCore, tokenOptions.authUrl, tokenOptions.authHeaders, HttpUtils.flattenParams(requestParams), responseHandler);
                 }
             } catch(AblyException e) {
-                throw AblyException.fromErrorInfo(e, new ErrorInfo("authUrl failed with an exception", 401, 80019));
+                throw AblyException.fromErrorInfo(e, new ErrorInfo("authUrl failed with an exception", e.errorInfo.statusCode, 80019));
             }
             if(authUrlResponse == null) {
                 throw AblyException.fromErrorInfo(null, new ErrorInfo("Empty response received from authUrl", 401, 80019));

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -491,7 +491,7 @@ public class Auth {
      *
      * - ttl:        (optional) the requested life of any new token in ms. If none
      *               is specified a default of 1 hour is provided. The maximum lifetime
-     *               is 24hours; any request exceeeding that lifetime will be rejected
+     *               is 24hours; any request exceeding that lifetime will be rejected
      *               with an error.
      *
      * - capability: (optional) the capability to associate with the access token.

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -978,6 +978,12 @@ public class ConnectionManager implements ConnectListener {
      */
     public void onAuthError(ErrorInfo errorInfo) {
         Log.i(TAG, String.format("onAuthError: (%d) %s", errorInfo.code, errorInfo.message));
+
+        if(errorInfo.code == 403) {
+            this.connection.state = ConnectionState.failed;
+            return;
+        }
+
         switch (currentState.state) {
             case connecting:
                 ITransport transport = this.transport;

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -980,7 +980,14 @@ public class ConnectionManager implements ConnectListener {
         Log.i(TAG, String.format("onAuthError: (%d) %s", errorInfo.code, errorInfo.message));
 
         if(errorInfo.code == 403) {
-            this.connection.state = ConnectionState.failed;
+            ConnectionStateChange failedStateChange =
+                new ConnectionStateChange(
+                    connection.state,
+                    ConnectionState.failed,
+                    0,
+                    errorInfo);
+
+            this.connection.onConnectionStateChange(failedStateChange);
             return;
         }
 

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -979,7 +979,7 @@ public class ConnectionManager implements ConnectListener {
     public void onAuthError(ErrorInfo errorInfo) {
         Log.i(TAG, String.format("onAuthError: (%d) %s", errorInfo.code, errorInfo.message));
 
-        if(errorInfo.code == 403) {
+        if(errorInfo.statusCode == 403) {
             ConnectionStateChange failedStateChange =
                 new ConnectionStateChange(
                     connection.state,

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
@@ -1,11 +1,7 @@
 package io.ably.lib.test.realtime;
 
-import io.ably.lib.realtime.*;
-import io.ably.lib.test.common.Setup;
-import io.ably.lib.types.*;
-import io.ably.lib.util.Log;
-
 import io.ably.lib.debug.DebugOptions;
+import io.ably.lib.realtime.*;
 import io.ably.lib.rest.AblyRest;
 import io.ably.lib.rest.Auth;
 import io.ably.lib.rest.Auth.TokenDetails;
@@ -14,11 +10,8 @@ import io.ably.lib.test.common.Helpers.ChannelWaiter;
 import io.ably.lib.test.common.Helpers.CompletionSet;
 import io.ably.lib.test.common.Helpers.ConnectionWaiter;
 import io.ably.lib.test.common.ParameterizedTest;
-import io.ably.lib.types.AblyException;
-import io.ably.lib.types.ClientOptions;
-import io.ably.lib.types.ErrorInfo;
-import io.ably.lib.types.Message;
-import io.ably.lib.types.ProtocolMessage;
+import io.ably.lib.test.common.Setup;
+import io.ably.lib.types.*;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -110,8 +103,8 @@ public class RealtimeAuthTest extends ParameterizedTest {
             ablyRealtime.connection.once(ConnectionEvent.failed, new ConnectionStateListener() {
                 @Override
                 public void onConnectionStateChanged(ConnectionStateChange stateChange) {
-                    assertEquals(stateChange.previous, ConnectionState.connected);
-                    assertEquals(stateChange.reason.code, 80019);
+                    assertEquals(ConnectionState.connected, stateChange.previous);
+                    assertEquals(80019, stateChange.reason.code);
                     assertEquals(80019, ablyRealtime.connection.reason.code);
                     assertEquals(403, ablyRealtime.connection.reason.statusCode);
                 }


### PR DESCRIPTION
- If server replies with 403 status code on authorisation attempt, connection state turns to Failed
- Fixes [#620](https://github.com/ably/ably-java/issues/620)
