### PR TITLE
Fix Maven Central metadata

### DIFF
--- a/android/maven.gradle
+++ b/android/maven.gradle
@@ -43,7 +43,7 @@ uploadArchives {
             }
             organization {
                 name 'Ably'
-                url 'http://ably.io'
+                url 'https://ably.com/'
             }
             issueManagement {
                 system 'Github'

--- a/android/maven.gradle
+++ b/android/maven.gradle
@@ -36,6 +36,16 @@ uploadArchives {
             packaging 'aar'
             inceptionYear '2015'
             url 'https://www.github.com/ably/ably-java'
+            developers {
+                developer {
+                    id 'ably' // our company org in GitHub: https://github.com/ably
+                    name 'Ably' // UK based company: Ably Real-time Ltd
+                    email 'support@ably.com'
+                    organization 'Ably' // UK based company: Ably Real-time Ltd
+                    organizationUrl 'https://ably.com/'
+                    url 'https://ably.com/'
+                }
+            }
             scm {
                 url 'scm:git:https://github.com/ably/ably-java'
                 connection 'scm:git:https://github.com/ably/ably-java'

--- a/android/maven.gradle
+++ b/android/maven.gradle
@@ -30,7 +30,6 @@ uploadArchives {
         pom.artifactId = ARTIFACT_ID
         pom.version = version
 
-        // Add other pom properties here if you want (developer details / licenses)
         pom.project {
             name 'Ably Android client library'
             description 'An Android Realtime and REST client library for [Ably.io](https://www.ably.io), the realtime messaging service.'

--- a/android/maven.gradle
+++ b/android/maven.gradle
@@ -37,14 +37,6 @@ uploadArchives {
             packaging 'aar'
             inceptionYear '2015'
             url 'https://www.github.com/ably/ably-java'
-            developers {
-                developer {
-                    name 'Paddy Byers'
-                    email 'paddy@ably.io'
-                    url 'https://github.com/paddybyers'
-                    id 'paddybyers'
-                }
-            }
             scm {
                 url 'scm:git:https://github.com/ably/ably-java'
                 connection 'scm:git:https://github.com/ably/ably-java'

--- a/android/maven.gradle
+++ b/android/maven.gradle
@@ -31,7 +31,7 @@ uploadArchives {
         pom.version = version
 
         pom.project {
-            name 'Ably Android client library'
+            name 'Ably Android client library SDK'
             description 'An Android Realtime and REST client library SDK for the Ably platform.'
             packaging 'aar'
             inceptionYear '2015'

--- a/android/maven.gradle
+++ b/android/maven.gradle
@@ -32,7 +32,7 @@ uploadArchives {
 
         pom.project {
             name 'Ably Android client library'
-            description 'An Android Realtime and REST client library for [Ably.io](https://www.ably.io), the realtime messaging service.'
+            description 'An Android Realtime and REST client library SDK for the Ably platform.'
             packaging 'aar'
             inceptionYear '2015'
             url 'https://www.github.com/ably/ably-java'

--- a/java/maven.gradle
+++ b/java/maven.gradle
@@ -32,7 +32,6 @@ uploadArchives {
         pom.artifactId = ARTIFACT_ID
         pom.version = version
 
-        // Add other pom properties here if you want (developer details / licenses)
         pom.project {
             name 'Ably java client library'
             description 'A Java Realtime and REST client library for [Ably.io](https://www.ably.io), the realtime messaging service.'

--- a/java/maven.gradle
+++ b/java/maven.gradle
@@ -38,6 +38,16 @@ uploadArchives {
             packaging 'jar'
             inceptionYear '2015'
             url 'https://www.github.com/ably/ably-java'
+            developers {
+                developer {
+                    id 'ably' // our company org in GitHub: https://github.com/ably
+                    name 'Ably' // UK based company: Ably Real-time Ltd
+                    email 'support@ably.com'
+                    organization 'Ably' // UK based company: Ably Real-time Ltd
+                    organizationUrl 'https://ably.com/'
+                    url 'https://ably.com/'
+                }
+            }
             scm {
                 url 'scm:git:https://github.com/ably/ably-java'
                 connection 'scm:git:https://github.com/ably/ably-java'

--- a/java/maven.gradle
+++ b/java/maven.gradle
@@ -39,14 +39,6 @@ uploadArchives {
             packaging 'jar'
             inceptionYear '2015'
             url 'https://www.github.com/ably/ably-java'
-            developers {
-                developer {
-                    name 'Paddy Byers'
-                    email 'paddy@ably.io'
-                    url 'https://github.com/paddybyers'
-                    id 'paddybyers'
-                }
-            }
             scm {
                 url 'scm:git:https://github.com/ably/ably-java'
                 connection 'scm:git:https://github.com/ably/ably-java'

--- a/java/maven.gradle
+++ b/java/maven.gradle
@@ -33,7 +33,7 @@ uploadArchives {
         pom.version = version
 
         pom.project {
-            name 'Ably java client library'
+            name 'Ably Java client library SDK'
             description 'A Java Realtime and REST client library SDK for the Ably platform.'
             packaging 'jar'
             inceptionYear '2015'

--- a/java/maven.gradle
+++ b/java/maven.gradle
@@ -45,7 +45,7 @@ uploadArchives {
             }
             organization {
                 name 'Ably'
-                url 'http://ably.io'
+                url 'https://ably.com/'
             }
             issueManagement {
                 system 'Github'

--- a/java/maven.gradle
+++ b/java/maven.gradle
@@ -34,7 +34,7 @@ uploadArchives {
 
         pom.project {
             name 'Ably java client library'
-            description 'A Java Realtime and REST client library for [Ably.io](https://www.ably.io), the realtime messaging service.'
+            description 'A Java Realtime and REST client library SDK for the Ably platform.'
             packaging 'jar'
             inceptionYear '2015'
             url 'https://www.github.com/ably/ably-java'


### PR DESCRIPTION
This PR was initially opened and left in a WIP/Draft state while @KacperKluka experimented with whether or not the `developers` node was really needed over in [AAT Android](https://github.com/ably/ably-asset-tracking-android).