### PR TITLE
Add missing syntax information to code snippets in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@ Include the library by adding an `implementation` reference to `dependencies` bl
 
 For [Java](https://mvnrepository.com/artifact/io.ably/ably-java/latest):
 
-```
+```groovy
 implementation 'io.ably:ably-java:1.2.11'
 ```
 
 For [Android](https://mvnrepository.com/artifact/io.ably/ably-android/latest):
 
-```
+```groovy
 implementation 'io.ably:ably-android:1.2.11'
 ```
 
 The library is hosted on [Maven Central](https://mvnrepository.com/repos/central), so you need to ensure that the repository is referenced also; IDEs will typically include this by default:
 
-```
+```groovy
 repositories {
 	mavenCentral()
 }
@@ -403,7 +403,7 @@ Ably provides two models for delivering push notifications to devices.
 
 To publish a message to a channel including a push payload:
 
-```
+```java
 Message message = new Message("example", "realtime data");
 message.extras = io.ably.lib.util.JsonUtils.object()
     .add("push", io.ably.lib.util.JsonUtils.object()
@@ -427,7 +427,7 @@ rest.channels.get("pushenabled:foo").publishAsync(message, new CompletionListene
 
 To publish a push payload directly to a registered device:
 
-```
+```java
 Param[] recipient = new Param[]{new Param("deviceId", "xxxxxxxxxxx");
 
 JsonObject payload = io.ably.lib.util.JsonUtils.object()
@@ -459,7 +459,7 @@ In order to enable an app as a recipient of Ably push messages:
   - Override [`onNewToken`](https://firebase.google.com/docs/reference/android/com/google/firebase/messaging/FirebaseMessagingService#public-void-onnewtoken-string-token), and provide Ably with the registration token: `ActivationContext.getActivationContext(this).onNewRegistrationToken(RegistrationToken.Type.FCM, token);`. This method will be called whenever a new token is provided by Android.
 - Activate the device for push notifications:
 
-```
+```java
 realtime.setAndroidContext(context);
 realtime.push.activate();
 ```


### PR DESCRIPTION
While I was reading the README I've noticed that some code snippets have syntax highlighting while the others don't. I've added the missing syntax info to snippets.