### PR TITLE
Use only the secure SSL/TLS protocols

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/SecureSSLSocketFactory.java
+++ b/lib/src/main/java/io/ably/lib/transport/SecureSSLSocketFactory.java
@@ -1,0 +1,89 @@
+package io.ably.lib.transport;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * This is a decorator for the {@code SSLSocketFactory} which modifies the enabled TLS protocols
+ * for each created {@code SSLSocket} to only use the protocols which are considered to be secure.
+ * <p>
+ * This class was created because the {@code SSLContext.getInstance()} method does not allow specifying
+ * precisely which TLS protocols can be used and which cannot.
+ */
+public class SecureSSLSocketFactory extends SSLSocketFactory {
+    /**
+     * All API calls should be delegated to this factory instance.
+     */
+    private final SSLSocketFactory factory;
+
+    public SecureSSLSocketFactory(SSLSocketFactory factory) {
+        this.factory = factory;
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return factory.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return factory.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket() throws IOException {
+        return getSocketWithOnlySecureProtocolsEnabled(factory.createSocket());
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return getSocketWithOnlySecureProtocolsEnabled(factory.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+        return getSocketWithOnlySecureProtocolsEnabled(factory.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException, UnknownHostException {
+        return getSocketWithOnlySecureProtocolsEnabled(factory.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return getSocketWithOnlySecureProtocolsEnabled(factory.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return getSocketWithOnlySecureProtocolsEnabled(factory.createSocket(address, port, localAddress, localPort));
+    }
+
+    /**
+     * Modifies the socket's enabled protocols list to only support the secure ones.
+     * If no secure protocol is supported then the socket won't have any protocols enabled.
+     */
+    private Socket getSocketWithOnlySecureProtocolsEnabled(Socket socket) {
+        SSLSocket sslSocket = (SSLSocket) socket;
+        Set<String> supportedProtocols = new HashSet<>(Arrays.asList(sslSocket.getSupportedProtocols()));
+        List<String> protocolsToEnable = new ArrayList<>();
+        if (supportedProtocols.contains("TLSv1.2")) {
+            protocolsToEnable.add("TLSv1.2");
+        }
+        if (supportedProtocols.contains("TLSv1.3")) {
+            protocolsToEnable.add("TLSv1.3");
+        }
+        sslSocket.setEnabledProtocols(protocolsToEnable.toArray(new String[0]));
+        return sslSocket;
+    }
+}

--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -14,7 +14,6 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
 
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.exceptions.WebsocketNotConnectedException;
@@ -72,7 +71,7 @@ public class WebSocketTransport implements ITransport {
                 if(isTls) {
                     SSLContext sslContext = SSLContext.getInstance("TLS");
                     sslContext.init( null, null, null );
-                    SSLSocketFactory factory = sslContext.getSocketFactory();// (SSLSocketFactory) SSLSocketFactory.getDefault();
+                    SecureSSLSocketFactory factory = new SecureSSLSocketFactory(sslContext.getSocketFactory());
                     wsConnection.setSocketFactory(factory);
                 }
             }

--- a/lib/src/test/java/io/ably/lib/transport/SecureSSLSocketFactoryTest.java
+++ b/lib/src/test/java/io/ably/lib/transport/SecureSSLSocketFactoryTest.java
@@ -1,0 +1,73 @@
+package io.ably.lib.transport;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class SecureSSLSocketFactoryTest {
+    SecureSSLSocketFactory secureSSLSocketFactory;
+
+    @Before
+    public void setup() throws NoSuchAlgorithmException, KeyManagementException {
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, null, null);
+        secureSSLSocketFactory = new SecureSSLSocketFactory(sslContext.getSocketFactory());
+    }
+
+    @Test
+    public void should_not_use_insecure_tls_protocols() throws IOException {
+        // given
+        Set<String> insecureProtocols = new HashSet<>(Arrays.asList(
+            "SSLv3",
+            "TLSv1",
+            "TLSv1.1"
+        ));
+
+        // when
+        SSLSocket sslSocket = (SSLSocket) secureSSLSocketFactory.createSocket();
+
+        // then
+        for (String enabledProtocol : sslSocket.getEnabledProtocols()) {
+            Assert.assertFalse(
+                "Protocol " + enabledProtocol + " is insecure and should not be enabled",
+                insecureProtocols.contains(enabledProtocol)
+            );
+
+        }
+    }
+
+    @Test
+    public void should_use_at_least_one_secure_tls_protocol() throws IOException {
+        // given
+        Set<String> secureProtocols = new HashSet<>(Arrays.asList(
+            "TLSv1.2",
+            "TLSv1.3"
+        ));
+
+        // when
+        SSLSocket sslSocket = (SSLSocket) secureSSLSocketFactory.createSocket();
+
+        // then
+        boolean isUsingSecureProtocol = containsAnySecureProtocol(sslSocket.getEnabledProtocols(), secureProtocols);
+        Assert.assertTrue("No secure protocols are enabled", isUsingSecureProtocol);
+    }
+
+    private boolean containsAnySecureProtocol(String[] protocols, Set<String> secureProtocols) {
+        for (String protocol : protocols) {
+            if (secureProtocols.contains(protocol)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
As `SSLContext.getInstance()` doesn't allow specifying a set of enabled protocols versions I had to create a special version of the `SSLSocketFactory` that enables only the secure protocol versions when creating a `SSLSocket`.