### PR TITLE
Removed forName method 

### DIFF
--- a/android/src/androidTest/java/io/ably/lib/test/android/EventTest.java
+++ b/android/src/androidTest/java/io/ably/lib/test/android/EventTest.java
@@ -1,0 +1,86 @@
+package io.ably.lib.test.android;
+
+import io.ably.lib.push.ActivationStateMachine.CalledActivate;
+import io.ably.lib.push.ActivationStateMachine.CalledDeactivate;
+import io.ably.lib.push.ActivationStateMachine.Deregistered;
+import io.ably.lib.push.ActivationStateMachine.Event;
+import io.ably.lib.push.ActivationStateMachine.GotDeviceRegistration;
+import io.ably.lib.push.ActivationStateMachine.GotPushDeviceDetails;
+import io.ably.lib.push.ActivationStateMachine.RegistrationSynced;
+import io.ably.lib.push.ActivationStateMachine.GettingDeviceRegistrationFailed;
+import io.ably.lib.push.ActivationStateMachine.GettingPushDeviceDetailsFailed;
+import io.ably.lib.push.ActivationStateMachine.SyncRegistrationFailed;
+import io.ably.lib.push.ActivationStateMachine.DeregistrationFailed;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EventTest {
+
+    @Test
+    public void events_subclasses_correctly_constructed_by_name() throws ClassNotFoundException, InstantiationException {
+
+        CalledActivate calledActivateEvent = new CalledActivate();
+        Event calledActivateReconstructed = Event.constructEventByName(calledActivateEvent.getName());
+        assertEquals(calledActivateEvent.getClass(), calledActivateReconstructed.getClass());
+
+        CalledDeactivate calledDeactivateEvent = new CalledDeactivate();
+        Event calledDeactivateReconstructed = Event.constructEventByName(calledDeactivateEvent.getName());
+        assertEquals(calledDeactivateEvent.getClass(), calledDeactivateReconstructed.getClass());
+
+        GotPushDeviceDetails gotPushDeviceDetailsEvent = new GotPushDeviceDetails();
+        Event gotPushDeviceDetailsReconstructed = Event.constructEventByName(gotPushDeviceDetailsEvent.getName());
+        assertEquals(gotPushDeviceDetailsEvent.getClass(), gotPushDeviceDetailsReconstructed.getClass());
+
+        RegistrationSynced registrationSyncedEvent = new RegistrationSynced();
+        Event registrationSyncedReconstructed = Event.constructEventByName(registrationSyncedEvent.getName());
+        assertEquals(registrationSyncedEvent.getClass(), registrationSyncedReconstructed.getClass());
+
+        Deregistered DeregisteredEvent = new Deregistered();
+        Event DeregisteredReconstructed = Event.constructEventByName(DeregisteredEvent.getName());
+        assertEquals(DeregisteredEvent.getClass(), DeregisteredReconstructed.getClass());
+    }
+
+    @Test
+    public void events_with_constructor_parameter_cannot_be_restored() {
+        GotDeviceRegistration gotDeviceRegistration = new GotDeviceRegistration(null);
+        try{
+            Event.constructEventByName(gotDeviceRegistration.getName());
+        } catch (Exception e) {
+            assertEquals(InstantiationException.class, e.getClass());
+        }
+
+        GettingDeviceRegistrationFailed gettingDeviceRegistrationFailed = new GettingDeviceRegistrationFailed(null);
+        try {
+            Event.constructEventByName(gettingDeviceRegistrationFailed.getName());
+        } catch (Exception e) {
+            assertEquals(InstantiationException.class, e.getClass());
+        }
+
+        GettingPushDeviceDetailsFailed gettingPushDeviceDetailsFailed = new GettingPushDeviceDetailsFailed(null);
+        try {
+            Event.constructEventByName(gettingPushDeviceDetailsFailed.getName());
+        } catch (Exception e) {
+            assertEquals(InstantiationException.class, e.getClass());
+        }
+
+        SyncRegistrationFailed syncRegistrationFailed = new SyncRegistrationFailed(null);
+        try {
+            Event.constructEventByName(syncRegistrationFailed.getName());
+        } catch (Exception e) {
+            assertEquals(InstantiationException.class, e.getClass());
+        }
+
+        DeregistrationFailed deregistrationFailed = new DeregistrationFailed(null);
+        try {
+            Event.constructEventByName(deregistrationFailed.getName());
+        } catch (Exception e) {
+            assertEquals(InstantiationException.class, e.getClass());
+        }
+    }
+
+    @Test(expected = ClassNotFoundException.class)
+    public void unknown_events_cannot_be_constructed_by_name() throws Exception {
+        Event.constructEventByName("notDefinedName");
+    }
+}

