### PR TITLE
Split ChannelCipher implementation into encrypt and decrypt specialisms

### DIFF
--- a/lib/src/main/java/io/ably/lib/types/BaseMessage.java
+++ b/lib/src/main/java/io/ably/lib/types/BaseMessage.java
@@ -8,7 +8,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import io.ably.lib.util.Base64Coder;
-import io.ably.lib.util.Crypto.ChannelCipher;
+import io.ably.lib.util.Crypto.EncryptingChannelCipher;
 import io.ably.lib.util.Log;
 import io.ably.lib.util.Serialisation;
 import org.msgpack.core.MessageFormat;
@@ -131,7 +131,7 @@ public class BaseMessage implements Cloneable {
                         case "cipher":
                             if(opts != null && opts.encrypted) {
                                 try {
-                                    data = opts.getCipher().decrypt((byte[]) data);
+                                    data = opts.getDecryptingCipher().decrypt((byte[]) data);
                                 } catch(AblyException e) {
                                     throw MessageDecodeException.fromDescription(e.errorInfo.message);
                                 }
@@ -179,7 +179,7 @@ public class BaseMessage implements Cloneable {
             }
         }
         if (opts != null && opts.encrypted) {
-            ChannelCipher cipher = opts.getCipher();
+            EncryptingChannelCipher cipher = opts.getEncryptingCipher();
             data = cipher.encrypt((byte[]) data);
             encoding = ((encoding == null) ? "" : encoding + "/") + "cipher+" + cipher.getAlgorithm();
         }

--- a/lib/src/main/java/io/ably/lib/types/BaseMessage.java
+++ b/lib/src/main/java/io/ably/lib/types/BaseMessage.java
@@ -131,7 +131,7 @@ public class BaseMessage implements Cloneable {
                         case "cipher":
                             if(opts != null && opts.encrypted) {
                                 try {
-                                    data = opts.getDecryptingCipher().decrypt((byte[]) data);
+                                    data = opts.getCipherSet().getDecipher().decrypt((byte[]) data);
                                 } catch(AblyException e) {
                                     throw MessageDecodeException.fromDescription(e.errorInfo.message);
                                 }
@@ -179,7 +179,7 @@ public class BaseMessage implements Cloneable {
             }
         }
         if (opts != null && opts.encrypted) {
-            EncryptingChannelCipher cipher = opts.getEncryptingCipher();
+            EncryptingChannelCipher cipher = opts.getCipherSet().getEncipher();
             data = cipher.encrypt((byte[]) data);
             encoding = ((encoding == null) ? "" : encoding + "/") + "cipher+" + cipher.getAlgorithm();
         }

--- a/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
@@ -42,7 +42,7 @@ public class ChannelOptions {
 
     /**
      * Returns a wrapper around the cipher set to be used for this channel. This wrapper is only available in this API
-     * to support customers who may have been using it in their applications against with version 1.2.10 or before.
+     * to support customers who may have been using it in their applications with version 1.2.10 or before.
      *
      * @deprecated Since version 1.2.11, this method (which was only ever intended for internal use within this library
      * has been replaced by {@link #getCipherSet()}. It will be removed in the future.

--- a/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
@@ -4,16 +4,14 @@ import java.util.Map;
 
 import io.ably.lib.util.Base64Coder;
 import io.ably.lib.util.Crypto;
-import io.ably.lib.util.Crypto.EncryptingChannelCipher;
-import io.ably.lib.util.Crypto.DecryptingChannelCipher;
+import io.ably.lib.util.Crypto.ChannelCipherSet;
 
 public class ChannelOptions {
     public Map<String, String> params;
 
     public ChannelMode[] modes;
 
-    private EncryptingChannelCipher encryptingCipher;
-    private DecryptingChannelCipher decryptingCipher;
+    private ChannelCipherSet cipherSet;
 
     /**
      * Parameters for the cipher.
@@ -42,41 +40,22 @@ public class ChannelOptions {
     }
 
     /**
-     * Returns the cipher to be used for encrypting data on a channel, given the current state of this instance.
-     * On the first call to this method a new cipher instance is created, with subsequent callers to this method being
-     * returned that same cipher instance. This method is safe to be called from any thread.
+     * Returns the cipher set to be used for encrypting and decrypting data on a channel, given the current state of
+     * this instance. On the first call to this method a new cipher set instance is created, with subsequent callers to
+     * this method being returned that same cipher set instance. This method is safe to be called from any thread.
      *
-     * @apiNote Once this method has been called then the cipher is fixed based on the value of the
-     * {@link #cipherParams} field at that time. If that field is then mutated, the cipher will not be updated.
+     * @apiNote Once this method has been called then the cipher set is fixed based on the value of the
+     * {@link #cipherParams} field at that time. If that field is then mutated, the cipher set will not be updated.
      * This is not great API design and we should fix this under https://github.com/ably/ably-java/issues/745
      */
-    public synchronized EncryptingChannelCipher getEncryptingCipher() throws AblyException {
+    public synchronized ChannelCipherSet getCipherSet() throws AblyException {
         if (!encrypted) {
             throw new IllegalStateException("ChannelOptions encrypted field value is false.");
         }
-        if (null == encryptingCipher) {
-            encryptingCipher = Crypto.getEncryptingCipher(cipherParams);
+        if (null == cipherSet) {
+            cipherSet = Crypto.createChannelCipherSet(cipherParams);
         }
-        return encryptingCipher;
-    }
-
-    /**
-     * Returns the cipher to be used for decrypting data on a channel, given the current state of this instance.
-     * On the first call to this method a new cipher instance is created, with subsequent callers to this method being
-     * returned that same cipher instance. This method is safe to be called from any thread.
-     *
-     * @apiNote Once this method has been called then the cipher is fixed based on the value of the
-     * {@link #cipherParams} field at that time. If that field is then mutated, the cipher will not be updated.
-     * This is not great API design and we should fix this under https://github.com/ably/ably-java/issues/745
-     */
-    public synchronized DecryptingChannelCipher getDecryptingCipher() throws AblyException {
-        if (!encrypted) {
-            throw new IllegalStateException("ChannelOptions encrypted field value is false.");
-        }
-        if (null == decryptingCipher) {
-            decryptingCipher = Crypto.getDecryptingCipher(cipherParams);
-        }
-        return decryptingCipher;
+        return cipherSet;
     }
 
     /**

--- a/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
@@ -52,7 +52,7 @@ public class ChannelOptions {
      */
     public synchronized EncryptingChannelCipher getEncryptingCipher() throws AblyException {
         if (null == encryptingCipher) {
-            encryptingCipher = Crypto.getEncryptingCipher(this);
+            encryptingCipher = Crypto.getEncryptingCipher(cipherParams);
         }
         return encryptingCipher;
     }
@@ -68,7 +68,7 @@ public class ChannelOptions {
      */
     public synchronized DecryptingChannelCipher getDecryptingCipher() throws AblyException {
         if (null == decryptingCipher) {
-            decryptingCipher = Crypto.getDecryptingCipher(this);
+            decryptingCipher = Crypto.getDecryptingCipher(cipherParams);
         }
         return decryptingCipher;
     }

--- a/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
@@ -51,6 +51,9 @@ public class ChannelOptions {
      * This is not great API design and we should fix this under https://github.com/ably/ably-java/issues/745
      */
     public synchronized EncryptingChannelCipher getEncryptingCipher() throws AblyException {
+        if (!encrypted) {
+            throw new IllegalStateException("ChannelOptions encrypted field value is false.");
+        }
         if (null == encryptingCipher) {
             encryptingCipher = Crypto.getEncryptingCipher(cipherParams);
         }
@@ -67,6 +70,9 @@ public class ChannelOptions {
      * This is not great API design and we should fix this under https://github.com/ably/ably-java/issues/745
      */
     public synchronized DecryptingChannelCipher getDecryptingCipher() throws AblyException {
+        if (!encrypted) {
+            throw new IllegalStateException("ChannelOptions encrypted field value is false.");
+        }
         if (null == decryptingCipher) {
             decryptingCipher = Crypto.getDecryptingCipher(cipherParams);
         }

--- a/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
@@ -42,7 +42,7 @@ public class ChannelOptions {
     }
 
     /**
-     * Returns the cipher to be used for encrypting data on this channel, given the current state of this instance.
+     * Returns the cipher to be used for encrypting data on a channel, given the current state of this instance.
      * On the first call to this method a new cipher instance is created, with subsequent callers to this method being
      * returned that same cipher instance. This method is safe to be called from any thread.
      *
@@ -58,7 +58,7 @@ public class ChannelOptions {
     }
 
     /**
-     * Returns the cipher to be used for decrypting data on this channel, given the current state of this instance.
+     * Returns the cipher to be used for decrypting data on a channel, given the current state of this instance.
      * On the first call to this method a new cipher instance is created, with subsequent callers to this method being
      * returned that same cipher instance. This method is safe to be called from any thread.
      *

--- a/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import io.ably.lib.util.Base64Coder;
 import io.ably.lib.util.Crypto;
+import io.ably.lib.util.Crypto.ChannelCipher;
 import io.ably.lib.util.Crypto.ChannelCipherSet;
 
 public class ChannelOptions {
@@ -40,6 +41,39 @@ public class ChannelOptions {
     }
 
     /**
+     * Returns a wrapper around the cipher set to be used for this channel. This wrapper is only available in this API
+     * to support customers who may have been using it in their applications against with version 1.2.10 or before.
+     *
+     * @deprecated Since version 1.2.11, this method (which was only ever intended for internal use within this library
+     * has been replaced by {@link #getCipherSet()}. It will be removed in the future.
+     */
+    @Deprecated
+    public ChannelCipher getCipher() throws AblyException {
+        return new ChannelCipher() {
+            @Override
+            public byte[] encrypt(byte[] plaintext) throws AblyException {
+                return getCipherSet().getEncipher().encrypt(plaintext);
+            }
+
+            @Override
+            public byte[] decrypt(byte[] ciphertext) throws AblyException {
+                return getCipherSet().getDecipher().decrypt(ciphertext);
+            }
+
+            @Override
+            public String getAlgorithm() {
+                try {
+                    return getCipherSet().getEncipher().getAlgorithm();
+                } catch (final AblyException e) {
+                    throw new IllegalStateException("Unexpected exception when using legacy crypto cipher interface.", e);
+                }
+            }
+        };
+    }
+
+    /**
+     * Internal; this method is not intended for use by application developers. It may be changed or removed in future.
+     *
      * Returns the cipher set to be used for encrypting and decrypting data on a channel, given the current state of
      * this instance. On the first call to this method a new cipher set instance is created, with subsequent callers to
      * this method being returned that same cipher set instance. This method is safe to be called from any thread.

--- a/lib/src/main/java/io/ably/lib/util/Crypto.java
+++ b/lib/src/main/java/io/ably/lib/util/Crypto.java
@@ -205,15 +205,6 @@ public class Crypto {
         byte[] decrypt(byte[] ciphertext) throws AblyException;
     }
 
-    private static CipherParams getParams(final Object cipherParams) throws AblyException {
-        if (null == cipherParams)
-            return Crypto.getDefaultParams();
-        else if (cipherParams instanceof CipherParams)
-            return (CipherParams)cipherParams;
-        else
-            throw AblyException.fromErrorInfo(new ErrorInfo("ChannelOptions not supported", 400, 40000));
-    }
-
     /**
      * A matching encipher and decipher pair, where both are guaranteed to have been configured with the same
      * {@link CipherParams} as each other.

--- a/lib/src/main/java/io/ably/lib/util/Crypto.java
+++ b/lib/src/main/java/io/ably/lib/util/Crypto.java
@@ -17,7 +17,6 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import io.ably.lib.types.AblyException;
-import io.ably.lib.types.ChannelOptions;
 import io.ably.lib.types.ErrorInfo;
 import io.ably.lib.types.Param;
 
@@ -177,41 +176,13 @@ public class Crypto {
      * safe to be called from any thread.
      *
      * @deprecated Since version 1.2.11, this interface (which was only ever intended for internal use within this
-     * library) has been replaced by {@link ChannelCipherSet}.
+     * library) has been replaced by {@link ChannelCipherSet}. It will be removed in the future.
      */
     @Deprecated
     public interface ChannelCipher {
         byte[] encrypt(byte[] plaintext) throws AblyException;
         byte[] decrypt(byte[] ciphertext) throws AblyException;
         String getAlgorithm();
-    }
-
-    /**
-     * Internal; get a ChannelCipher instance based on the given ChannelOptions
-     *
-     * @deprecated Since version 1.2.11, this method (which was only ever intended for internal use within this
-     * library) has been replaced by {@link #createChannelCipherSet(Object)}.
-     */
-    @Deprecated
-    public static ChannelCipher getCipher(final ChannelOptions opts) throws AblyException {
-        return new ChannelCipher() {
-            private final ChannelCipherSet set = createChannelCipherSet(opts.cipherParams);
-
-            @Override
-            public byte[] encrypt(byte[] plaintext) throws AblyException {
-                return set.getEncipher().encrypt(plaintext);
-            }
-
-            @Override
-            public byte[] decrypt(byte[] ciphertext) throws AblyException {
-                return set.getDecipher().decrypt(ciphertext);
-            }
-
-            @Override
-            public String getAlgorithm() {
-                return set.getEncipher().getAlgorithm();
-            }
-        };
     }
 
     /**

--- a/lib/src/main/java/io/ably/lib/util/Crypto.java
+++ b/lib/src/main/java/io/ably/lib/util/Crypto.java
@@ -181,6 +181,12 @@ public class Crypto {
 
     public interface EncryptingChannelCipher extends ChannelCipher {
         /**
+         * Enciphers plaintext.
+         *
+         * This method is not safe to be called from multiple threads at the same time, and it will throw a
+         * {@link ConcurrentModificationException} if that happens at runtime.
+         *
+         * @return ciphertext, being the result of encrypting plaintext.
          * @throws ConcurrentModificationException If this method is called from more than one thread at a time.
          */
         byte[] encrypt(byte[] plaintext) throws AblyException;
@@ -188,6 +194,12 @@ public class Crypto {
 
     public interface DecryptingChannelCipher extends ChannelCipher {
         /**
+         * Deciphers ciphertext.
+         *
+         * This method is not safe to be called from multiple threads at the same time, and it will throw a
+         * {@link ConcurrentModificationException} if that happens at runtime.
+         *
+         * @return plaintext, being the result of decrypting ciphertext.
          * @throws ConcurrentModificationException If this method is called from more than one thread at a time.
          */
         byte[] decrypt(byte[] ciphertext) throws AblyException;

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeCryptoTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeCryptoTest.java
@@ -33,8 +33,9 @@ import io.ably.lib.types.ChannelOptions;
 import io.ably.lib.types.ClientOptions;
 import io.ably.lib.types.ErrorInfo;
 import io.ably.lib.util.Crypto;
-import io.ably.lib.util.Crypto.ChannelCipher;
 import io.ably.lib.util.Crypto.CipherParams;
+import io.ably.lib.util.Crypto.DecryptingChannelCipher;
+import io.ably.lib.util.Crypto.EncryptingChannelCipher;
 
 public class RealtimeCryptoTest extends ParameterizedTest {
 
@@ -805,12 +806,13 @@ public class RealtimeCryptoTest extends ParameterizedTest {
     @Test
     public void encodeDecodeVariableSizesWithAES256CBC() throws NoSuchAlgorithmException, AblyException {
         final CipherParams params = Crypto.getParams("aes", generateNonce(32), generateNonce(16));
-        final ChannelCipher cipher = Crypto.getCipher(new ChannelOptions() {{ encrypted=true; cipherParams=params; }});
+        final EncryptingChannelCipher encipher = Crypto.getEncryptingCipher(params);
+        final DecryptingChannelCipher decipher = Crypto.getDecryptingCipher(params);
         for (int i=1; i<1000; i++) {
             final int size = RANDOM.nextInt(2000) + 1;
             final byte[] message = generateNonce(size);
-            final byte[] encrypted = cipher.encrypt(message);
-            final byte[] decrypted = cipher.decrypt(encrypted);
+            final byte[] encrypted = encipher.encrypt(message);
+            final byte[] decrypted = decipher.decrypt(encrypted);
             try {
                 assertArrayEquals(message, decrypted);
             } catch (final AssertionError e) {
@@ -1066,12 +1068,13 @@ public class RealtimeCryptoTest extends ParameterizedTest {
             // We have to create a new ChannelCipher for each message we encode because
             // cipher instances only use the IV we've supplied via CipherParams for the
             // encryption of the very first message.
-            final ChannelCipher cipher = Crypto.getCipher(new ChannelOptions() {{ encrypted=true; cipherParams=params; }});
+            final EncryptingChannelCipher encipher = Crypto.getEncryptingCipher(params);
+            final DecryptingChannelCipher decipher = Crypto.getDecryptingCipher(params);
 
             final byte[] appleMessage = hexStringToByteArray(entry.getKey());
             final byte[] appleEncrypted = hexStringToByteArray(entry.getValue());
-            final byte[] encrypted = cipher.encrypt(appleMessage);
-            final byte[] decrypted = cipher.decrypt(appleEncrypted);
+            final byte[] encrypted = encipher.encrypt(appleMessage);
+            final byte[] decrypted = decipher.decrypt(appleEncrypted);
 
             try {
                 assertArrayEquals(appleMessage, decrypted);

--- a/lib/src/test/java/io/ably/lib/test/rest/RestCryptoTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestCryptoTest.java
@@ -67,8 +67,12 @@ public class RestCryptoTest extends ParameterizedTest {
         /* verify message contents */
         for (final Message message : messages.items())
             messageContents.put(message.name, message.data);
-        assertEquals("This is a string message payload", messageContents.get("publish0"));
-        assertEquals("This is a byte[] message payload", new String((byte[])messageContents.get("publish1")));
+        final Object payload0 = messageContents.get("publish0");
+        final Object payload1 = messageContents.get("publish1");
+        assertTrue("Unexpected " + payload0.getClass(), payload0 instanceof String);
+        assertTrue("Unexpected " + payload1.getClass(), payload1 instanceof byte[]);
+        assertEquals("This is a string message payload", payload0);
+        assertEquals("This is a byte[] message payload", new String((byte[])payload1));
     }
 
     /**

--- a/lib/src/test/java/io/ably/lib/util/CryptoTest.java
+++ b/lib/src/test/java/io/ably/lib/util/CryptoTest.java
@@ -18,8 +18,8 @@ import org.msgpack.core.MessagePacker;
 import com.google.gson.stream.JsonWriter;
 
 import io.ably.lib.types.AblyException;
+import io.ably.lib.util.Crypto.ChannelCipherSet;
 import io.ably.lib.util.Crypto.CipherParams;
-import io.ably.lib.util.Crypto.DecryptingChannelCipher;
 import io.ably.lib.util.Crypto.EncryptingChannelCipher;
 import io.ably.lib.util.CryptoMessageTest.FixtureSet;
 
@@ -57,10 +57,10 @@ public class CryptoTest {
         );
 
         byte[] plaintext = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
-        EncryptingChannelCipher channelCipher1 = Crypto.getEncryptingCipher(params1);
-        EncryptingChannelCipher channelCipher2 = Crypto.getEncryptingCipher(params2);
-        EncryptingChannelCipher channelCipher3 = Crypto.getEncryptingCipher(params3);
-        EncryptingChannelCipher channelCipher4 = Crypto.getEncryptingCipher(params4);
+        EncryptingChannelCipher channelCipher1 = Crypto.createChannelCipherSet(params1).getEncipher();
+        EncryptingChannelCipher channelCipher2 = Crypto.createChannelCipherSet(params2).getEncipher();
+        EncryptingChannelCipher channelCipher3 = Crypto.createChannelCipherSet(params3).getEncipher();
+        EncryptingChannelCipher channelCipher4 = Crypto.createChannelCipherSet(params4).getEncipher();
 
         byte[] ciphertext1 = channelCipher1.encrypt(plaintext);
         byte[] ciphertext2 = channelCipher2.encrypt(plaintext);
@@ -127,19 +127,18 @@ public class CryptoTest {
         for (int i=1; i<=maxLength; i++) {
             // We need to create a new ChannelCipher for each message we encode,
             // so that our IV gets used (being start of CBC chain).
-            final EncryptingChannelCipher encipher = Crypto.getEncryptingCipher(params);
-            final DecryptingChannelCipher decipher = Crypto.getDecryptingCipher(params);
+            final ChannelCipherSet cipherSet = Crypto.createChannelCipherSet(params);
 
             // Encrypt i bytes from the start of the message data.
             final byte[] encoded = Arrays.copyOfRange(message, 0, i);
-            final byte[] encrypted = encipher.encrypt(encoded);
+            final byte[] encrypted = cipherSet.getEncipher().encrypt(encoded);
 
             // Add encryption result to results in format ready for fixture.
             writeResult(writer, "byte 1 to " + i, encoded, encrypted, fixtureSet.cipherName);
 
             // Decrypt the encrypted data and verify the result is the same as what
             // we submitted for encryption.
-            final byte[] verify = decipher.decrypt(encrypted);
+            final byte[] verify = cipherSet.getDecipher().decrypt(encrypted);
             assertArrayEquals(verify, encoded);
         }
         writer.endArray();

--- a/lib/src/test/java/io/ably/lib/util/CryptoTest.java
+++ b/lib/src/test/java/io/ably/lib/util/CryptoTest.java
@@ -18,9 +18,9 @@ import org.msgpack.core.MessagePacker;
 import com.google.gson.stream.JsonWriter;
 
 import io.ably.lib.types.AblyException;
-import io.ably.lib.types.ChannelOptions;
-import io.ably.lib.util.Crypto.ChannelCipher;
 import io.ably.lib.util.Crypto.CipherParams;
+import io.ably.lib.util.Crypto.DecryptingChannelCipher;
+import io.ably.lib.util.Crypto.EncryptingChannelCipher;
 import io.ably.lib.util.CryptoMessageTest.FixtureSet;
 
 public class CryptoTest {
@@ -57,10 +57,10 @@ public class CryptoTest {
         );
 
         byte[] plaintext = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
-        ChannelCipher channelCipher1 = Crypto.getCipher(new ChannelOptions() {{ encrypted=true; cipherParams=params1; }});
-        ChannelCipher channelCipher2 = Crypto.getCipher(new ChannelOptions() {{ encrypted=true; cipherParams=params2; }});
-        ChannelCipher channelCipher3 = Crypto.getCipher(new ChannelOptions() {{ encrypted=true; cipherParams=params3; }});
-        ChannelCipher channelCipher4 = Crypto.getCipher(new ChannelOptions() {{ encrypted=true; cipherParams=params4; }});
+        EncryptingChannelCipher channelCipher1 = Crypto.getEncryptingCipher(params1);
+        EncryptingChannelCipher channelCipher2 = Crypto.getEncryptingCipher(params2);
+        EncryptingChannelCipher channelCipher3 = Crypto.getEncryptingCipher(params3);
+        EncryptingChannelCipher channelCipher4 = Crypto.getEncryptingCipher(params4);
 
         byte[] ciphertext1 = channelCipher1.encrypt(plaintext);
         byte[] ciphertext2 = channelCipher2.encrypt(plaintext);
@@ -127,18 +127,19 @@ public class CryptoTest {
         for (int i=1; i<=maxLength; i++) {
             // We need to create a new ChannelCipher for each message we encode,
             // so that our IV gets used (being start of CBC chain).
-            final ChannelCipher cipher = Crypto.getCipher(new ChannelOptions() {{ encrypted=true; cipherParams=params; }});
+            final EncryptingChannelCipher encipher = Crypto.getEncryptingCipher(params);
+            final DecryptingChannelCipher decipher = Crypto.getDecryptingCipher(params);
 
             // Encrypt i bytes from the start of the message data.
             final byte[] encoded = Arrays.copyOfRange(message, 0, i);
-            final byte[] encrypted = cipher.encrypt(encoded);
+            final byte[] encrypted = encipher.encrypt(encoded);
 
             // Add encryption result to results in format ready for fixture.
             writeResult(writer, "byte 1 to " + i, encoded, encrypted, fixtureSet.cipherName);
 
             // Decrypt the encrypted data and verify the result is the same as what
             // we submitted for encryption.
-            final byte[] verify = cipher.decrypt(encrypted);
+            final byte[] verify = decipher.decrypt(encrypted);
             assertArrayEquals(verify, encoded);
         }
         writer.endArray();


### PR DESCRIPTION
I've made the cipher get method on `ChannelOptions` safe to be called from any thread.

I've also added a lightweight protection to each cipher implementation to fail early with a `ConcurrentModificationException` if the cipher is asked to operate from multiple threads concurrently.

This refactor ended up being a little larger than I had originally anticipated, but I feel that this area of the codebase is now clearer to follow and reason about. There is more I could have tackled but it fell outside of the scope of solving this particular grey area.

Fixes #741.