### PR TITLE
Add request_id query param if addRequestIds is enabled

### DIFF
--- a/android/src/main/java/io/ably/lib/push/ActivationStateMachine.java
+++ b/android/src/main/java/io/ably/lib/push/ActivationStateMachine.java
@@ -7,9 +7,6 @@ import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.support.v4.content.LocalBroadcastManager;
 
-import com.google.android.gms.tasks.OnCompleteListener;
-import com.google.android.gms.tasks.Task;
-import com.google.firebase.iid.InstanceIdResult;
 import com.google.gson.JsonObject;
 
 import java.lang.reflect.Constructor;
@@ -21,6 +18,7 @@ import io.ably.lib.http.*;
 import io.ably.lib.rest.AblyRest;
 import io.ably.lib.rest.DeviceDetails;
 import io.ably.lib.types.*;
+import io.ably.lib.util.Crypto;
 import io.ably.lib.util.IntentUtils;
 import io.ably.lib.util.Log;
 import io.ably.lib.util.Serialisation;
@@ -432,6 +430,9 @@ public class ActivationStateMachine {
                     if (ably.options.pushFullWait) {
                         params = Param.push(params, "fullWait", "true");
                     }
+                    if(ably.options.addRequestIds) { // RSC7c
+                        Param.set(params, Crypto.generateRandomRequestId());
+                    }
 
                     http.patch("/push/deviceRegistrations/" + device.id, ably.push.pushRequestHeaders(true), params, body, null, false, callback);
                 }
