### PR TITLE
Improve release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,9 +202,7 @@ This library uses [semantic versioning](http://semver.org/). For each release, t
 
 1. Create a branch for the release, named like `release/1.2.4` (where `1.2.4` is what you're releasing, being the new version)
 2. Replace all references of the current version number with the new version number (check the [README.md](./README.md) and [common.gradle](./common.gradle)) and commit the changes
-3. Run [`github_changelog_generator`](https://github.com/skywinder/Github-Changelog-Generator) to update the [CHANGELOG](./CHANGELOG.md):
-    * This might work: `github_changelog_generator -u ably -p ably-java --header-label="# Changelog" --release-branch=release/1.2.4 --future-release=v1.2.4`
-    * But your mileage may vary as it can error. Perhaps more reliable is something like: `github_changelog_generator -u ably -p ably-java --since-tag v1.2.3 --output delta.md` and then manually merge the delta contents in to the main change log (where `1.2.3` is the preceding release)
+3. Run the [GitHub Changelog Generator](https://github.com/github-changelog-generator/github-changelog-generator) to update the [CHANGELOG](./CHANGELOG.md): something like: `github_changelog_generator -u ably -p ably-java --since-tag v1.2.3 --output delta.md` and then manually merge the delta contents in to the main change log (where `1.2.3` is the preceding release)
 4. Commit [CHANGELOG](./CHANGELOG.md)
 5. Make a PR against `main`
 6. Once the PR is approved, merge it into `main`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,17 +206,18 @@ This library uses [semantic versioning](http://semver.org/). For each release, t
 4. Commit [CHANGELOG](./CHANGELOG.md)
 5. Make a PR against `main`
 6. Once the PR is approved, merge it into `main`
-7. Add a tag and push to origin - e.g.: `git tag v1.2.4 && git push origin v1.2.4`
-8. Create the release on Github including populating the release notes
-9. Assemble and Upload ([see below](#publishing-to-maven-central) for details) - but the overall order to follow is:
-    1. Comment out local `repository` lines in the two `maven.gradle` files temporarily (this is horrible but is [to be fixed soon](https://github.com/ably/ably-java/issues/566))
+7. From the updated `main` branch on your local workstation, assemble and upload:
+    1. Comment out local `repository` lines in the two `maven.gradle` files temporarily (this is horrible but is [in our backlog to be fixed](https://github.com/ably/ably-java/issues/566))
     2. Run `./gradlew java:assembleRelease` to build and upload `ably-java` to Nexus staging repository
     3. Run `./gradlew android:assembleRelease` build and upload `ably-android` to Nexus staging repository
     4. Find the new staging repository using the [Nexus Repository Manager](https://oss.sonatype.org/#stagingRepositories)
-    5. Check that it contains Android and Java releases
+    5. Check that it contains `ably-android` and `ably-java` releases
     6. "Close" it - this will take a few minutes during which time it will say (after a refresh of your browser) that "Activity: Operation in Progress"
     7. Once it has closed you will have "Release" available. You can allow it to "automatically drop" after successful release. A refresh or two later of the browser and the staging repository will have disappeared from the list (i.e. it's been dropped which implies it was released successfully)
     8. A [search for Ably packages](https://oss.sonatype.org/#nexus-search;quick~io.ably) should now list the new version for both `ably-android` and `ably-java`
+8. Add a tag and push to origin - e.g.: `git tag v1.2.4 && git push origin v1.2.4`
+9. Create the release on Github including populating the release notes
+10. Create the entry on the [Ably Changelog](https://changelog.ably.com/) (via [headwayapp](https://headwayapp.co/))
 
 ### Signing
 


### PR DESCRIPTION
After doing this morning's Java release I've finally taken a moment to refine the release process, as it never truly reflected what I was _actually_ doing for each release. That refinement is represented by this pull request.

In lieu of working on https://github.com/ably/ably-java/issues/659, this now much more closely reflects what has to be done.