### PR TITLE
Fix incorrect parsing of HTTP auth type for some locales

### DIFF
--- a/lib/src/main/java/io/ably/lib/http/HttpAuth.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpAuth.java
@@ -7,6 +7,7 @@ import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
@@ -20,7 +21,16 @@ public class HttpAuth {
     public enum Type {
         BASIC,
         DIGEST,
-        X_ABLY_TOKEN
+        X_ABLY_TOKEN;
+
+        static Type parse(final String value) {
+            final String conformedValue = value.toUpperCase(Locale.ROOT).replace('-', '_');
+            try {
+                return Type.valueOf(conformedValue);
+            } catch (final IllegalArgumentException e) {
+                throw new IllegalArgumentException("Failed to parse conformed form '" + conformedValue + "' of raw value '" + value + "'.", e);
+            }
+        }
     }
 
     HttpAuth(String username, String password, Type prefType) {
@@ -46,7 +56,7 @@ public class HttpAuth {
             if(delimiterIdx == -1) { throw AblyException.fromErrorInfo(new ErrorInfo("Invalid authenticate header (no delimiter)", 40000, 400)); }
             String authType = header.substring(0,  delimiterIdx).trim();
             String authDetails = header.substring(delimiterIdx + 1).trim();
-            sortedHeaders.put(Type.valueOf(authType.toUpperCase().replace('-', '_')), authDetails);
+            sortedHeaders.put(Type.parse(authType), authDetails);
         }
         return sortedHeaders;
     }

--- a/lib/src/test/java/io/ably/lib/http/HttpAuthTypeTest.java
+++ b/lib/src/test/java/io/ably/lib/http/HttpAuthTypeTest.java
@@ -25,4 +25,9 @@ public class HttpAuthTypeTest {
     public void parseFailure() {
         HttpAuth.Type.parse("Früli");
     }
+
+    @Test(expected = NullPointerException.class)
+    public void parseFailureNullValue() {
+        HttpAuth.Type.parse(null);
+    }
 }

--- a/lib/src/test/java/io/ably/lib/http/HttpAuthTypeTest.java
+++ b/lib/src/test/java/io/ably/lib/http/HttpAuthTypeTest.java
@@ -1,0 +1,23 @@
+package io.ably.lib.http;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class HttpAuthTypeTest {
+    @Test
+    public void parseSuccess() {
+        // The expected form in `www-authenticate` HTTP header in server response.
+        // See: https://github.com/ably/ably-java/issues/711
+        //
+        // The test for "basic" has been observed to fail under the following conditions:
+        //   1. Add `import java.util.Locale;` to this file.
+        //   2. Call `Locale.setDefault(new Locale("tr", "TR"));` as the first statement in this test method.
+        //   3. Use `toUpperCase()`, without `Locale.ROOT`, in the implementation of `HttpAuth.Type.parse(String)`.
+        // The observed failure is:
+        //   java.lang.IllegalArgumentException: Failed to parse conformed form 'BASİC' of raw value 'basic'.
+        assertEquals(HttpAuth.Type.BASIC, HttpAuth.Type.parse("basic"));
+        assertEquals(HttpAuth.Type.DIGEST, HttpAuth.Type.parse("digest"));
+        assertEquals(HttpAuth.Type.X_ABLY_TOKEN, HttpAuth.Type.parse("x-ably-token"));
+    }
+}

--- a/lib/src/test/java/io/ably/lib/http/HttpAuthTypeTest.java
+++ b/lib/src/test/java/io/ably/lib/http/HttpAuthTypeTest.java
@@ -20,4 +20,9 @@ public class HttpAuthTypeTest {
         assertEquals(HttpAuth.Type.DIGEST, HttpAuth.Type.parse("digest"));
         assertEquals(HttpAuth.Type.X_ABLY_TOKEN, HttpAuth.Type.parse("x-ably-token"));
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parseFailure() {
+        HttpAuth.Type.parse("Früli");
+    }
 }


### PR DESCRIPTION
Fixes #711.

The step-based commentary in https://github.com/ably/ably-java/commit/6948671b4353de74d1d8e2fc12b59d25ba049006 is a compromise I'm intentionally making for this pull request to keep the scope narrow.

I will create an issue for work on fixing implicit locale violations codebase-wide, under which we shall work on finding a mechanism for reliably running tests under multiple locales (perhaps just unit tests initially, if enough of the critical I/O parse/encode paths can obtain unit test coverage).