### PR TITLE
Suppressed warning in ProGuard

### DIFF
--- a/android/proguard.txt
+++ b/android/proguard.txt
@@ -4,3 +4,4 @@
 -keepclasseswithmembers class io.ably.lib.rest.Auth** {*;}
 -keep class com.google.gson.** {*;}
 -dontwarn org.msgpack.core.buffer.**
+-dontwarn org.slf4j.**


### PR DESCRIPTION
- fixes [#529 ](https://github.com/ably/ably-java/issues/529)
- Added ProGuard rule to suppress warnings 