### PR TITLE
Added explicit locale for string manipulation methods

### DIFF
--- a/android/src/androidTest/java/io/ably/lib/test/android/AndroidSuite.java
+++ b/android/src/androidTest/java/io/ably/lib/test/android/AndroidSuite.java
@@ -64,7 +64,7 @@ public class AndroidSuite {
             Map<String, String> headers = server.getHeaders();
 
             assertNotNull("Verify ably server was reached", headers);
-            String header = headers.get(Defaults.ABLY_AGENT_HEADER.toLowerCase());
+            String header = headers.get(Defaults.ABLY_AGENT_HEADER.toLowerCase(Locale.ROOT));
             assertTrue("Verify correct library header was passed to the server", header != null && header.startsWith("android"));
         }
         catch (AblyException e) {

--- a/android/src/main/java/io/ably/lib/push/ActivationStateMachine.java
+++ b/android/src/main/java/io/ably/lib/push/ActivationStateMachine.java
@@ -27,6 +27,7 @@ import io.ably.lib.util.Serialisation;
 
 import java.lang.reflect.Field;
 import java.util.ArrayDeque;
+import java.util.Locale;
 
 public class ActivationStateMachine {
     public static class CalledActivate extends ActivationStateMachine.Event {
@@ -859,7 +860,7 @@ public class ActivationStateMachine {
             final String name = e.getPersistedName();
             if (name != null) {
                 editor.putString(
-                    String.format("%s[%d]", ActivationStateMachine.PersistKeys.PENDING_EVENTS_PREFIX, i),
+                    String.format(Locale.ROOT, "%s[%d]", ActivationStateMachine.PersistKeys.PENDING_EVENTS_PREFIX, i),
                     name
                 );
             }
@@ -883,7 +884,7 @@ public class ActivationStateMachine {
         int length = activationContext.getPreferences().getInt(ActivationStateMachine.PersistKeys.PENDING_EVENTS_LENGTH, 0);
         ArrayDeque<ActivationStateMachine.Event> deque = new ArrayDeque<>(length);
         for (int i = 0; i < length; i++) {
-            String className = activationContext.getPreferences().getString(String.format("%s[%d]", ActivationStateMachine.PersistKeys.PENDING_EVENTS_PREFIX, i), "");
+            String className = activationContext.getPreferences().getString(String.format(Locale.ROOT, "%s[%d]", ActivationStateMachine.PersistKeys.PENDING_EVENTS_PREFIX, i), "");
             ActivationStateMachine.Event event = Event.constructEventByName(className);
             if (event != null) {
                 deque.add(event);

--- a/android/src/main/java/io/ably/lib/types/RegistrationToken.java
+++ b/android/src/main/java/io/ably/lib/types/RegistrationToken.java
@@ -1,5 +1,7 @@
 package io.ably.lib.types;
 
+import java.util.Locale;
+
 public class RegistrationToken {
     public Type type;
     public String token;
@@ -23,14 +25,14 @@ public class RegistrationToken {
 
         public static Type fromName(String name) {
             try {
-                return Type.valueOf(name.toUpperCase());
+                return Type.valueOf(name.toUpperCase(Locale.ROOT));
             } catch(Throwable t) {
                 return null;
             }
         }
 
         public String toName() {
-            return name().toLowerCase();
+            return name().toLowerCase(Locale.ROOT);
         }
     }
 

--- a/lib/src/main/java/io/ably/lib/http/HttpCore.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpCore.java
@@ -11,6 +11,7 @@ import java.net.Proxy;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import com.google.gson.JsonParseException;
@@ -408,7 +409,7 @@ public class HttpCore {
 
         for (Map.Entry<String, List<String>> entry : caseSensitiveHeaders.entrySet()) {
             if (entry.getKey() != null) {
-                response.headers.put(entry.getKey().toLowerCase(), entry.getValue());
+                response.headers.put(entry.getKey().toLowerCase(Locale.ROOT), entry.getValue());
                 if (Log.level <= Log.VERBOSE)
                     for (String val : entry.getValue())
                         Log.v(TAG, entry.getKey() + ": " + val);
@@ -575,7 +576,7 @@ public class HttpCore {
                 return null;
             }
 
-            return headers.get(name.toLowerCase());
+            return headers.get(name.toLowerCase(Locale.ROOT));
         }
     }
 

--- a/lib/src/main/java/io/ably/lib/http/HttpScheduler.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpScheduler.java
@@ -2,6 +2,7 @@ package io.ably.lib.http;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -192,7 +193,7 @@ public class HttpScheduler<Executor extends java.util.concurrent.Executor> {
 
         private String extendMessage(String msg) {
             return Param.getFirst(params, "request_id") == null ?
-                msg : String.format("%s request_id=%s", msg, Param.getFirst(params, "request_id"));
+                msg : String.format(Locale.ROOT, "%s request_id=%s", msg, Param.getFirst(params, "request_id"));
         }
 
         @Override

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.Timer;
@@ -300,7 +301,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
         params = message.params;
         modes = ChannelMode.toSet(message.flags);
         if(state == ChannelState.attached) {
-            Log.v(TAG, String.format("Server initiated attach for channel %s", name));
+            Log.v(TAG, String.format(Locale.ROOT, "Server initiated attach for channel %s", name));
             /* emit UPDATE event according to RTL12 */
             emitUpdate(null, resumed);
         } else {
@@ -396,7 +397,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
                 new TimerTask() {
                     @Override
                     public void run() {
-                        String errorMessage = String.format("Attach timed out for channel %s", name);
+                        String errorMessage = String.format(Locale.ROOT, "Attach timed out for channel %s", name);
                         Log.v(TAG, errorMessage);
                         synchronized (ChannelBase.this) {
                             if(attachTimer != inProgressTimer) {
@@ -684,7 +685,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
 
         final DeltaExtras deltaExtras = (null == firstMessage.extras) ? null : firstMessage.extras.getDelta();
         if (null != deltaExtras && !deltaExtras.getFrom().equals(this.lastPayloadMessageId)) {
-            Log.e(TAG, String.format("Delta message decode failure - previous message not available. Message id = %s, channel = %s", firstMessage.id, name));
+            Log.e(TAG, String.format(Locale.ROOT, "Delta message decode failure - previous message not available. Message id = %s, channel = %s", firstMessage.id, name));
             startDecodeFailureRecovery();
             return;
         }
@@ -701,20 +702,20 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
                 msg.decode(options, decodingContext);
             } catch (MessageDecodeException e) {
                 if (e.errorInfo.code == 40018) {
-                    Log.e(TAG, String.format("Delta message decode failure - %s. Message id = %s, channel = %s", e.errorInfo.message, msg.id, name));
+                    Log.e(TAG, String.format(Locale.ROOT, "Delta message decode failure - %s. Message id = %s, channel = %s", e.errorInfo.message, msg.id, name));
                     startDecodeFailureRecovery();
 
                     // log messages skipped per RTL16
                     for (int j = i + 1; j < messages.length; j++) {
                         final String jId = messages[j].id; // might be null
                         final String jIdToLog = (null == jId) ? protocolMessage.id + ':' + j : jId;
-                        Log.v(TAG, String.format("Delta recovery in progress - message skipped. Message id = %s, channel = %s", jIdToLog, name));
+                        Log.v(TAG, String.format(Locale.ROOT, "Delta recovery in progress - message skipped. Message id = %s, channel = %s", jIdToLog, name));
                     }
 
                     return;
                 }
                 else {
-                    Log.e(TAG, String.format("Message decode failure - %s. Message id = %s, channel = %s", e.errorInfo.message, msg.id, name));
+                    Log.e(TAG, String.format(Locale.ROOT, "Message decode failure - %s. Message id = %s, channel = %s", e.errorInfo.message, msg.id, name));
                 }
             }
 
@@ -759,7 +760,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
             try {
                 msg.decode(options);
             } catch (MessageDecodeException e) {
-                Log.e(TAG, String.format("%s on channel %s", e.errorInfo.message, name));
+                Log.e(TAG, String.format(Locale.ROOT, "%s on channel %s", e.errorInfo.message, name));
             }
             /* populate fields derived from protocol message */
             if(msg.connectionId == null) msg.connectionId = message.connectionId;
@@ -1114,7 +1115,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
                 case attached:
                     /* Unexpected detach, reattach when possible */
                     setDetached((msg.error != null) ? msg.error : REASON_NOT_ATTACHED);
-                    Log.v(TAG, String.format("Server initiated detach for channel %s; attempting reattach", name));
+                    Log.v(TAG, String.format(Locale.ROOT, "Server initiated detach for channel %s; attempting reattach", name));
                     try {
                         attachWithTimeout(null);
                     } catch (AblyException e) {
@@ -1125,7 +1126,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
                     break;
                 case attaching:
                     /* RTL13b says we need to be suspended, but continue to retry */
-                    Log.v(TAG, String.format("Server initiated detach for channel %s whilst attaching; moving to suspended", name));
+                    Log.v(TAG, String.format(Locale.ROOT, "Server initiated detach for channel %s whilst attaching; moving to suspended", name));
                     setSuspended(msg.error, true);
                     reattachAfterTimeout();
                     break;

--- a/lib/src/main/java/io/ably/lib/realtime/Presence.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Presence.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -61,7 +62,7 @@ public class Presence {
             Collection<PresenceMessage> values = presence.get(params);
             return values.toArray(new PresenceMessage[values.size()]);
         } catch (InterruptedException e) {
-            Log.v(TAG, String.format("Channel %s: get() operation interrupted", channel.name));
+            Log.v(TAG, String.format(Locale.ROOT, "Channel %s: get() operation interrupted", channel.name));
             throw AblyException.fromThrowable(e);
         }
     }
@@ -214,7 +215,7 @@ public class Presence {
      */
     private void implicitAttachOnSubscribe(CompletionListener completionListener) throws AblyException {
         if (channel.state == ChannelState.failed) {
-            String errorString = String.format("Channel %s: subscribe in FAILED channel state", channel.name);
+            String errorString = String.format(Locale.ROOT, "Channel %s: subscribe in FAILED channel state", channel.name);
             Log.v(TAG, errorString);
             ErrorInfo errorInfo = new ErrorInfo(errorString, 90001);
             throw AblyException.fromErrorInfo(errorInfo);
@@ -270,14 +271,14 @@ public class Presence {
                                      * received from Ably (if applicable), the code received from Ably
                                      * (if applicable) and the explicit or implicit client_id of the PresenceMessage
                                      */
-                                String errorString = String.format("Cannot automatically re-enter %s on channel %s (%s)",
+                                String errorString = String.format(Locale.ROOT, "Cannot automatically re-enter %s on channel %s (%s)",
                                         clientId, channel.name, reason.message);
                                 Log.e(TAG, errorString);
                                 channel.emitUpdate(new ErrorInfo(errorString, 91004), true);
                             }
                         });
                     } catch(AblyException e) {
-                        String errorString = String.format("Cannot automatically re-enter %s on channel %s (%s)",
+                        String errorString = String.format(Locale.ROOT, "Cannot automatically re-enter %s on channel %s (%s)",
                                 clientId, channel.name, e.errorInfo.message);
                         Log.e(TAG, errorString);
                         channel.emitUpdate(new ErrorInfo(errorString, 91004), true);
@@ -480,7 +481,7 @@ public class Presence {
      */
     public void enterClient(String clientId, Object data, CompletionListener listener) throws AblyException {
         if(clientId == null) {
-            String errorMessage = String.format("Channel %s: unable to enter presence channel (null clientId specified)", channel.name);
+            String errorMessage = String.format(Locale.ROOT, "Channel %s: unable to enter presence channel (null clientId specified)", channel.name);
             Log.v(TAG, errorMessage);
             if(listener != null) {
                 listener.onError(new ErrorInfo(errorMessage, 40000));
@@ -531,7 +532,7 @@ public class Presence {
      */
     public void updateClient(String clientId, Object data, CompletionListener listener) throws AblyException {
         if(clientId == null) {
-            String errorMessage = String.format("Channel %s: unable to update presence channel (null clientId specified)", channel.name);
+            String errorMessage = String.format(Locale.ROOT, "Channel %s: unable to update presence channel (null clientId specified)", channel.name);
             Log.v(TAG, errorMessage);
             if(listener != null) {
                 listener.onError(new ErrorInfo(errorMessage, 40000));
@@ -574,7 +575,7 @@ public class Presence {
      */
     public void leaveClient(String clientId, Object data, CompletionListener listener) throws AblyException {
         if(clientId == null) {
-            String errorMessage = String.format("Channel %s: unable to leave presence channel (null clientId specified)", channel.name);
+            String errorMessage = String.format(Locale.ROOT, "Channel %s: unable to leave presence channel (null clientId specified)", channel.name);
             Log.v(TAG, errorMessage);
             if(listener != null) {
                 listener.onError(new ErrorInfo(errorMessage, 40000));
@@ -814,12 +815,12 @@ public class Presence {
                  * or if waitForSync is set to true, result in an error with code 91005 and a message stating
                  * that the presence state is out of sync due to the channel being in a SUSPENDED state */
                 errorCode = 91005;
-                errorMessage = String.format("Channel %s: presence state is out of sync due to the channel being in a SUSPENDED state", channel.name);
+                errorMessage = String.format(Locale.ROOT, "Channel %s: presence state is out of sync due to the channel being in a SUSPENDED state", channel.name);
             } else if(syncIsComplete) {
                 return;
             } else {
                 errorCode = 90001;
-                errorMessage = String.format("Channel %s: cannot get presence state because channel is in invalid state", channel.name);
+                errorMessage = String.format(Locale.ROOT, "Channel %s: cannot get presence state because channel is in invalid state", channel.name);
             }
             Log.v(TAG, errorMessage);
             throw AblyException.fromErrorInfo(new ErrorInfo(errorMessage, errorCode));

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -4,6 +4,7 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.security.GeneralSecurityException;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import javax.crypto.Mac;
@@ -993,7 +994,7 @@ public class Auth {
         return authHeader;
     }
 
-    private static String random() { return String.format("%016d", (long)(Math.random() * 1E16)); }
+    private static String random() { return String.format(Locale.ROOT, "%016d", (long)(Math.random() * 1E16)); }
 
     private static boolean equalNullableStrings(String one, String two) {
         return (one == null) ? (two == null) : one.equals(two);

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class ConnectionManager implements ConnectListener {
@@ -980,7 +981,7 @@ public class ConnectionManager implements ConnectListener {
      * @param errorInfo Error associated with unsuccessful authentication
      */
     public void onAuthError(ErrorInfo errorInfo) {
-        Log.i(TAG, String.format("onAuthError: (%d) %s", errorInfo.code, errorInfo.message));
+        Log.i(TAG, String.format(Locale.ROOT, "onAuthError: (%d) %s", errorInfo.code, errorInfo.message));
 
         if(errorInfo.statusCode == 403) {
             ConnectionStateChange failedStateChange =

--- a/lib/src/main/java/io/ably/lib/util/Crypto.java
+++ b/lib/src/main/java/io/ably/lib/util/Crypto.java
@@ -4,6 +4,7 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.Locale;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
@@ -60,7 +61,7 @@ public class Crypto {
         CipherParams(String algorithm, byte[] key, byte[] iv) throws NoSuchAlgorithmException {
             this.algorithm = (null == algorithm) ? DEFAULT_ALGORITHM : algorithm;
             keyLength = key.length * 8;
-            keySpec = new SecretKeySpec(key, this.algorithm.toUpperCase());
+            keySpec = new SecretKeySpec(key, this.algorithm.toUpperCase(Locale.ROOT));
             ivSpec = new IvParameterSpec(iv);
         }
 
@@ -139,7 +140,7 @@ public class Crypto {
     public static CipherParams getParams(String algorithm, int keyLength) {
         if(algorithm == null) algorithm = DEFAULT_ALGORITHM;
         try {
-            KeyGenerator keygen = KeyGenerator.getInstance(algorithm.toUpperCase());
+            KeyGenerator keygen = KeyGenerator.getInstance(algorithm.toUpperCase(Locale.ROOT));
             keygen.init(keyLength);
             byte[] key = keygen.generateKey().getEncoded();
             return getParams(algorithm, key);
@@ -215,7 +216,7 @@ public class Crypto {
 
         private CBCCipher(CipherParams params) throws AblyException {
             final String cipherAlgorithm = params.getAlgorithm();
-            String transformation = cipherAlgorithm.toUpperCase() + "/CBC/PKCS5Padding";
+            String transformation = cipherAlgorithm.toUpperCase(Locale.ROOT) + "/CBC/PKCS5Padding";
             try {
                 algorithm = cipherAlgorithm + '-' + params.getKeyLength() + "-cbc";
                 keySpec = params.keySpec;

--- a/lib/src/test/java/io/ably/lib/test/common/Helpers.java
+++ b/lib/src/test/java/io/ably/lib/test/common/Helpers.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
@@ -78,8 +79,8 @@ public class Helpers {
             return result;
         } catch (AblyException e) {
             try {
-                assertNotNull(String.format("got error \"%s\", none expected", e.errorInfo.message), expectedError);
-                assertEquals(String.format("expected to match \"%s\", got \"%s\"", expectedError, e.errorInfo.message), true, Pattern.compile(expectedError).matcher(e.errorInfo.message).find());
+                assertNotNull(String.format(Locale.ROOT, "got error \"%s\", none expected", e.errorInfo.message), expectedError);
+                assertEquals(String.format(Locale.ROOT, "expected to match \"%s\", got \"%s\"", expectedError, e.errorInfo.message), true, Pattern.compile(expectedError).matcher(e.errorInfo.message).find());
                 if (expectedCode > 0) {
                     assertEquals(expectedCode, e.errorInfo.code);
                 }
@@ -95,17 +96,17 @@ public class Helpers {
     }
 
     public static void assertInstanceOf(Class<?> c, Object o) {
-        assertTrue(String.format("expected object of class %s to be instance of %s", o.getClass().getName(), c.getName()), c.isInstance(o));
+        assertTrue(String.format(Locale.ROOT, "expected object of class %s to be instance of %s", o.getClass().getName(), c.getName()), c.isInstance(o));
     }
 
     public static void assertSize(int expected, Collection<?> c) {
         int size = c.size();
-        assertEquals(String.format("expected collection to have size %d, got %d: %s", expected, size, c), expected, size);
+        assertEquals(String.format(Locale.ROOT, "expected collection to have size %d, got %d: %s", expected, size, c), expected, size);
     }
 
     public static <T> void assertSize(int expected, T[] c) {
         int size = c.length;
-        assertEquals(String.format("expected array to have size %d, got %d: %s", expected, size, c), expected, size);
+        assertEquals(String.format(Locale.ROOT, "expected array to have size %d, got %d: %s", expected, size, c), expected, size);
     }
 
     public static HttpCore.Response httpResponseFromErrorInfo(final ErrorInfo errorInfo) {
@@ -816,7 +817,7 @@ public class Helpers {
             if(requestHeaders != null) {
                 normalisedHeaders.putAll(requestHeaders);
                 for(String header : requestHeaders.keySet()) {
-                    normalisedHeaders.put(header.toLowerCase(), requestHeaders.get(header));
+                    normalisedHeaders.put(header.toLowerCase(Locale.ROOT), requestHeaders.get(header));
                 }
             }
             RawHttpRequest req = new RawHttpRequest();
@@ -863,7 +864,7 @@ public class Helpers {
             if(headers != null) {
                 normalisedHeaders.putAll(headers);
                 for(String header : headers.keySet()) {
-                    normalisedHeaders.put(header.toLowerCase(), headers.get(header));
+                    normalisedHeaders.put(header.toLowerCase(Locale.ROOT), headers.get(header));
                 }
                 response.headers = normalisedHeaders;
             }
@@ -908,7 +909,7 @@ public class Helpers {
             List<String> result = null;
             RawHttpRequest req = get(id);
             if(req != null) {
-                header = header.toLowerCase();
+                header = header.toLowerCase(Locale.ROOT);
                 if(header.equalsIgnoreCase("authorization")) {
                     result = Collections.singletonList(req.authHeader);
                 } else {
@@ -922,7 +923,7 @@ public class Helpers {
             List<String> result = null;
             RawHttpRequest req = get(id);
             if(req != null) {
-                header = header.toLowerCase();
+                header = header.toLowerCase(Locale.ROOT);
                 List<String>headers = req.response.headers.get(header);
                 if(headers != null && headers.size() > 0) {
                     result = headers;

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
@@ -518,7 +518,7 @@ public class RealtimeConnectFailTest extends ParameterizedTest {
             ablyRealtime.connection.on(new ConnectionStateListener() {
                 @Override
                 public void onConnectionStateChanged(ConnectionStateChange state) {
-                    System.out.println(String.format("New state: %s", state.current));
+                    System.out.printf("New state: %s%n", state.current);
                     synchronized (reachedFinalState) {
                         reachedFinalState[0] = state.current == ConnectionState.closed ||
                                 state.current == ConnectionState.suspended ||

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
@@ -769,7 +769,7 @@ public class RealtimeMessageTest extends ParameterizedTest {
             String receivedDataHex = sb.toString();
             assertEquals("Verify decoded message data", fixtureMessage.expectedHexValue, receivedDataHex);
         } else {
-            throw new RuntimeException(String.format("unhandled: %s", fixtureMessage.expectedType));
+            throw new RuntimeException(String.format(Locale.ROOT, "unhandled: %s", fixtureMessage.expectedType));
         }
     }
 

--- a/lib/src/test/java/io/ably/lib/test/rest/RestChannelPublishTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestChannelPublishTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -305,7 +306,7 @@ public class RestChannelPublishTest extends ParameterizedTest {
             opts.useBinaryProtocol = true;
             opts.httpListener = requestListener;
             /* generate a fallback which resolves to the same address, which the library will treat as a different host */
-            opts.fallbackHosts = new String[]{ablyForToken.httpCore.getPrimaryHost().toUpperCase()};
+            opts.fallbackHosts = new String[]{ablyForToken.httpCore.getPrimaryHost().toUpperCase(Locale.ROOT)};
             AblyRest ably = new AblyRest(opts);
 
             /* publish message */
@@ -414,7 +415,7 @@ public class RestChannelPublishTest extends ParameterizedTest {
             opts.useBinaryProtocol = true;
             opts.httpListener = requestListener;
             /* generate a fallback which resolves to the same address, which the library will treat as a different host */
-            opts.fallbackHosts = new String[]{ablyForToken.httpCore.getPrimaryHost().toUpperCase()};
+            opts.fallbackHosts = new String[]{ablyForToken.httpCore.getPrimaryHost().toUpperCase(Locale.ROOT)};
             AblyRest ably = new AblyRest(opts);
 
             /* publish message */

--- a/lib/src/test/java/io/ably/lib/test/rest/RestInitTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestInitTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.Locale;
 
 import io.ably.lib.rest.AblyRest;
 import io.ably.lib.test.common.Setup;
@@ -299,7 +300,7 @@ public class RestInitTest {
             ClientOptions opts = new ClientOptions(testVars.keys[0].keyStr);
             opts.environment = givenEnvironment;
             AblyRest ably = new AblyRest(opts);
-            assertEquals("Unexpected host mismatch", String.format("%s-%s", givenEnvironment, Defaults.HOST_REST), ably.httpCore.getPrimaryHost());
+            assertEquals("Unexpected host mismatch", String.format(Locale.ROOT, "%s-%s", givenEnvironment, Defaults.HOST_REST), ably.httpCore.getPrimaryHost());
         } catch (AblyException e) {
             e.printStackTrace();
             fail("init4: Unexpected exception instantiating library");

--- a/lib/src/test/java/io/ably/lib/test/rest/RestPushTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestPushTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
@@ -241,7 +242,7 @@ public class RestPushTest extends ParameterizedTest {
                         new Param("transportType", "ablyChannel"),
                         new Param("channel", "pushenabled:push_admin_publish-ok"),
                         new Param("ablyKey", testVars.keys[0].keyStr),
-                        new Param("ablyUrl", String.format("%s%s:%d", rest.httpCore.scheme, rest.httpCore.getPrimaryHost(), rest.httpCore.port)),
+                        new Param("ablyUrl", String.format(Locale.ROOT, "%s%s:%d", rest.httpCore.scheme, rest.httpCore.getPrimaryHost(), rest.httpCore.port)),
                 },
                 testPayload,
                 null));


### PR DESCRIPTION
- fixes [#713](https://github.com/ably/ably-java/issues/713)
- to prevent unexpected results, methods which do string manipulation or parsing should have explicit localisation (`Locale.ROOT`)