### PR TITLE
Support for encryption of shared preferences

### DIFF
--- a/android/src/androidTest/java/io/ably/lib/push/LocalDeviceStorageTest.java
+++ b/android/src/androidTest/java/io/ably/lib/push/LocalDeviceStorageTest.java
@@ -41,7 +41,7 @@ public class LocalDeviceStorageTest extends AndroidTestCase {
         }
 
         @Override
-        public void reset(Field[] fields) {
+        public void clear(Field[] fields) {
             hashMap = new HashMap<>();
         }
     };

--- a/android/src/androidTest/java/io/ably/lib/push/LocalDeviceStorageTest.java
+++ b/android/src/androidTest/java/io/ably/lib/push/LocalDeviceStorageTest.java
@@ -19,23 +19,23 @@ public class LocalDeviceStorageTest extends AndroidTestCase {
 
     private Storage inMemoryStorage = new Storage() {
         @Override
-        public void putString(String key, String value) {
+        public void put(String key, String value) {
             hashMap.put(key, value);
         }
 
         @Override
-        public void putInt(String key, int value) {
+        public void put(String key, int value) {
             hashMap.put(key, value);
         }
 
         @Override
-        public String getString(String key, String defaultValue) {
+        public String get(String key, String defaultValue) {
             Object value = hashMap.get(key);
             return value != null ? (String) value : defaultValue;
         }
 
         @Override
-        public int getInt(String key, int defaultValue) {
+        public int get(String key, int defaultValue) {
             Object value = hashMap.get(key);
             return value != null ? (int) value : defaultValue;
         }

--- a/android/src/androidTest/java/io/ably/lib/push/LocalDeviceStorageTest.java
+++ b/android/src/androidTest/java/io/ably/lib/push/LocalDeviceStorageTest.java
@@ -1,0 +1,149 @@
+package io.ably.lib.push;
+
+import android.content.Context;
+import android.test.AndroidTestCase;
+import io.ably.lib.types.RegistrationToken;
+import junit.extensions.TestSetup;
+import junit.framework.TestSuite;
+import org.junit.BeforeClass;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+
+public class LocalDeviceStorageTest extends AndroidTestCase {
+    private Context context;
+    private ActivationContext activationContext;
+
+
+    private HashMap<String, Object> hashMap = new HashMap<>();
+
+    private Storage inMemoryStorage = new Storage() {
+        @Override
+        public void putString(String key, String value) {
+            hashMap.put(key, value);
+        }
+
+        @Override
+        public void putInt(String key, int value) {
+            hashMap.put(key, value);
+        }
+
+        @Override
+        public String getString(String key, String defaultValue) {
+            Object value = hashMap.get(key);
+            return value != null ? (String) value : defaultValue;
+        }
+
+        @Override
+        public int getInt(String key, int defaultValue) {
+            Object value = hashMap.get(key);
+            return value != null ? (int) value : defaultValue;
+        }
+
+        @Override
+        public void reset(Field[] fields) {
+            hashMap = new HashMap<>();
+        }
+    };
+
+    @BeforeClass
+    public void setUp() {
+        context = getContext();
+        activationContext = new ActivationContext(context.getApplicationContext());
+    }
+
+    public static junit.framework.Test suite() {
+        TestSuite suite = new TestSuite();
+        suite.addTest(new TestSetup(new TestSuite(LocalDeviceStorageTest.class)) {});
+        return suite;
+    }
+
+    public void test_shared_preferences_storage_used_by_default() {
+        LocalDevice localDevice = new LocalDevice(activationContext, null);
+        /* initialize properties in storage */
+        localDevice.create();
+
+        /* verify custom storage is not used */
+        assertTrue(hashMap.isEmpty());
+
+        /* load properties */
+        assertNotNull(localDevice.id);
+        assertNotNull(localDevice.deviceSecret);
+    }
+
+    public void test_shared_preferences_storage_works_correctly() {
+        LocalDevice localDevice = new LocalDevice(activationContext, null);
+
+        RegistrationToken registrationToken= new RegistrationToken(RegistrationToken.Type.FCM, "ABLY");
+        /* initialize properties in storage */
+        localDevice.create();
+        localDevice.setAndPersistRegistrationToken(registrationToken);
+
+        /* verify custom storage is not used */
+        assertTrue(hashMap.isEmpty());
+
+        /* load properties */
+        assertNotNull(localDevice.id);
+        assertNotNull(localDevice.deviceSecret);
+        assertTrue(localDevice.isCreated());
+        assertEquals("FCM", localDevice.getRegistrationToken().type.name());
+        assertEquals("ABLY", localDevice.getRegistrationToken().token);
+
+        /* reset all properties */
+        localDevice.reset();
+
+        /* properties were cleared */
+        assertNull(localDevice.id);
+        assertNull(localDevice.deviceSecret);
+        assertNull(localDevice.getRegistrationToken());
+    }
+
+    public void test_custom_storage_used_if_provided() {
+        LocalDevice localDevice = new LocalDevice(activationContext, inMemoryStorage);
+        /* initialize properties in storage */
+        localDevice.create();
+
+        /* verify in memory storage is used */
+        assertFalse(hashMap.isEmpty());
+
+        /* load properties */
+        assertNotNull(localDevice.id);
+        assertNotNull(localDevice.deviceSecret);
+
+        String deviceId = localDevice.id;
+        String deviceSecret = localDevice.deviceSecret;
+
+        /* values are the same */
+        assertEquals(deviceId, hashMap.get("ABLY_DEVICE_ID"));
+        assertEquals(deviceSecret, hashMap.get("ABLY_DEVICE_SECRET"));
+    }
+
+    public void test_custom_storage_works_correctly() {
+        LocalDevice localDevice = new LocalDevice(activationContext, inMemoryStorage);
+
+        RegistrationToken registrationToken= new RegistrationToken(RegistrationToken.Type.FCM, "ABLY");
+        /* initialize properties in storage */
+        localDevice.create();
+        localDevice.setAndPersistRegistrationToken(registrationToken);
+
+        /* verify custom storage is used */
+        assertFalse(hashMap.isEmpty());
+
+        /* load properties */
+        assertNotNull(localDevice.id);
+        assertNotNull(localDevice.deviceSecret);
+        assertTrue(localDevice.isCreated());
+        assertEquals("FCM", localDevice.getRegistrationToken().type.name());
+        assertEquals("ABLY", localDevice.getRegistrationToken().token);
+
+        /* reset all properties */
+        localDevice.reset();
+        /* verify custom storage was cleared out */
+        assertTrue(hashMap.isEmpty());
+
+        /* properties were cleared */
+        assertNull(localDevice.id);
+        assertNull(localDevice.deviceSecret);
+        assertNull(localDevice.getRegistrationToken());
+    }
+}

--- a/android/src/main/java/io/ably/lib/push/ActivationContext.java
+++ b/android/src/main/java/io/ably/lib/push/ActivationContext.java
@@ -5,7 +5,6 @@ import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
-import com.google.firebase.FirebaseApp;
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.google.firebase.iid.InstanceIdResult;
 import io.ably.lib.rest.AblyRest;
@@ -31,7 +30,9 @@ public class ActivationContext {
     public synchronized LocalDevice getLocalDevice() {
         if(localDevice == null) {
             Log.v(TAG, "getLocalDevice(): creating new instance and returning that");
-            localDevice = new LocalDevice(this);
+            Storage storage = ably != null ? ably.options.storage : null;
+
+            localDevice = new LocalDevice(this, storage);
         } else {
             Log.v(TAG, "getLocalDevice(): returning existing instance");
         }

--- a/android/src/main/java/io/ably/lib/push/ActivationContext.java
+++ b/android/src/main/java/io/ably/lib/push/ActivationContext.java
@@ -30,7 +30,7 @@ public class ActivationContext {
     public synchronized LocalDevice getLocalDevice() {
         if(localDevice == null) {
             Log.v(TAG, "getLocalDevice(): creating new instance and returning that");
-            Storage storage = ably != null ? ably.options.storage : null;
+            Storage storage = ably != null ? ably.options.localStorage : null;
 
             localDevice = new LocalDevice(this, storage);
         } else {

--- a/android/src/main/java/io/ably/lib/push/LocalDevice.java
+++ b/android/src/main/java/io/ably/lib/push/LocalDevice.java
@@ -133,7 +133,7 @@ public class LocalDevice extends DeviceDetails {
         this.clientId = null;
         this.clearRegistrationToken();
 
-        storage.reset(SharedPrefKeys.class.getDeclaredFields());
+        storage.clear(SharedPrefKeys.class.getDeclaredFields());
     }
 
     boolean isRegistered() {

--- a/android/src/main/java/io/ably/lib/push/LocalDevice.java
+++ b/android/src/main/java/io/ably/lib/push/LocalDevice.java
@@ -43,24 +43,24 @@ public class LocalDevice extends DeviceDetails {
 
     private void loadPersisted() {
         /* Spec: RSH8a */
-        String id = storage.getString(SharedPrefKeys.DEVICE_ID, null);
+        String id = storage.get(SharedPrefKeys.DEVICE_ID, null);
         this.id = id;
         if(id != null) {
             Log.v(TAG, "loadPersisted(): existing deviceId found; id: " + id);
-            deviceSecret = storage.getString(SharedPrefKeys.DEVICE_SECRET, null);
+            deviceSecret = storage.get(SharedPrefKeys.DEVICE_SECRET, null);
         } else {
             Log.v(TAG, "loadPersisted(): existing deviceId not found.");
         }
-        this.clientId = storage.getString(SharedPrefKeys.CLIENT_ID, null);
-        this.deviceIdentityToken = storage.getString(SharedPrefKeys.DEVICE_TOKEN, null);
+        this.clientId = storage.get(SharedPrefKeys.CLIENT_ID, null);
+        this.deviceIdentityToken = storage.get(SharedPrefKeys.DEVICE_TOKEN, null);
 
         RegistrationToken.Type type = RegistrationToken.Type.fromOrdinal(
-            storage.getInt(SharedPrefKeys.TOKEN_TYPE, -1));
+            storage.get(SharedPrefKeys.TOKEN_TYPE, -1));
 
         Log.d(TAG, "loadPersisted(): token type = " + type);
         if(type != null) {
             RegistrationToken token = null;
-            String tokenString = storage.getString(SharedPrefKeys.TOKEN, null);
+            String tokenString = storage.get(SharedPrefKeys.TOKEN, null);
             Log.d(TAG, "loadPersisted(): token string = " + tokenString);
             if(tokenString != null) {
                 token = new RegistrationToken(type, tokenString);
@@ -97,20 +97,20 @@ public class LocalDevice extends DeviceDetails {
     void setAndPersistRegistrationToken(RegistrationToken token) {
         Log.v(TAG, "setAndPersistRegistrationToken(): token=" + token);
         setRegistrationToken(token);
-        storage.putInt(SharedPrefKeys.TOKEN_TYPE, token.type.ordinal());
-        storage.putString(SharedPrefKeys.TOKEN, token.token);
+        storage.put(SharedPrefKeys.TOKEN_TYPE, token.type.ordinal());
+        storage.put(SharedPrefKeys.TOKEN, token.token);
     }
 
     void setClientId(String clientId) {
         Log.v(TAG, "setClientId(): clientId=" + clientId);
         this.clientId = clientId;
-        storage.putString(SharedPrefKeys.CLIENT_ID, clientId);
+        storage.put(SharedPrefKeys.CLIENT_ID, clientId);
     }
 
     public void setDeviceIdentityToken(String token) {
         Log.v(TAG, "setDeviceIdentityToken(): token=" + token);
         this.deviceIdentityToken = token;
-        storage.putString(SharedPrefKeys.DEVICE_TOKEN, token);
+        storage.put(SharedPrefKeys.DEVICE_TOKEN, token);
     }
 
     boolean isCreated() {
@@ -120,9 +120,9 @@ public class LocalDevice extends DeviceDetails {
     void create() {
         /* Spec: RSH8b */
         Log.v(TAG, "create()");
-        storage.putString(SharedPrefKeys.DEVICE_ID, (id = ULID.random()));
-        storage.putString(SharedPrefKeys.CLIENT_ID, (clientId = activationContext.clientId));
-        storage.putString(SharedPrefKeys.DEVICE_SECRET, (deviceSecret = generateSecret()));
+        storage.put(SharedPrefKeys.DEVICE_ID, (id = ULID.random()));
+        storage.put(SharedPrefKeys.CLIENT_ID, (clientId = activationContext.clientId));
+        storage.put(SharedPrefKeys.DEVICE_SECRET, (deviceSecret = generateSecret()));
     }
 
     public void reset() {

--- a/android/src/main/java/io/ably/lib/push/SharedPreferenceStorage.java
+++ b/android/src/main/java/io/ably/lib/push/SharedPreferenceStorage.java
@@ -1,0 +1,52 @@
+package io.ably.lib.push;
+
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+import java.lang.reflect.Field;
+
+public class SharedPreferenceStorage implements Storage{
+
+    private final ActivationContext activationContext;
+
+    public SharedPreferenceStorage(ActivationContext activationContext) {
+        this.activationContext = activationContext;
+    }
+
+    @Override
+    public void putString(String key, String value) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activationContext.getContext());
+        prefs.edit().putString(key, value).apply();
+    }
+
+    @Override
+    public void putInt(String key, int value) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activationContext.getContext());
+        prefs.edit().putInt(key, value).apply();
+    }
+
+    @Override
+    public String getString(String key, String defaultValue) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activationContext.getContext());
+        return prefs.getString(key, defaultValue);
+    }
+
+    @Override
+    public int getInt(String key, int defValue) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activationContext.getContext());
+        return prefs.getInt(key, defValue);
+    }
+
+    @Override
+    public void reset(Field[] fields) {
+        SharedPreferences.Editor editor = activationContext.getPreferences().edit();
+        for (Field f : fields) {
+            try {
+                editor.remove((String) f.get(null));
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        editor.commit();
+    }
+}

--- a/android/src/main/java/io/ably/lib/push/SharedPreferenceStorage.java
+++ b/android/src/main/java/io/ably/lib/push/SharedPreferenceStorage.java
@@ -13,28 +13,28 @@ public class SharedPreferenceStorage implements Storage{
         this.activationContext = activationContext;
     }
 
+    private SharedPreferences sharedPreferences() {
+        return PreferenceManager.getDefaultSharedPreferences(activationContext.getContext());
+    }
+
     @Override
     public void putString(String key, String value) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activationContext.getContext());
-        prefs.edit().putString(key, value).apply();
+        sharedPreferences().edit().putString(key, value).apply();
     }
 
     @Override
     public void putInt(String key, int value) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activationContext.getContext());
-        prefs.edit().putInt(key, value).apply();
+        sharedPreferences().edit().putInt(key, value).apply();
     }
 
     @Override
     public String getString(String key, String defaultValue) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activationContext.getContext());
-        return prefs.getString(key, defaultValue);
+        return sharedPreferences().getString(key, defaultValue);
     }
 
     @Override
     public int getInt(String key, int defaultValue) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activationContext.getContext());
-        return prefs.getInt(key, defaultValue);
+        return sharedPreferences().getInt(key, defaultValue);
     }
 
     @Override

--- a/android/src/main/java/io/ably/lib/push/SharedPreferenceStorage.java
+++ b/android/src/main/java/io/ably/lib/push/SharedPreferenceStorage.java
@@ -18,22 +18,22 @@ public class SharedPreferenceStorage implements Storage{
     }
 
     @Override
-    public void putString(String key, String value) {
+    public void put(String key, String value) {
         sharedPreferences().edit().putString(key, value).apply();
     }
 
     @Override
-    public void putInt(String key, int value) {
+    public void put(String key, int value) {
         sharedPreferences().edit().putInt(key, value).apply();
     }
 
     @Override
-    public String getString(String key, String defaultValue) {
+    public String get(String key, String defaultValue) {
         return sharedPreferences().getString(key, defaultValue);
     }
 
     @Override
-    public int getInt(String key, int defaultValue) {
+    public int get(String key, int defaultValue) {
         return sharedPreferences().getInt(key, defaultValue);
     }
 

--- a/android/src/main/java/io/ably/lib/push/SharedPreferenceStorage.java
+++ b/android/src/main/java/io/ably/lib/push/SharedPreferenceStorage.java
@@ -32,9 +32,9 @@ public class SharedPreferenceStorage implements Storage{
     }
 
     @Override
-    public int getInt(String key, int defValue) {
+    public int getInt(String key, int defaultValue) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activationContext.getContext());
-        return prefs.getInt(key, defValue);
+        return prefs.getInt(key, defaultValue);
     }
 
     @Override

--- a/android/src/main/java/io/ably/lib/push/SharedPreferenceStorage.java
+++ b/android/src/main/java/io/ably/lib/push/SharedPreferenceStorage.java
@@ -38,7 +38,7 @@ public class SharedPreferenceStorage implements Storage{
     }
 
     @Override
-    public void reset(Field[] fields) {
+    public void clear(Field[] fields) {
         SharedPreferences.Editor editor = activationContext.getPreferences().edit();
         for (Field f : fields) {
             try {

--- a/lib/src/main/java/io/ably/lib/push/Storage.java
+++ b/lib/src/main/java/io/ably/lib/push/Storage.java
@@ -2,6 +2,10 @@ package io.ably.lib.push;
 
 import java.lang.reflect.Field;
 
+/**
+ * Interface for an entity that supplies key value store
+ * - methods getString and getInt have to return default value if requested key is not found
+ */
 public interface Storage {
 
     void putString(String key, String value);
@@ -12,5 +16,5 @@ public interface Storage {
 
     int getInt(String key, int defaultValue);
 
-    void reset(Field[] fields);
+    void clear(Field[] fields);
 }

--- a/lib/src/main/java/io/ably/lib/push/Storage.java
+++ b/lib/src/main/java/io/ably/lib/push/Storage.java
@@ -10,7 +10,7 @@ public interface Storage {
 
     String getString(String key, String defaultValue);
 
-    int getInt(String key, int defValue);
+    int getInt(String key, int defaultValue);
 
     void reset(Field[] fields);
 }

--- a/lib/src/main/java/io/ably/lib/push/Storage.java
+++ b/lib/src/main/java/io/ably/lib/push/Storage.java
@@ -1,0 +1,16 @@
+package io.ably.lib.push;
+
+import java.lang.reflect.Field;
+
+public interface Storage {
+
+    void putString(String key, String value);
+
+    void putInt(String key, int value);
+
+    String getString(String key, String defaultValue);
+
+    int getInt(String key, int defValue);
+
+    void reset(Field[] fields);
+}

--- a/lib/src/main/java/io/ably/lib/push/Storage.java
+++ b/lib/src/main/java/io/ably/lib/push/Storage.java
@@ -4,17 +4,42 @@ import java.lang.reflect.Field;
 
 /**
  * Interface for an entity that supplies key value store
- * - methods getString and getInt have to return default value if requested key is not found
  */
 public interface Storage {
 
+    /**
+     * Insert string value in to storage
+     * @param key name under which value is stored
+     * @param value stored string value
+     */
     void putString(String key, String value);
 
+    /**
+     * Insert integer value in to storage
+     * @param key name after which value is stored
+     * @param value stored integer value
+     */
     void putInt(String key, int value);
 
+    /**
+     * Returns string value based on key from storage
+     * @param key name under value is stored
+     * @param defaultValue value which is returned if key is not found
+     * @return value stored under key or default value if key is not found
+     */
     String getString(String key, String defaultValue);
 
+    /**
+     * Returns integer value based on key from storage
+     * @param key name under value is stored
+     * @param defaultValue value which is returned if key is not found
+     * @return value stored under key or default value if key is not found
+     */
     int getInt(String key, int defaultValue);
 
+    /**
+     * Removes fields from storage
+     * @param fields array of keys which values should be removed from storage
+     */
     void clear(Field[] fields);
 }

--- a/lib/src/main/java/io/ably/lib/push/Storage.java
+++ b/lib/src/main/java/io/ably/lib/push/Storage.java
@@ -8,18 +8,18 @@ import java.lang.reflect.Field;
 public interface Storage {
 
     /**
-     * Insert string value in to storage
+     * Put string value in to storage
      * @param key name under which value is stored
      * @param value stored string value
      */
-    void putString(String key, String value);
+    void put(String key, String value);
 
     /**
-     * Insert integer value in to storage
+     * Put integer value in to storage
      * @param key name after which value is stored
      * @param value stored integer value
      */
-    void putInt(String key, int value);
+    void put(String key, int value);
 
     /**
      * Returns string value based on key from storage
@@ -27,7 +27,7 @@ public interface Storage {
      * @param defaultValue value which is returned if key is not found
      * @return value stored under key or default value if key is not found
      */
-    String getString(String key, String defaultValue);
+    String get(String key, String defaultValue);
 
     /**
      * Returns integer value based on key from storage
@@ -35,7 +35,7 @@ public interface Storage {
      * @param defaultValue value which is returned if key is not found
      * @return value stored under key or default value if key is not found
      */
-    int getInt(String key, int defaultValue);
+    int get(String key, int defaultValue);
 
     /**
      * Removes fields from storage

--- a/lib/src/main/java/io/ably/lib/types/ClientOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ClientOptions.java
@@ -1,5 +1,6 @@
 package io.ably.lib.types;
 
+import io.ably.lib.push.Storage;
 import io.ably.lib.rest.Auth.AuthOptions;
 import io.ably.lib.rest.Auth.TokenParams;
 import io.ably.lib.transport.Defaults;
@@ -195,4 +196,10 @@ public class ClientOptions extends AuthOptions {
      * before responding.
      */
     public boolean pushFullWait = false;
+
+    /**
+     * Allows provide custom Local Device storage. In a case nothing is provided default implementation
+     * using SharedPreferences is used.
+     */
+    public Storage storage = null;
 }

--- a/lib/src/main/java/io/ably/lib/types/ClientOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ClientOptions.java
@@ -198,8 +198,8 @@ public class ClientOptions extends AuthOptions {
     public boolean pushFullWait = false;
 
     /**
-     * Allows provide custom Local Device storage. In a case nothing is provided default implementation
+     * Custom Local Device storage. In the case nothing is provided then a default implementation
      * using SharedPreferences is used.
      */
-    public Storage storage = null;
+    public Storage localStorage = null;
 }


### PR DESCRIPTION
- Fixes [593](https://github.com/ably/ably-java/issues/593)
- Default SharedPreferences could be replaced with custom Storage implementation, ClientOptions allows to inject custom object. If nothing is injected current behaviour using SharedPreferences is used so no need to do any changes to keep current functionality. 