### PR TITLE
Increase minimum SDK version to Android 4.1 (Jelly Bean, API Level 16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ We only support installation via Maven / Gradle from the Maven Central repositor
 For Java, JRE 7 or later is required. Note that the [Java Unlimited JCE extensions](http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html)
 must be installed in the Java runtime environment.
 
-For Android, 4.0 (API level 14) or later is required.
+For Android, 4.1 (API level 16) or later is required.
 
 ## Feature support
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ android {
     defaultConfig {
         buildConfigField 'String', 'LIBRARY_NAME', '"android"'
         buildConfigField 'String', 'VERSION', "\"$version\""
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 24
         versionCode 1
         versionName version


### PR DESCRIPTION
After recent upgrade in Firebase version the android build is failing because the `minSdkVersion` is too low. I updated it to the minimal required version `16` but in the future we could consider increasing it to some newer versions like `19`.
```
Manifest merger failed : uses-sdk:minSdkVersion 14 cannot be smaller than version 16 declared in library [com.google.firebase:firebase-messaging:22.0.0] /Users/runner/.gradle/caches/transforms-2/files-2.1/b39a806af3e38e8d80a3a7e52816e28b/AndroidManifest.xml as the library might be using APIs not available in 14
  	Suggestion: use a compatible library with a minSdk of at most 14,
  		or increase this project's minSdk version to at least 16,
  		or use tools:overrideLibrary="com.google.firebase.messaging" to force usage (may lead to runtime failures)
```