### PR TITLE
Use only the clientId and data of the original presence message when automatically re-entering

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/Presence.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Presence.java
@@ -254,7 +254,13 @@ public class Presence {
                     /* Message is new to presence map, send it */
                     final String clientId = item.clientId;
                     try {
-                        PresenceMessage itemToSend = (PresenceMessage)item.clone();
+                        /**
+                         * (RTP17d) [...] publishing a PresenceMessage with an ENTER action using the
+                         * clientId and data attributes from that member [...]
+                         */
+                        PresenceMessage itemToSend = new PresenceMessage();
+                        itemToSend.clientId = item.clientId;
+                        itemToSend.data = item.data;
                         itemToSend.action = PresenceMessage.Action.enter;
                         updatePresence(itemToSend, new CompletionListener() {
                             @Override


### PR DESCRIPTION
Previously, we were copying the whole presence message and overriding the action to `ENTER`. However, [the spec](https://docs.ably.io/client-lib-development-guide/features/#RTP17d) requires to only copy the `clientId` and `data`. After this change we no longer receive the `Malformed message; mismatched connectionId` error.