### PR TITLE
Multicaster encapsulation

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -782,7 +782,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     private static class MessageMulticaster extends io.ably.lib.util.Multicaster<MessageListener> implements MessageListener {
         @Override
         public void onMessage(Message message) {
-            for(MessageListener member : members)
+            for (final MessageListener member : getMembers())
                 try {
                     member.onMessage(message);
                 } catch (Throwable t) {

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelStateListener.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelStateListener.java
@@ -56,7 +56,7 @@ public interface ChannelStateListener {
     class Multicaster extends io.ably.lib.util.Multicaster<ChannelStateListener> implements ChannelStateListener {
         @Override
         public void onChannelStateChanged(ChannelStateChange stateChange) {
-            for(ChannelStateListener member : members)
+            for (final ChannelStateListener member : getMembers())
                 try {
                     member.onChannelStateChanged(stateChange);
                 } catch(Throwable t) {}

--- a/lib/src/main/java/io/ably/lib/realtime/CompletionListener.java
+++ b/lib/src/main/java/io/ably/lib/realtime/CompletionListener.java
@@ -29,7 +29,7 @@ public interface CompletionListener {
 
         @Override
         public void onSuccess() {
-            for(CompletionListener member : members)
+            for (final CompletionListener member : getMembers())
                 try {
                     member.onSuccess();
                 } catch(Throwable t) {}
@@ -37,7 +37,7 @@ public interface CompletionListener {
 
         @Override
         public void onError(ErrorInfo reason) {
-            for(CompletionListener member : members)
+            for (final CompletionListener member : getMembers())
                 try {
                     member.onError(reason);
                 } catch(Throwable t) {}

--- a/lib/src/main/java/io/ably/lib/realtime/ConnectionStateListener.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ConnectionStateListener.java
@@ -38,7 +38,7 @@ public interface ConnectionStateListener {
     class Multicaster extends io.ably.lib.util.Multicaster<ConnectionStateListener> implements ConnectionStateListener {
         @Override
         public void onConnectionStateChanged(ConnectionStateChange state) {
-            for(ConnectionStateListener member : members)
+            for (final ConnectionStateListener member : getMembers())
                 try {
                     member.onConnectionStateChanged(state);
                 } catch(Throwable t) {}

--- a/lib/src/main/java/io/ably/lib/realtime/Presence.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Presence.java
@@ -357,7 +357,7 @@ public class Presence {
     private static class Multicaster extends io.ably.lib.util.Multicaster<PresenceListener> implements PresenceListener {
         @Override
         public void onPresenceMessage(PresenceMessage message) {
-            for(PresenceListener member : members)
+            for (final PresenceListener member : getMembers())
                 try {
                     member.onPresenceMessage(message);
                 } catch(Throwable t) {}

--- a/lib/src/main/java/io/ably/lib/util/Multicaster.java
+++ b/lib/src/main/java/io/ably/lib/util/Multicaster.java
@@ -3,15 +3,25 @@ package io.ably.lib.util;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Collection of members who are listeners, with methods that are safe to be called from any thread.
+ * @param <T> The type of elements being added to this multicaster - the listeners.
+ */
 public abstract class Multicaster<T> {
-
-    protected final List<T> members = new ArrayList<T>();
+    private final List<T> members = new ArrayList<>();
 
     public Multicaster(T... members) { for(T m : members) this.members.add(m); }
-    
-    public void add(T member) { members.add(member); }
-    public void remove(T member) { members.remove(member); }
-    public void clear() { members.clear(); }
-    public boolean isEmpty() { return members.isEmpty(); }
-    public int size() { return members.size(); }
+
+    public synchronized void add(T member) { members.add(member); }
+    public synchronized void remove(T member) { members.remove(member); }
+    public synchronized void clear() { members.clear(); }
+    public synchronized boolean isEmpty() { return members.isEmpty(); }
+    public synchronized int size() { return members.size(); }
+
+    /**
+     * Returns a snapshot of the members of this multicaster instance.
+     */
+    protected synchronized List<T> getMembers() {
+        return new ArrayList<>(members);
+    }
 }

--- a/lib/src/main/java/io/ably/lib/util/Multicaster.java
+++ b/lib/src/main/java/io/ably/lib/util/Multicaster.java
@@ -1,7 +1,6 @@
 package io.ably.lib.util;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 public abstract class Multicaster<T> {
@@ -15,5 +14,4 @@ public abstract class Multicaster<T> {
     public void clear() { members.clear(); }
     public boolean isEmpty() { return members.isEmpty(); }
     public int size() { return members.size(); }
-    public Iterator<T>  iterator() { return members.iterator(); }
 }


### PR DESCRIPTION
We've had a customer experiencing a `ConcurrentModificationException`, thrown by one of the `Multicaster` subclasses.

This isn't really that easy to test, without perhaps some sort of multi-threaded 'chaos' test... however, I think the problem was fairly obvious (as pointed out by @paddybyers in [this internal Slack message](https://ably-real-time.slack.com/archives/C8SPU4589/p1643285690094800?thread_ts=1643263851.076300&cid=C8SPU4589)), so the change presented in this pull request should make this base class robust to manipulation and query from multiple threads simultaneously.

I acknowledge that this does add a new shallow array copy operation each time an event requires member list iteration, but I've seen no evidence that this needed to be a high performance area of the codebase. We can further refactor in future if this is proven to be a performance hit.

Fixes #743.