@@ -480,6 +481,9 @@ public class ActivationStateMachine {
                     if (ably.options.pushFullWait) {
                         params = Param.push(params, "fullWait", "true");
                     }
+                    if(ably.options.addRequestIds) { // RSC7c
+                        Param.set(params, Crypto.generateRandomRequestId());
+                    }
 
                     final HttpCore.RequestBody body = HttpUtils.requestBodyFromGson(device.toJsonObject(), ably.options.useBinaryProtocol);
                     http.put("/push/deviceRegistrations/" + device.id, ably.push.pushRequestHeaders(true), params, body, new Serialisation.HttpResponseHandler<JsonObject>(), true, callback);
@@ -527,6 +531,9 @@ public class ActivationStateMachine {
                     Param[] params = new Param[0];
                     if (ably.options.pushFullWait) {
                         params = Param.push(params, "fullWait", "true");
+                    }
+                    if(ably.options.addRequestIds) { // RSC7c
+                        Param.set(params, Crypto.generateRandomRequestId());
                     }
                     http.del("/push/deviceRegistrations/" + device.id, ably.push.pushRequestHeaders(true), params, null, true, callback);
                 }

--- a/android/src/main/java/io/ably/lib/push/ActivationStateMachine.java
+++ b/android/src/main/java/io/ably/lib/push/ActivationStateMachine.java
@@ -18,9 +18,9 @@ import io.ably.lib.http.*;
 import io.ably.lib.rest.AblyRest;
 import io.ably.lib.rest.DeviceDetails;
 import io.ably.lib.types.*;
-import io.ably.lib.util.Crypto;
 import io.ably.lib.util.IntentUtils;
 import io.ably.lib.util.Log;
+import io.ably.lib.util.ParamsUtils;
 import io.ably.lib.util.Serialisation;
 
 public class ActivationStateMachine {
@@ -136,13 +136,7 @@ public class ActivationStateMachine {
                     ably.http.request(new Http.Execute<JsonObject>() {
                         @Override
                         public void execute(HttpScheduler http, Callback<JsonObject> callback) throws AblyException {
-                            Param[] params = null;
-                            if(ably.options.pushFullWait) {
-                                params = Param.push(null, "fullWait", "true");
-                            }
-                            if(ably.options.addRequestIds) { // RSC7c
-                                params = Param.set(params, Crypto.generateRandomRequestId());
-                            }
+                            Param[] params = ParamsUtils.enrichParams(null, ably.options);
                             /* this is authenticated using the Ably library credentials, plus the deviceSecret in the request body */
                             http.post("/push/deviceRegistrations", HttpUtils.defaultAcceptHeaders(ably.options.useBinaryProtocol), params, body, new Serialisation.HttpResponseHandler<JsonObject>(), true, callback);
                         }
@@ -429,14 +423,7 @@ public class ActivationStateMachine {
             ably.http.request(new Http.Execute<Void>() {
                 @Override
                 public void execute(HttpScheduler http, Callback<Void> callback) throws AblyException {
-                    Param[] params = null;
-                    if (ably.options.pushFullWait) {
-                        params = Param.push(params, "fullWait", "true");
-                    }
-                    if(ably.options.addRequestIds) { // RSC7c
-                        params = Param.set(params, Crypto.generateRandomRequestId());
-                    }
-
+                    Param[] params = ParamsUtils.enrichParams(null, ably.options);
                     http.patch("/push/deviceRegistrations/" + device.id, ably.push.pushRequestHeaders(true), params, body, null, false, callback);
                 }
             }).async(new Callback<Void>() {
@@ -480,14 +467,7 @@ public class ActivationStateMachine {
             ably.http.request(new Http.Execute<JsonObject>() {
                 @Override
                 public void execute(HttpScheduler http, Callback<JsonObject> callback) throws AblyException {
-                    Param[] params = null;
-                    if (ably.options.pushFullWait) {
-                        params = Param.push(params, "fullWait", "true");
-                    }
-                    if(ably.options.addRequestIds) { // RSC7c
-                        params = Param.set(params, Crypto.generateRandomRequestId());
-                    }
-
+                    Param[] params = ParamsUtils.enrichParams(null, ably.options);
                     final HttpCore.RequestBody body = HttpUtils.requestBodyFromGson(device.toJsonObject(), ably.options.useBinaryProtocol);
                     http.put("/push/deviceRegistrations/" + device.id, ably.push.pushRequestHeaders(true), params, body, new Serialisation.HttpResponseHandler<JsonObject>(), true, callback);
                 }
@@ -531,13 +511,7 @@ public class ActivationStateMachine {
             ably.http.request(new Http.Execute<Void>() {
                 @Override
                 public void execute(HttpScheduler http, Callback<Void> callback) throws AblyException {
-                    Param[] params = new Param[0];
-                    if (ably.options.pushFullWait) {
-                        params = Param.push(params, "fullWait", "true");
-                    }
-                    if(ably.options.addRequestIds) { // RSC7c
-                        params = Param.set(params, Crypto.generateRandomRequestId());
-                    }
+                    Param[] params = ParamsUtils.enrichParams(new Param[0], ably.options);
                     http.del("/push/deviceRegistrations/" + device.id, ably.push.pushRequestHeaders(true), params, null, true, callback);
                 }
             }).async(new Callback<Void>() {

--- a/android/src/main/java/io/ably/lib/push/ActivationStateMachine.java
+++ b/android/src/main/java/io/ably/lib/push/ActivationStateMachine.java
@@ -140,6 +140,9 @@ public class ActivationStateMachine {
                             if(ably.options.pushFullWait) {
                                 params = Param.push(null, "fullWait", "true");
                             }
+                            if(ably.options.addRequestIds) { // RSC7c
+                                params = Param.set(params, Crypto.generateRandomRequestId());
+                            }
                             /* this is authenticated using the Ably library credentials, plus the deviceSecret in the request body */
                             http.post("/push/deviceRegistrations", HttpUtils.defaultAcceptHeaders(ably.options.useBinaryProtocol), params, body, new Serialisation.HttpResponseHandler<JsonObject>(), true, callback);
                         }
@@ -431,7 +434,7 @@ public class ActivationStateMachine {
                         params = Param.push(params, "fullWait", "true");
                     }
                     if(ably.options.addRequestIds) { // RSC7c
-                        Param.set(params, Crypto.generateRandomRequestId());
+                        params = Param.set(params, Crypto.generateRandomRequestId());
                     }
 
                     http.patch("/push/deviceRegistrations/" + device.id, ably.push.pushRequestHeaders(true), params, body, null, false, callback);
@@ -482,7 +485,7 @@ public class ActivationStateMachine {
                         params = Param.push(params, "fullWait", "true");
                     }
                     if(ably.options.addRequestIds) { // RSC7c
-                        Param.set(params, Crypto.generateRandomRequestId());
+                        params = Param.set(params, Crypto.generateRandomRequestId());
                     }
 
                     final HttpCore.RequestBody body = HttpUtils.requestBodyFromGson(device.toJsonObject(), ably.options.useBinaryProtocol);
@@ -533,7 +536,7 @@ public class ActivationStateMachine {
                         params = Param.push(params, "fullWait", "true");
                     }
                     if(ably.options.addRequestIds) { // RSC7c
-                        Param.set(params, Crypto.generateRandomRequestId());
+                        params = Param.set(params, Crypto.generateRandomRequestId());
                     }
                     http.del("/push/deviceRegistrations/" + device.id, ably.push.pushRequestHeaders(true), params, null, true, callback);
                 }

--- a/android/src/main/java/io/ably/lib/push/PushChannel.java
+++ b/android/src/main/java/io/ably/lib/push/PushChannel.java
@@ -68,6 +68,9 @@ public class PushChannel {
                 if (rest.options.pushFullWait) {
                     params = Param.push(params, "fullWait", "true");
                 }
+                if(rest.options.addRequestIds) { // RSC7c
+                    params = Param.set(params, Crypto.generateRandomRequestId());
+                }
                 http.post("/push/channelSubscriptions", rest.push.pushRequestHeaders(true), params, body, null, true, callback);
             }
         });

--- a/android/src/main/java/io/ably/lib/push/PushChannel.java
+++ b/android/src/main/java/io/ably/lib/push/PushChannel.java
@@ -1,6 +1,5 @@
 package io.ably.lib.push;
 
-import android.content.Context;
 import com.google.gson.JsonObject;
 import io.ably.lib.http.*;
 import io.ably.lib.realtime.CompletionListener;
@@ -8,6 +7,7 @@ import io.ably.lib.rest.AblyRest;
 import io.ably.lib.rest.Channel;
 import io.ably.lib.rest.DeviceDetails;
 import io.ably.lib.types.*;
+import io.ably.lib.util.Crypto;
 
 public class PushChannel {
     protected final Channel channel;
@@ -112,7 +112,7 @@ public class PushChannel {
         if (rest.options.pushFullWait) {
             params = Param.push(params, "fullWait", "true");
         }
-        final Param[] finalParams = params;
+        final Param[] finalParams = rest.options.addRequestIds ? Param.set(params, Crypto.generateRandomRequestId()) : params; // RSC7c
         return rest.http.request(new Http.Execute<Void>() {
             @Override
             public void execute(HttpScheduler http, Callback<Void> callback) throws AblyException {

--- a/android/src/main/java/io/ably/lib/push/PushChannel.java
+++ b/android/src/main/java/io/ably/lib/push/PushChannel.java
@@ -7,7 +7,7 @@ import io.ably.lib.rest.AblyRest;
 import io.ably.lib.rest.Channel;
 import io.ably.lib.rest.DeviceDetails;
 import io.ably.lib.types.*;
-import io.ably.lib.util.Crypto;
+import io.ably.lib.util.ParamsUtils;
 
 public class PushChannel {
     protected final Channel channel;
@@ -64,13 +64,7 @@ public class PushChannel {
         return rest.http.request(new Http.Execute<Void>() {
             @Override
             public void execute(HttpScheduler http, Callback<Void> callback) throws AblyException {
-                Param[] params = null;
-                if (rest.options.pushFullWait) {
-                    params = Param.push(params, "fullWait", "true");
-                }
-                if(rest.options.addRequestIds) { // RSC7c
-                    params = Param.set(params, Crypto.generateRandomRequestId());
-                }
+                Param[] params = ParamsUtils.enrichParams(null, rest.options);
                 http.post("/push/channelSubscriptions", rest.push.pushRequestHeaders(true), params, body, null, true, callback);
             }
         });
@@ -112,10 +106,7 @@ public class PushChannel {
     }
 
     protected Http.Request<Void> delSubscription(Param[] params) {
-        if (rest.options.pushFullWait) {
-            params = Param.push(params, "fullWait", "true");
-        }
-        final Param[] finalParams = rest.options.addRequestIds ? Param.set(params, Crypto.generateRandomRequestId()) : params; // RSC7c
+        final Param[] finalParams = ParamsUtils.enrichParams(params, rest.options);
         return rest.http.request(new Http.Execute<Void>() {
             @Override
             public void execute(HttpScheduler http, Callback<Void> callback) throws AblyException {

--- a/lib/src/main/java/io/ably/lib/http/HttpScheduler.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpScheduler.java
@@ -202,17 +202,26 @@ public class HttpScheduler<Executor extends java.util.concurrent.Executor> {
                     break;
                 } catch (AblyException.HostFailedException e) {
                     if(--retryCountRemaining < 0) {
+                        if(Param.getFirst(params, "request_id") != null) {
+                            e.errorInfo.message += String.format(", request_id %s", Param.getFirst(params, "request_id"));
+                        }
                         setError(e.errorInfo);
                         break;
                     }
                     Log.d(TAG, "Connection failed to host `" + candidateHost + "`. Searching for new host...");
                     candidateHost = httpCore.hosts.getFallback(candidateHost);
                     if (candidateHost == null) {
+                        if(Param.getFirst(params, "request_id") != null) {
+                            e.errorInfo.message += String.format(", request_id %s", Param.getFirst(params, "request_id"));
+                        }
                         setError(e.errorInfo);
                         break;
                     }
                     Log.d(TAG, "Switched to `" + candidateHost + "`.");
                 } catch(AblyException e) {
+                    if(Param.getFirst(params, "request_id") != null) {
+                        e.errorInfo.message += String.format(", request_id %s", Param.getFirst(params, "request_id"));
+                    }
                     setError(e.errorInfo);
                     break;
                 } finally {

--- a/lib/src/main/java/io/ably/lib/push/PushBase.java
+++ b/lib/src/main/java/io/ably/lib/push/PushBase.java
@@ -15,8 +15,8 @@ import io.ably.lib.types.AsyncPaginatedResult;
 import io.ably.lib.types.Callback;
 import io.ably.lib.types.PaginatedResult;
 import io.ably.lib.types.Param;
-import io.ably.lib.util.Crypto;
 import io.ably.lib.util.Log;
+import io.ably.lib.util.ParamsUtils;
 import io.ably.lib.util.Serialisation;
 import io.ably.lib.util.StringUtils;
 
@@ -72,14 +72,7 @@ public class PushBase {
                         bodyJson.add(entry.getKey(), entry.getValue());
                     }
                     HttpCore.RequestBody body = HttpUtils.requestBodyFromGson(bodyJson, rest.options.useBinaryProtocol);
-
-                    Param[] params = null;
-                    if (rest.options.pushFullWait) {
-                        params = Param.push(params, "fullWait", "true");
-                    }
-                    if (rest.options.addRequestIds) {
-                        params = Param.set(params, Crypto.generateRandomRequestId()); // RSC7c
-                    }
+                    Param[] params = ParamsUtils.enrichParams(null, rest.options);
 
                     http.post("/push/publish", HttpUtils.defaultAcceptHeaders(rest.options.useBinaryProtocol), params, body, null, true, callback);
                 }
@@ -105,14 +98,8 @@ public class PushBase {
             final HttpCore.RequestBody body = HttpUtils.requestBodyFromGson(device.toJsonObject(), rest.options.useBinaryProtocol);
             return rest.http.request(new Http.Execute<DeviceDetails>() {
                 @Override
-                public void execute(HttpScheduler http, Callback<DeviceDetails> callback) throws AblyException {
-                    Param[] params = null;
-                    if (rest.options.pushFullWait) {
-                        params = Param.push(params, "fullWait", "true");
-                    }
-                    if(rest.options.addRequestIds) { // RSC7c
-                        params = Param.set(params, Crypto.generateRandomRequestId());
-                    }
+                public void execute(HttpScheduler http, Callback<DeviceDetails> callback) {
+                    Param[] params = ParamsUtils.enrichParams(null, rest.options);
                     http.put("/push/deviceRegistrations/" + device.id, rest.push.pushRequestHeaders(device.id), params, body, DeviceDetails.httpResponseHandler, true, callback);
                 }
             });
@@ -131,13 +118,7 @@ public class PushBase {
             return rest.http.request(new Http.Execute<DeviceDetails>() {
                 @Override
                 public void execute(HttpScheduler http, Callback<DeviceDetails> callback) throws AblyException {
-                    Param[] params = null;
-                    if (rest.options.pushFullWait) {
-                        params = Param.push(params, "fullWait", "true");
-                    }
-                    if (rest.options.addRequestIds) { // RSC7c
-                        params = Param.set(params, Crypto.generateRandomRequestId());
-                    }
+                    Param[] params = ParamsUtils.enrichParams(null, rest.options);
                     http.get("/push/deviceRegistrations/" + deviceId, rest.push.pushRequestHeaders(deviceId), params, DeviceDetails.httpResponseHandler, true, callback);
                 }
             });
@@ -177,13 +158,7 @@ public class PushBase {
             return rest.http.request(new Http.Execute<Void>() {
                 @Override
                 public void execute(HttpScheduler http, Callback<Void> callback) throws AblyException {
-                    Param[] params = null;
-                    if (rest.options.pushFullWait) {
-                        params = Param.push(params, "fullWait", "true");
-                    }
-                    if(rest.options.addRequestIds) { // RSC7c
-                        params = Param.set(params, Crypto.generateRandomRequestId());
-                    }
+                    Param[] params = ParamsUtils.enrichParams(null, rest.options);
                     http.del("/push/deviceRegistrations/" + deviceId, rest.push.pushRequestHeaders(deviceId), params, null, true, callback);
                 }
             });
@@ -199,10 +174,7 @@ public class PushBase {
 
         protected Http.Request<Void> removeWhereImpl(Param[] params) {
             Log.v(TAG, "removeWhereImpl(): params=" + Arrays.toString(params));
-            if (rest.options.pushFullWait) {
-                params = Param.push(params, "fullWait", "true");
-            }
-            final Param[] finalParams = rest.options.addRequestIds ? Param.set(params, Crypto.generateRandomRequestId()) : params; // RSC7c
+            final Param[] finalParams = ParamsUtils.enrichParams(params, rest.options);
             return rest.http.request(new Http.Execute<Void>() {
                 @Override
                 public void execute(HttpScheduler http, Callback<Void> callback) throws AblyException {
@@ -235,13 +207,7 @@ public class PushBase {
             return rest.http.request(new Http.Execute<ChannelSubscription>() {
                 @Override
                 public void execute(HttpScheduler http, Callback<ChannelSubscription> callback) throws AblyException {
-                    Param[] params = null;
-                    if (rest.options.pushFullWait) {
-                        params = Param.push(params, "fullWait", "true");
-                    }
-                    if (rest.options.addRequestIds) {
-                        params = Param.set(params, Crypto.generateRandomRequestId()); // RSC7c
-                    }
+                    Param[] params = ParamsUtils.enrichParams(null, rest.options);
                     http.post("/push/channelSubscriptions", rest.push.pushRequestHeaders(subscription.deviceId), params, body, ChannelSubscription.httpResponseHandler, true, callback);
                 }
             });
@@ -295,11 +261,8 @@ public class PushBase {
         protected Http.Request<Void> removeWhereImpl(Param[] params) {
             Log.v(TAG, "removeWhereImpl(): params=" + Arrays.toString(params));
             String deviceId = HttpUtils.getParam(params, "deviceId");
-            if (rest.options.pushFullWait) {
-                params = Param.push(params, "fullWait", "true");
-            }
+            final Param[] finalParams = ParamsUtils.enrichParams(params, rest.options);
             final Param[] finalHeaders = rest.push.pushRequestHeaders(deviceId);
-            final Param[] finalParams = rest.options.addRequestIds ? Param.set(params, Crypto.generateRandomRequestId()) : params; // RSC7c
             return rest.http.request(new Http.Execute<Void>() {
                 @Override
                 public void execute(HttpScheduler http, Callback<Void> callback) throws AblyException {

--- a/lib/src/main/java/io/ably/lib/push/PushBase.java
+++ b/lib/src/main/java/io/ably/lib/push/PushBase.java
@@ -111,7 +111,7 @@ public class PushBase {
                         params = Param.push(params, "fullWait", "true");
                     }
                     if(rest.options.addRequestIds) { // RSC7c
-                        Param.set(params, Crypto.generateRandomRequestId());
+                        params = Param.set(params, Crypto.generateRandomRequestId());
                     }
                     http.put("/push/deviceRegistrations/" + device.id, rest.push.pushRequestHeaders(device.id), params, body, DeviceDetails.httpResponseHandler, true, callback);
                 }
@@ -136,7 +136,7 @@ public class PushBase {
                         params = Param.push(params, "fullWait", "true");
                     }
                     if (rest.options.addRequestIds) { // RSC7c
-                        Param.set(params, Crypto.generateRandomRequestId());
+                        params = Param.set(params, Crypto.generateRandomRequestId());
                     }
                     http.get("/push/deviceRegistrations/" + deviceId, rest.push.pushRequestHeaders(deviceId), params, DeviceDetails.httpResponseHandler, true, callback);
                 }
@@ -182,7 +182,7 @@ public class PushBase {
                         params = Param.push(params, "fullWait", "true");
                     }
                     if(rest.options.addRequestIds) { // RSC7c
-                        Param.set(params, Crypto.generateRandomRequestId());
+                        params = Param.set(params, Crypto.generateRandomRequestId());
                     }
                     http.del("/push/deviceRegistrations/" + deviceId, rest.push.pushRequestHeaders(deviceId), params, null, true, callback);
                 }

--- a/lib/src/main/java/io/ably/lib/push/PushBase.java
+++ b/lib/src/main/java/io/ably/lib/push/PushBase.java
@@ -15,6 +15,7 @@ import io.ably.lib.types.AsyncPaginatedResult;
 import io.ably.lib.types.Callback;
 import io.ably.lib.types.PaginatedResult;
 import io.ably.lib.types.Param;
+import io.ably.lib.util.Crypto;
 import io.ably.lib.util.Log;
 import io.ably.lib.util.Serialisation;
 import io.ably.lib.util.StringUtils;
@@ -76,6 +77,9 @@ public class PushBase {
                     if (rest.options.pushFullWait) {
                         params = Param.push(params, "fullWait", "true");
                     }
+                    if (rest.options.addRequestIds) {
+                        params = Param.set(params, Crypto.generateRandomRequestId()); // RSC7c
+                    }
 
                     http.post("/push/publish", HttpUtils.defaultAcceptHeaders(rest.options.useBinaryProtocol), params, body, null, true, callback);
                 }
@@ -106,6 +110,9 @@ public class PushBase {
                     if (rest.options.pushFullWait) {
                         params = Param.push(params, "fullWait", "true");
                     }
+                    if(rest.options.addRequestIds) { // RSC7c
+                        Param.set(params, Crypto.generateRandomRequestId());
+                    }
                     http.put("/push/deviceRegistrations/" + device.id, rest.push.pushRequestHeaders(device.id), params, body, DeviceDetails.httpResponseHandler, true, callback);
                 }
             });
@@ -127,6 +134,9 @@ public class PushBase {
                     Param[] params = null;
                     if (rest.options.pushFullWait) {
                         params = Param.push(params, "fullWait", "true");
+                    }
+                    if (rest.options.addRequestIds) { // RSC7c
+                        Param.set(params, Crypto.generateRandomRequestId());
                     }
                     http.get("/push/deviceRegistrations/" + deviceId, rest.push.pushRequestHeaders(deviceId), params, DeviceDetails.httpResponseHandler, true, callback);
                 }
@@ -171,6 +181,9 @@ public class PushBase {
                     if (rest.options.pushFullWait) {
                         params = Param.push(params, "fullWait", "true");
                     }
+                    if(rest.options.addRequestIds) { // RSC7c
+                        Param.set(params, Crypto.generateRandomRequestId());
+                    }
                     http.del("/push/deviceRegistrations/" + deviceId, rest.push.pushRequestHeaders(deviceId), params, null, true, callback);
                 }
             });
@@ -189,7 +202,7 @@ public class PushBase {
             if (rest.options.pushFullWait) {
                 params = Param.push(params, "fullWait", "true");
             }
-            final Param[] finalParams = params;
+            final Param[] finalParams = rest.options.addRequestIds ? Param.set(params, Crypto.generateRandomRequestId()) : params; // RSC7c
             return rest.http.request(new Http.Execute<Void>() {
                 @Override
                 public void execute(HttpScheduler http, Callback<Void> callback) throws AblyException {
@@ -225,6 +238,9 @@ public class PushBase {
                     Param[] params = null;
                     if (rest.options.pushFullWait) {
                         params = Param.push(params, "fullWait", "true");
+                    }
+                    if (rest.options.addRequestIds) {
+                        params = Param.set(params, Crypto.generateRandomRequestId()); // RSC7c
                     }
                     http.post("/push/channelSubscriptions", rest.push.pushRequestHeaders(subscription.deviceId), params, body, ChannelSubscription.httpResponseHandler, true, callback);
                 }
@@ -283,7 +299,7 @@ public class PushBase {
                 params = Param.push(params, "fullWait", "true");
             }
             final Param[] finalHeaders = rest.push.pushRequestHeaders(deviceId);
-            final Param[] finalParams = params;
+            final Param[] finalParams = rest.options.addRequestIds ? Param.set(params, Crypto.generateRandomRequestId()) : params; // RSC7c
             return rest.http.request(new Http.Execute<Void>() {
                 @Override
                 public void execute(HttpScheduler http, Callback<Void> callback) throws AblyException {

--- a/lib/src/main/java/io/ably/lib/rest/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/rest/ChannelBase.java
@@ -103,15 +103,16 @@ public class ChannelBase {
                 }
                 if(!hasClientSuppliedId && ably.options.idempotentRestPublishing) {
                     /* RSL1k1: populate the message id with a library-generated id */
-                    String messageId = Crypto.getRandomMessageId();
+                    String messageId = Crypto.getRandomId();
                     for (int i = 0; i < messages.length; i++) {
                         messages[i].id = messageId + ':' + i;
                     }
                 }
 
                 HttpCore.RequestBody requestBody = ably.options.useBinaryProtocol ? MessageSerializer.asMsgpackRequest(messages) : MessageSerializer.asJsonRequest(messages);
+                final Param[] params = ably.options.addRequestIds ? Param.array(Crypto.generateRandomRequestId()) : null; // RSC7c
 
-                http.post(basePath + "/messages", HttpUtils.defaultAcceptHeaders(ably.options.useBinaryProtocol), null, requestBody, null, true, callback);
+                http.post(basePath + "/messages", HttpUtils.defaultAcceptHeaders(ably.options.useBinaryProtocol), params, requestBody, null, true, callback);
             }
         });
     }
@@ -139,8 +140,9 @@ public class ChannelBase {
         historyImpl(params).async(callback);
     }
 
-    private BasePaginatedQuery.ResultRequest<Message> historyImpl(Param[] params) {
+    private BasePaginatedQuery.ResultRequest<Message> historyImpl(Param[] initialParams) {
         HttpCore.BodyHandler<Message> bodyHandler = MessageSerializer.getMessageResponseHandler(options);
+        final Param[] params = ably.options.addRequestIds ? Param.set(initialParams, Crypto.generateRandomRequestId()) : initialParams; // RSC7c
         return (new BasePaginatedQuery<Message>(ably.http, basePath + "/messages", HttpUtils.defaultAcceptHeaders(ably.options.useBinaryProtocol), params, bodyHandler)).get();
     }
 
@@ -169,8 +171,9 @@ public class ChannelBase {
             getImpl(params).async(callback);
         }
 
-        private BasePaginatedQuery.ResultRequest<PresenceMessage> getImpl(Param[] params) {
+        private BasePaginatedQuery.ResultRequest<PresenceMessage> getImpl(Param[] initialParams) {
             HttpCore.BodyHandler<PresenceMessage> bodyHandler = PresenceSerializer.getPresenceResponseHandler(options);
+            final Param[] params = ably.options.addRequestIds ? Param.set(initialParams, Crypto.generateRandomRequestId()) : initialParams; // RSC7c
             return (new BasePaginatedQuery<PresenceMessage>(ably.http, basePath + "/presence", HttpUtils.defaultAcceptHeaders(ably.options.useBinaryProtocol), params, bodyHandler)).get();
         }
 
@@ -195,8 +198,9 @@ public class ChannelBase {
             historyImpl(params).async(callback);
         }
 
-        private BasePaginatedQuery.ResultRequest<PresenceMessage> historyImpl(Param[] params) {
+        private BasePaginatedQuery.ResultRequest<PresenceMessage> historyImpl(Param[] initialParams) {
             HttpCore.BodyHandler<PresenceMessage> bodyHandler = PresenceSerializer.getPresenceResponseHandler(options);
+            final Param[] params = ably.options.addRequestIds ? Param.set(initialParams, Crypto.generateRandomRequestId()) : initialParams; // RSC7c
             return (new BasePaginatedQuery<PresenceMessage>(ably.http, basePath + "/presence/history", HttpUtils.defaultAcceptHeaders(ably.options.useBinaryProtocol), params, bodyHandler)).get();
         }
 

--- a/lib/src/main/java/io/ably/lib/types/ClientOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ClientOptions.java
@@ -195,4 +195,10 @@ public class ClientOptions extends AuthOptions {
      * before responding.
      */
     public boolean pushFullWait = false;
+
+    /**
+     If enabled, every REST request to Ably includes a `request_id` query string parameter. This request ID
+     remain the same if a request is retried to a fallback host.
+     */
+    public boolean addRequestIds = false;
 }

--- a/lib/src/main/java/io/ably/lib/types/Param.java
+++ b/lib/src/main/java/io/ably/lib/types/Param.java
@@ -10,6 +10,10 @@ public class Param {
     public String key;
     public String value;
 
+    public static Param[] array(final Param val) {
+        return new Param[] { val };
+    }
+
     public static Param[] push(Param[] params, Param val) {
         if (params == null) {
             return new Param[] { val };

--- a/lib/src/main/java/io/ably/lib/util/Crypto.java
+++ b/lib/src/main/java/io/ably/lib/util/Crypto.java
@@ -16,6 +16,7 @@ import javax.crypto.spec.SecretKeySpec;
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.ChannelOptions;
 import io.ably.lib.types.ErrorInfo;
+import io.ably.lib.types.Param;
 
 /**
  * Utility classes and interfaces for message payload encryption.
@@ -318,10 +319,20 @@ public class Crypto {
         };
     }
 
-    public static String getRandomMessageId() {
+    public static String getRandomId() {
         byte[] entropy = new byte[9];
         secureRandom.nextBytes(entropy);
         return Base64Coder.encodeToString(entropy);
+    }
+
+    /**
+     * Returns a "request_id" query param, based on a sequence of 9 random bytes
+     * which have been base64 encoded.
+     *
+     * Spec: RSC7c
+     */
+    public static Param generateRandomRequestId() {
+        return new Param("request_id", Crypto.getRandomId());
     }
 
     /**

--- a/lib/src/main/java/io/ably/lib/util/ParamsUtils.java
+++ b/lib/src/main/java/io/ably/lib/util/ParamsUtils.java
@@ -5,6 +5,13 @@ import io.ably.lib.types.Param;
 
 public class ParamsUtils {
 
+    /**
+     * Produce either new or extend provided array of parameters based on values in Client options
+     *
+     * @param params Array of already set parameters
+     * @param options Client options
+     * @return Array of parameters extended of parameters based on values in client options
+     */
     public static Param[] enrichParams(Param[] params, ClientOptions options) {
         if (options.pushFullWait) {
             params = Param.push(params, "fullWait", "true");

--- a/lib/src/main/java/io/ably/lib/util/ParamsUtils.java
+++ b/lib/src/main/java/io/ably/lib/util/ParamsUtils.java
@@ -1,0 +1,18 @@
+package io.ably.lib.util;
+
+import io.ably.lib.types.ClientOptions;
+import io.ably.lib.types.Param;
+
+public class ParamsUtils {
+
+    public static Param[] enrichParams(Param[] params, ClientOptions options) {
+        if (options.pushFullWait) {
+            params = Param.push(params, "fullWait", "true");
+        }
+        if (options.addRequestIds) { // RSC7c
+            params = Param.set(params, Crypto.generateRandomRequestId());
+        }
+
+        return params;
+    }
+}

--- a/lib/src/test/java/io/ably/lib/test/rest/RestClientTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestClientTest.java
@@ -1,0 +1,50 @@
+package io.ably.lib.test.rest;
+
+import io.ably.lib.debug.DebugOptions;
+import io.ably.lib.rest.AblyRest;
+import io.ably.lib.test.common.Helpers;
+import io.ably.lib.test.common.ParameterizedTest;
+import io.ably.lib.types.AblyException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
+
+import static org.junit.Assert.assertEquals;
+
+public class RestClientTest extends ParameterizedTest {
+
+    @Rule
+    public Timeout testTimeout = Timeout.seconds(30);
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    /**
+     * Include `request_id` if addRequestIds in client options is enabled
+     * Spec: RSC7c
+     */
+    @Test
+    public void request_contains_request_id() throws AblyException {
+        DebugOptions opts = new DebugOptions(testVars.keys[0].keyStr);
+        fillInOptions(opts);
+        Helpers.RawHttpTracker httpListener = new Helpers.RawHttpTracker();
+
+        opts.httpListener = httpListener;
+        /* disable addRequestIds */
+        opts.addRequestIds = false;
+        AblyRest ablyA = new AblyRest(opts);
+
+        ablyA.channels.get("test").publish("foo", "bar");
+        /* verify client_id is not a part of url query */
+        assertEquals("Verify clientId is not present in query", null, httpListener.getFirstRequest().url.getQuery());
+
+        /* enable addRequestIds */
+        opts.addRequestIds = true;
+        AblyRest ablyB = new AblyRest(opts);
+
+        ablyB.channels.get("test").publish("foo", "bar");
+        /* verify client_id is a part of url query */
+        assertEquals("Verify clientId is present in query", true, httpListener.getLastRequest().url.getQuery().contains("request_id"));
+    }
+}

--- a/lib/src/test/java/io/ably/lib/util/CryptoTest.java
+++ b/lib/src/test/java/io/ably/lib/util/CryptoTest.java
@@ -202,7 +202,7 @@ public class CryptoTest {
 
     @Test
     public void getRandomId() {
-        String randomId = Crypto.getRandomMessageId();
+        String randomId = Crypto.getRandomId();
         assertEquals(12, randomId.length());
     }
 }

--- a/lib/src/test/java/io/ably/lib/util/ParamsUtilsTest.java
+++ b/lib/src/test/java/io/ably/lib/util/ParamsUtilsTest.java
@@ -1,0 +1,53 @@
+package io.ably.lib.util;
+
+import io.ably.lib.types.AblyException;
+import io.ably.lib.types.ClientOptions;
+import io.ably.lib.types.Param;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ParamsUtilsTest {
+
+    @Test
+    public void enrichParams_creates_params_if_original_are_null() throws AblyException {
+        ClientOptions opts = new ClientOptions("secret_key");
+        opts.pushFullWait = true;
+        opts.addRequestIds = true;
+
+        Param[] newParams = ParamsUtils.enrichParams(null, opts);
+
+        assertEquals(2, newParams.length);
+        assertTrue(Param.containsKey(newParams, "fullWait"));
+        assertTrue(Param.containsKey(newParams, "request_id"));
+    }
+
+    @Test
+    public void enrichParams_add_params_to_existing_ones() throws AblyException {
+        ClientOptions opts = new ClientOptions("secret_key");
+        opts.pushFullWait = true;
+        opts.addRequestIds = true;
+
+        Param[] originParams = Param.array(new Param("propertyName", "value"));
+        Param[] newParams = ParamsUtils.enrichParams(originParams, opts);
+
+        assertEquals(3, newParams.length);
+        assertTrue(Param.containsKey(newParams, "propertyName"));
+        assertTrue(Param.containsKey(newParams, "fullWait"));
+        assertTrue(Param.containsKey(newParams, "request_id"));
+    }
+
+    @Test
+    public void enrichParams_produce_only_requested_params() throws AblyException {
+        ClientOptions opts = new ClientOptions("secret_key");
+        opts.addRequestIds = true;
+
+        Param[] originParams = Param.array(new Param("propertyName", "value"));
+        Param[] newParams = ParamsUtils.enrichParams(originParams, opts);
+
+        assertEquals(2,newParams.length);
+        assertTrue(Param.containsKey(newParams, "propertyName"));
+        assertTrue(Param.containsKey(newParams, "request_id"));
+    }
+}


### PR DESCRIPTION
- Fixes [574](https://github.com/ably/ably-java/issues/574)
- Implementation of `RSC7c`. Adds `addRequestIds` parameter to client options. If this option is enabled every REST request to Ably should include in a request_id query string parameter a random string obtained by url-safe base64-encoding a sequence of at least 9 bytes obtained from a source of randomness. This request ID must remain the same if a request is retried to a fallback host per RSC15. Any log messages associated with the request should include the request ID. If the request fails, the request ID must be included in the ErrorInfo returned to the user.