--- a/android/src/androidTest/java/io/ably/lib/test/android/EventTest.java
+++ b/android/src/androidTest/java/io/ably/lib/test/android/EventTest.java
@@ -21,23 +21,23 @@ public class EventTest {
     public void events_subclasses_correctly_constructed_by_name() throws ClassNotFoundException, InstantiationException {
 
         CalledActivate calledActivateEvent = new CalledActivate();
-        Event calledActivateReconstructed = Event.constructEventByName(calledActivateEvent.getName());
+        Event calledActivateReconstructed = Event.constructEventByName(calledActivateEvent.getPersistedName());
         assertEquals(calledActivateEvent.getClass(), calledActivateReconstructed.getClass());
 
         CalledDeactivate calledDeactivateEvent = new CalledDeactivate();
-        Event calledDeactivateReconstructed = Event.constructEventByName(calledDeactivateEvent.getName());
+        Event calledDeactivateReconstructed = Event.constructEventByName(calledDeactivateEvent.getPersistedName());
         assertEquals(calledDeactivateEvent.getClass(), calledDeactivateReconstructed.getClass());
 
         GotPushDeviceDetails gotPushDeviceDetailsEvent = new GotPushDeviceDetails();
-        Event gotPushDeviceDetailsReconstructed = Event.constructEventByName(gotPushDeviceDetailsEvent.getName());
+        Event gotPushDeviceDetailsReconstructed = Event.constructEventByName(gotPushDeviceDetailsEvent.getPersistedName());
         assertEquals(gotPushDeviceDetailsEvent.getClass(), gotPushDeviceDetailsReconstructed.getClass());
 
         RegistrationSynced registrationSyncedEvent = new RegistrationSynced();
-        Event registrationSyncedReconstructed = Event.constructEventByName(registrationSyncedEvent.getName());
+        Event registrationSyncedReconstructed = Event.constructEventByName(registrationSyncedEvent.getPersistedName());
         assertEquals(registrationSyncedEvent.getClass(), registrationSyncedReconstructed.getClass());
 
         Deregistered DeregisteredEvent = new Deregistered();
-        Event DeregisteredReconstructed = Event.constructEventByName(DeregisteredEvent.getName());
+        Event DeregisteredReconstructed = Event.constructEventByName(DeregisteredEvent.getPersistedName());
         assertEquals(DeregisteredEvent.getClass(), DeregisteredReconstructed.getClass());
     }
 
@@ -45,35 +45,35 @@ public class EventTest {
     public void events_with_constructor_parameter_cannot_be_restored() {
         GotDeviceRegistration gotDeviceRegistration = new GotDeviceRegistration(null);
         try{
-            Event.constructEventByName(gotDeviceRegistration.getName());
+            Event.constructEventByName(gotDeviceRegistration.getPersistedName());
         } catch (Exception e) {
             assertEquals(InstantiationException.class, e.getClass());
         }
 
         GettingDeviceRegistrationFailed gettingDeviceRegistrationFailed = new GettingDeviceRegistrationFailed(null);
         try {
-            Event.constructEventByName(gettingDeviceRegistrationFailed.getName());
+            Event.constructEventByName(gettingDeviceRegistrationFailed.getPersistedName());
         } catch (Exception e) {
             assertEquals(InstantiationException.class, e.getClass());
         }
 
         GettingPushDeviceDetailsFailed gettingPushDeviceDetailsFailed = new GettingPushDeviceDetailsFailed(null);
         try {
-            Event.constructEventByName(gettingPushDeviceDetailsFailed.getName());
+            Event.constructEventByName(gettingPushDeviceDetailsFailed.getPersistedName());
         } catch (Exception e) {
             assertEquals(InstantiationException.class, e.getClass());
         }
 
         SyncRegistrationFailed syncRegistrationFailed = new SyncRegistrationFailed(null);
         try {
-            Event.constructEventByName(syncRegistrationFailed.getName());
+            Event.constructEventByName(syncRegistrationFailed.getPersistedName());
         } catch (Exception e) {
             assertEquals(InstantiationException.class, e.getClass());
         }
 
         DeregistrationFailed deregistrationFailed = new DeregistrationFailed(null);
         try {
-            Event.constructEventByName(deregistrationFailed.getName());
+            Event.constructEventByName(deregistrationFailed.getPersistedName());
         } catch (Exception e) {
             assertEquals(InstantiationException.class, e.getClass());
         }

--- a/android/src/main/java/io/ably/lib/push/ActivationStateMachine.java
+++ b/android/src/main/java/io/ably/lib/push/ActivationStateMachine.java
@@ -32,7 +32,7 @@ import java.util.ArrayDeque;
 
 public class ActivationStateMachine {
     public static class CalledActivate extends ActivationStateMachine.Event {
-        private static final String NAME = "CalledActivate";
+        public static final String NAME = "CalledActivate";
 
         public static ActivationStateMachine.CalledActivate useCustomRegistrar(boolean useCustomRegistrar, SharedPreferences prefs) {
             prefs.edit().putBoolean(ActivationStateMachine.PersistKeys.PUSH_CUSTOM_REGISTRAR, useCustomRegistrar).apply();
@@ -46,7 +46,7 @@ public class ActivationStateMachine {
     }
 
     public static class CalledDeactivate extends ActivationStateMachine.Event {
-        private static final String NAME = "CalledDeactivate";
+        public static final String NAME = "CalledDeactivate";
 
         static ActivationStateMachine.CalledDeactivate useCustomRegistrar(boolean useCustomRegistrar, SharedPreferences prefs) {
             prefs.edit().putBoolean(ActivationStateMachine.PersistKeys.PUSH_CUSTOM_REGISTRAR, useCustomRegistrar).apply();
@@ -60,7 +60,7 @@ public class ActivationStateMachine {
     }
 
     public static class GotPushDeviceDetails extends ActivationStateMachine.Event {
-        private static final String NAME = "GotPushDeviceDetails";
+        public static final String NAME = "GotPushDeviceDetails";
 
         @Override
         public String getName() {
@@ -102,7 +102,7 @@ public class ActivationStateMachine {
     }
 
     public static class RegistrationSynced extends ActivationStateMachine.Event {
-        private static final String NAME = "RegistrationSynced";
+        public static final String NAME = "RegistrationSynced";
 
         @Override
         public String getName() {
@@ -122,7 +122,7 @@ public class ActivationStateMachine {
     }
 
     public static class Deregistered extends ActivationStateMachine.Event {
-        private static final String NAME = "Deregistered";
+        public static final String NAME = "Deregistered";
 
         @Override
         public String getName() {
@@ -148,19 +148,19 @@ public class ActivationStateMachine {
             ActivationStateMachine.Event event;
 
             switch (className) {
-                case "CalledActivate":
+                case CalledActivate.NAME:
                     event = new CalledActivate();
                     break;
-                case "CalledDeactivate":
+                case CalledDeactivate.NAME:
                     event = new CalledDeactivate();
                     break;
-                case "GotPushDeviceDetails":
+                case GotPushDeviceDetails.NAME:
                     event = new GotPushDeviceDetails();
                     break;
-                case "RegistrationSynced":
+                case RegistrationSynced.NAME:
                     event = new RegistrationSynced();
                     break;
-                case "Deregistered":
+                case Deregistered.NAME:
                     event = new Deregistered();
                     break;
 

--- a/android/src/main/java/io/ably/lib/push/ActivationStateMachine.java
+++ b/android/src/main/java/io/ably/lib/push/ActivationStateMachine.java
@@ -29,47 +29,118 @@ import java.util.ArrayDeque;
 
 public class ActivationStateMachine {
     public static class CalledActivate extends ActivationStateMachine.Event {
+        private static final String NAME = "CalledActivate";
+
         public static ActivationStateMachine.CalledActivate useCustomRegistrar(boolean useCustomRegistrar, SharedPreferences prefs) {
             prefs.edit().putBoolean(ActivationStateMachine.PersistKeys.PUSH_CUSTOM_REGISTRAR, useCustomRegistrar).apply();
             return new ActivationStateMachine.CalledActivate();
         }
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
     }
 
     public static class CalledDeactivate extends ActivationStateMachine.Event {
+        private static final String NAME = "CalledDeactivate";
+
         static ActivationStateMachine.CalledDeactivate useCustomRegistrar(boolean useCustomRegistrar, SharedPreferences prefs) {
             prefs.edit().putBoolean(ActivationStateMachine.PersistKeys.PUSH_CUSTOM_REGISTRAR, useCustomRegistrar).apply();
             return new ActivationStateMachine.CalledDeactivate();
         }
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
     }
 
-    public static class GotPushDeviceDetails extends ActivationStateMachine.Event {}
+    public static class GotPushDeviceDetails extends ActivationStateMachine.Event {
+        private static final String NAME = "GotPushDeviceDetails";
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
+    }
 
     public static class GotDeviceRegistration extends ActivationStateMachine.Event {
+        private static final String NAME = "GotDeviceRegistration";
         final String deviceIdentityToken;
-        GotDeviceRegistration(String token) { this.deviceIdentityToken = token; }
+        public GotDeviceRegistration(String token) { this.deviceIdentityToken = token; }
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
     }
 
     public static class GettingDeviceRegistrationFailed extends ActivationStateMachine.ErrorEvent {
-        GettingDeviceRegistrationFailed(ErrorInfo reason) { super(reason); }
+        private static final String NAME = "GettingDeviceRegistrationFailed";
+
+        public GettingDeviceRegistrationFailed(ErrorInfo reason) { super(reason); }
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
     }
 
     public static class GettingPushDeviceDetailsFailed extends ActivationStateMachine.ErrorEvent {
-        GettingPushDeviceDetailsFailed(ErrorInfo reason) { super(reason); }
+        private static final String NAME = "GettingPushDeviceDetailsFailed";
+
+        public GettingPushDeviceDetailsFailed(ErrorInfo reason) { super(reason); }
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
     }
 
-    public static class RegistrationSynced extends ActivationStateMachine.Event {}
+    public static class RegistrationSynced extends ActivationStateMachine.Event {
+        private static final String NAME = "RegistrationSynced";
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
+    }
 
     public static class SyncRegistrationFailed extends ActivationStateMachine.ErrorEvent {
+        private static final String NAME = "SyncRegistrationFailed";
+
         public SyncRegistrationFailed(ErrorInfo reason) { super(reason); }
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
     }
 
-    public static class Deregistered extends ActivationStateMachine.Event {}
+    public static class Deregistered extends ActivationStateMachine.Event {
+        private static final String NAME = "Deregistered";
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
+    }
 
     public static class DeregistrationFailed extends ActivationStateMachine.ErrorEvent {
+        private static final String NAME = "DeregistrationFailed";
+
         public DeregistrationFailed(ErrorInfo reason) { super(reason); }
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
     }
 
     public abstract static class Event {
+        public abstract String getName();
+
         public static Event constructEventByName(String className) throws ClassNotFoundException, InstantiationException {
             ActivationStateMachine.Event event;
 
@@ -684,7 +755,7 @@ public class ActivationStateMachine {
         for (ActivationStateMachine.Event e : pendingEvents) {
             editor.putString(
                     String.format("%s[%d]", ActivationStateMachine.PersistKeys.PENDING_EVENTS_PREFIX, i),
-                    e.getClass().getName()
+                    e.getName()
             );
 
             i++;
@@ -722,6 +793,7 @@ public class ActivationStateMachine {
             } catch (ClassNotFoundException e) {
                 Log.e(TAG, e.getLocalizedMessage());
             } catch (InstantiationException e) {
+                Log.e(TAG, e.getLocalizedMessage());
                 continue;
             }
         }

--- a/android/src/main/java/io/ably/lib/push/ActivationStateMachine.java
+++ b/android/src/main/java/io/ably/lib/push/ActivationStateMachine.java
@@ -42,6 +42,11 @@ public class ActivationStateMachine {
         public String getPersistedName() {
             return NAME;
         }
+
+        @Override
+        public String toString() {
+            return NAME;
+        }
     }
 
     public static class CalledDeactivate extends ActivationStateMachine.Event {
@@ -56,6 +61,11 @@ public class ActivationStateMachine {
         public String getPersistedName() {
             return NAME;
         }
+
+        @Override
+        public String toString() {
+            return NAME;
+        }
     }
 
     public static class GotPushDeviceDetails extends ActivationStateMachine.Event {
@@ -65,19 +75,41 @@ public class ActivationStateMachine {
         public String getPersistedName() {
             return NAME;
         }
+
+        @Override
+        public String toString() {
+            return NAME;
+        }
     }
 
     public static class GotDeviceRegistration extends ActivationStateMachine.Event {
         final String deviceIdentityToken;
         public GotDeviceRegistration(String token) { this.deviceIdentityToken = token; }
+
+        @Override
+        public String toString() {
+            return "GotDeviceRegistration{" +
+                "deviceIdentityToken='" + deviceIdentityToken + '\'' +
+                '}';
+        }
     }
 
     public static class GettingDeviceRegistrationFailed extends ActivationStateMachine.ErrorEvent {
         public GettingDeviceRegistrationFailed(ErrorInfo reason) { super(reason); }
+
+        @Override
+        public String toString() {
+            return "GettingDeviceRegistrationFailed: " + super.toString();
+        }
     }
 
     public static class GettingPushDeviceDetailsFailed extends ActivationStateMachine.ErrorEvent {
         public GettingPushDeviceDetailsFailed(ErrorInfo reason) { super(reason); }
+
+        @Override
+        public String toString() {
+            return "GettingPushDeviceDetailsFailed: " + super.toString();
+        }
     }
 
     public static class RegistrationSynced extends ActivationStateMachine.Event {
@@ -87,10 +119,20 @@ public class ActivationStateMachine {
         public String getPersistedName() {
             return NAME;
         }
+
+        @Override
+        public String toString() {
+            return NAME;
+        }
     }
 
     public static class SyncRegistrationFailed extends ActivationStateMachine.ErrorEvent {
         public SyncRegistrationFailed(ErrorInfo reason) { super(reason); }
+
+        @Override
+        public String toString() {
+            return "SyncRegistrationFailed: " + super.toString();
+        }
     }
 
     public static class Deregistered extends ActivationStateMachine.Event {
@@ -100,10 +142,20 @@ public class ActivationStateMachine {
         public String getPersistedName() {
             return NAME;
         }
+
+        @Override
+        public String toString() {
+            return NAME;
+        }
     }
 
     public static class DeregistrationFailed extends ActivationStateMachine.ErrorEvent {
         public DeregistrationFailed(ErrorInfo reason) { super(reason); }
+
+        @Override
+        public String toString() {
+            return "DeregistrationFailed: " + super.toString();
+        }
     }
 
     public abstract static class Event {
@@ -144,6 +196,13 @@ public class ActivationStateMachine {
     public abstract static class ErrorEvent extends ActivationStateMachine.Event {
         public final ErrorInfo reason;
         ErrorEvent(ErrorInfo reason) { this.reason = reason; }
+
+        @Override
+        public String toString() {
+            return "ErrorEvent{" +
+                "reason=" + reason +
+                '}';
+        }
     }
 
     public static class NotActivated extends ActivationStateMachine.PersistentState {
@@ -153,6 +212,11 @@ public class ActivationStateMachine {
 
         @Override
         String getPersistedName() {
+            return NAME;
+        }
+
+        @Override
+        public String toString() {
             return NAME;
         }
 
@@ -193,6 +257,11 @@ public class ActivationStateMachine {
 
         @Override
         String getPersistedName() {
+            return NAME;
+        }
+
+        @Override
+        public String toString() {
             return NAME;
         }
 
@@ -266,6 +335,12 @@ public class ActivationStateMachine {
 
     public static class WaitingForDeviceRegistration extends ActivationStateMachine.State {
         public WaitingForDeviceRegistration(ActivationStateMachine machine) { super(machine); }
+
+        @Override
+        public String toString() {
+            return "WaitingForDeviceRegistration";
+        }
+
         public ActivationStateMachine.State transition(ActivationStateMachine.Event event) {
             if (event instanceof ActivationStateMachine.CalledActivate) {
                 return this;
@@ -292,6 +367,11 @@ public class ActivationStateMachine {
             return NAME;
         }
 
+        @Override
+        public String toString() {
+            return "WaitingForNewPushDeviceDetails";
+        }
+
         public ActivationStateMachine.State transition(ActivationStateMachine.Event event) {
             if (event instanceof ActivationStateMachine.CalledActivate) {
                 machine.callActivatedCallback(null);
@@ -316,6 +396,13 @@ public class ActivationStateMachine {
         public WaitingForRegistrationSync(ActivationStateMachine machine, Event fromEvent) {
             super(machine);
             this.fromEvent = fromEvent;
+        }
+
+        @Override
+        public String toString() {
+            return "WaitingForRegistrationSync{" +
+                "fromEvent=" + fromEvent +
+                '}';
         }
 
         public ActivationStateMachine.State transition(ActivationStateMachine.Event event) {
@@ -357,6 +444,11 @@ public class ActivationStateMachine {
             return NAME;
         }
 
+        @Override
+        public String toString() {
+            return NAME;
+        }
+
         public ActivationStateMachine.State transition(ActivationStateMachine.Event event) {
             if (event instanceof ActivationStateMachine.CalledActivate || event instanceof ActivationStateMachine.GotPushDeviceDetails) {
                 machine.validateRegistration();
@@ -375,6 +467,13 @@ public class ActivationStateMachine {
         public WaitingForDeregistration(ActivationStateMachine machine, ActivationStateMachine.State previousState) {
             super(machine);
             this.previousState = previousState;
+        }
+
+        @Override
+        public String toString() {
+            return "WaitingForDeregistration{" +
+                "previousState=" + previousState +
+                '}';
         }
 
         public ActivationStateMachine.State transition(ActivationStateMachine.Event event) {
@@ -678,7 +777,7 @@ public class ActivationStateMachine {
     }
 
     private void enqueueEvent(ActivationStateMachine.Event event) {
-        Log.d(TAG, "enqueuing event: " + event.getClass().getSimpleName());
+        Log.d(TAG, "enqueuing event: " + event);
         pendingEvents.add(event);
     }
 
@@ -696,7 +795,7 @@ public class ActivationStateMachine {
 
         handlingEvent = true;
         try {
-            Log.d(TAG, String.format("handling event %s from %s", event.getClass().getSimpleName(), current.getClass().getSimpleName()));
+            Log.d(TAG, "handling event " + event + " from state " + current);
 
             ActivationStateMachine.State maybeNext = current.transition(event);
             if (maybeNext == null) {
@@ -704,7 +803,7 @@ public class ActivationStateMachine {
                 return persist();
             }
 
-            Log.d(TAG, String.format("transition: %s -(%s)-> %s", current.getClass().getSimpleName(), event.getClass().getSimpleName(), maybeNext.getClass().getSimpleName()));
+            Log.d(TAG, "transition: " + current + " -(" + event + ")-> " + maybeNext + ".");
             current = maybeNext;
 
             while (true) {
@@ -713,7 +812,7 @@ public class ActivationStateMachine {
                     break;
                 }
 
-                Log.d(TAG, "attempting to consume pending event: " + pending.getClass().getSimpleName());
+                Log.d(TAG, "attempting to consume pending event: " + pending);
 
                 maybeNext = current.transition(pending);
                 if (maybeNext == null) {
@@ -721,7 +820,7 @@ public class ActivationStateMachine {
                 }
                 pendingEvents.poll();
 
-                Log.d(TAG, String.format("transition: %s -(%s)-> %s", current.getClass().getSimpleName(), pending.getClass().getSimpleName(), maybeNext.getClass().getSimpleName()));
+                Log.d(TAG, "transition: " + current + " -(" + pending + ")-> " + maybeNext + ".");
                 current = maybeNext;
             }
 


### PR DESCRIPTION
- fixes [686](https://github.com/ably/ably-java/issues/686) and [685](https://github.com/ably/ably-java/issues/685)
- Removed use of `forName` method in push activation state machine implementation and replaced by switch constructing Event object based on name