### PR TITLE
Throws exception when AuthOptions are initialized with an empty string

### DIFF
--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -130,6 +130,9 @@ public class Auth {
             if (key == null) {
                 throw AblyException.fromErrorInfo(new ErrorInfo("key string cannot be null", 40000, 400));
             }
+            if (key.isEmpty()) {
+                throw new IllegalArgumentException("Key string cannot be empty");
+            }
             if(key.indexOf(':') > -1)
                 this.key = key;
             else

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
@@ -25,6 +25,16 @@ public class RealtimeAuthTest extends ParameterizedTest {
     public Timeout testTimeout = Timeout.seconds(30);
 
     /**
+     * Verifies an Exception is thrown, when client is initialized with an empty key
+     *
+     * @throws IllegalArgumentException
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void auth_client_cannot_be_initialized_with_empty_key() throws AblyException {
+        new AblyRealtime("");
+    }
+
+    /**
      * RSA12a: The clientId attribute of a TokenRequest or TokenDetails
      * used for authentication is null, or ConnectionDetails#clientId is null
      * following a connection to Ably. In this case, the null value indicates


### PR DESCRIPTION
- fixes [382](https://github.com/ably/ably-java/issues/382)
- AuthOptions cannot be initialised with an empty string. When empty string is provided `IllegalArgumentException` is thrown. 