### PR TITLE
Add docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
       # Using the test command in lieu of https://github.com/ably/sdk-upload-action/issues/24
       - run: |
           ./gradlew javadoc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,8 +18,8 @@ jobs:
           ls -l java/build/docs/javadoc
           echo "Contents of android docs folder:"
           ls -l android/build/docs/javadoc
-          test -d java/build/docs/javadoc/index.html && echo "java docs index found."
-          test -d android/build/docs/javadoc/index.html && echo "android docs index found."
+          test -f java/build/docs/javadoc/index.html && echo "java docs index found."
+          test -f android/build/docs/javadoc/index.html && echo "android docs index found."
 
       - uses: ably/sdk-upload-action@v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: ./gradlew javadoc
+      # Using the test command in lieu of https://github.com/ably/sdk-upload-action/issues/24
+      - run: |
+        ./gradlew javadoc
+        test -d java/build/docs/javadoc
+        test -d android/build/docs/javadoc
 
       - uses: ably/sdk-upload-action@v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,8 @@ jobs:
           ./gradlew javadoc
           test -d java/build/docs/javadoc
           test -d android/build/docs/javadoc
+          ls -l java/build/docs/javadoc
+          ls -l android/build/docs/javadoc
 
       - uses: ably/sdk-upload-action@v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,9 +11,9 @@ jobs:
 
       # Using the test command in lieu of https://github.com/ably/sdk-upload-action/issues/24
       - run: |
-        ./gradlew javadoc
-        test -d java/build/docs/javadoc
-        test -d android/build/docs/javadoc
+          ./gradlew javadoc
+          test -d java/build/docs/javadoc
+          test -d android/build/docs/javadoc
 
       - uses: ably/sdk-upload-action@v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       # Using the test command in lieu of https://github.com/ably/sdk-upload-action/issues/24
       - run: |
-          ./gradlew groovydoc
+          ./gradlew java:javadoc
           test -d java/build/docs/javadoc && echo "java docs folder found."
           test -d android/build/docs/javadoc && echo "android docs folder found."
           echo "Contents of java docs folder:"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,10 +12,14 @@ jobs:
       # Using the test command in lieu of https://github.com/ably/sdk-upload-action/issues/24
       - run: |
           ./gradlew javadoc
-          test -d java/build/docs/javadoc
-          test -d android/build/docs/javadoc
+          test -d java/build/docs/javadoc && echo "java docs folder found."
+          test -d android/build/docs/javadoc && echo "android docs folder found."
+          echo "Contents of java docs folder:"
           ls -l java/build/docs/javadoc
+          echo "Contents of android docs folder:"
           ls -l android/build/docs/javadoc
+          test -d java/build/docs/javadoc/index.html && echo "java docs index found."
+          test -d android/build/docs/javadoc/index.html && echo "android docs index found."
 
       - uses: ably/sdk-upload-action@v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: ./gradlew javadoc
+
+      - uses: ably/sdk-upload-action@v1
+        with:
+          s3AccessKeyId: ${{ secrets.SDK_S3_ACCESS_KEY_ID }}
+          s3AccessKey: ${{ secrets.SDK_S3_ACCESS_KEY }}
+          sourcePath: java/build/docs/javadoc
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          artifactName: javadoc-java
+
+      - uses: ably/sdk-upload-action@v1
+        with:
+          s3AccessKeyId: ${{ secrets.SDK_S3_ACCESS_KEY_ID }}
+          s3AccessKey: ${{ secrets.SDK_S3_ACCESS_KEY }}
+          sourcePath: android/build/docs/javadoc
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          artifactName: javadoc-android

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       # Using the test command in lieu of https://github.com/ably/sdk-upload-action/issues/24
       - run: |
-          ./gradlew javadoc
+          ./gradlew groovydoc
           test -d java/build/docs/javadoc && echo "java docs folder found."
           test -d android/build/docs/javadoc && echo "android docs folder found."
           echo "Contents of java docs folder:"


### PR DESCRIPTION
It's going to be helpful to gain visibility of what our javadoc output is. While we don't currently publish it anywhere formally, in terms of API Reference accessibility (because it's very incomplete), this represents a good first step towards that.