### PR TITLE
Update documentation URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _[Ably](https://ably.com) is the platform that powers synchronized digital exper
 ## Overview
 
 A Java Realtime and REST client library.
-This library currently targets the [Ably client library features spec](https://www.ably.io/documentation/client-lib-development-guide/features/) Version 1.2.
+This library currently targets the [Ably client library features spec](https://www.ably.com/docs/client-lib-development-guide/features/) Version 1.2.
 
 ## Installation
 
@@ -43,7 +43,7 @@ The library requires that the runtime environment is able to establish a safe TL
 
 ## Usage
 
-Please refer to the [documentation](https://www.ably.io/documentation) for a full API reference.
+Please refer to the [documentation](https://www.ably.com/docs) for a full API reference.
 
 ### Using the Realtime API
 
@@ -109,7 +109,7 @@ channel.subscribe(events, new MessageListener() {
 
 #### Subscribing to a channel in delta mode
 
-Subscribing to a channel in delta mode enables [delta compression](https://www.ably.io/documentation/realtime/channels/channel-parameters/deltas). This is a way for a client to subscribe to a channel so that message payloads sent contain only the difference (ie the delta) between the present message and the previous message on the channel.
+Subscribing to a channel in delta mode enables [delta compression](https://www.ably.com/docs/realtime/channels/channel-parameters/deltas). This is a way for a client to subscribe to a channel so that message payloads sent contain only the difference (ie the delta) between the present message and the previous message on the channel.
 
 Request a Vcdiff formatted delta stream using channel options when you get the channel:
 
@@ -401,7 +401,7 @@ Log.setHandler(null);
 
 #### Delivering push notifications
 
-See [documentation](https://www.ably.io/documentation/general/push/publish)  for detail.
+See [documentation](https://www.ably.com/docs/general/push/publish)  for detail.
 
 Ably provides two models for delivering push notifications to devices.
 
@@ -455,7 +455,7 @@ rest.push.admin.publishAsync(recipient, payload, , new CompletionListener() {
 
 #### Activating a device and receiving notifications (Android only)
 
-See https://www.ably.io/documentation/general/push/activate-subscribe for detail.
+See https://www.ably.com/docs/general/push/activate-subscribe for detail.
 In order to enable an app as a recipient of Ably push messages:
 
 - register your app with Firebase Cloud Messaging (FCM) and configure the FCM credentials in the app dashboard;
@@ -470,7 +470,7 @@ realtime.push.activate();
 
 ## Resources
 
-Visit https://www.ably.io/documentation for a complete API reference and more examples.
+Visit https://www.ably.com/docs for a complete API reference and more examples.
 
 ### Example projects:
 

--- a/lib/src/main/java/io/ably/lib/types/MessageExtras.java
+++ b/lib/src/main/java/io/ably/lib/types/MessageExtras.java
@@ -28,7 +28,7 @@ public final class MessageExtras {
     /**
      * Creates a MessageExtras instance to be sent as extra with a Message to Ably's servers.
      *
-     * @see <a href="https://www.ably.io/documentation/general/push/publish#channel-broadcast-example">Channel-based push notification example</a>
+     * @see <a href="https://www.ably.com/docs/general/push/publish#channel-broadcast-example">Channel-based push notification example</a>
      *
      * @since 1.2.1
      */

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeCryptoTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeCryptoTest.java
@@ -665,7 +665,7 @@ public class RealtimeCryptoTest extends ParameterizedTest {
      * This test should be removed when we get rid of the methods
      * ChannelOptions.fromCipherKey(...) which are deprecated and have
      * been replaced with ChannelOptions.withCipherKey(...).
-     * @see <a href="https://docs.ably.io/client-lib-development-guide/features/#TB3>TB3</a>
+     * @see <a href="https://docs.ably.com/client-lib-development-guide/features/#TB3>TB3</a>
      */
     @Ignore("FIXME: fix exception")
     @Test
@@ -735,7 +735,7 @@ public class RealtimeCryptoTest extends ParameterizedTest {
 
     /**
      * Test channel options creation with the cipher key.
-     * @see <a href="https://docs.ably.io/client-lib-development-guide/features/#TB3>TB3</a>
+     * @see <a href="https://docs.ably.com/client-lib-development-guide/features/#TB3>TB3</a>
      */
     @Ignore("FIXME: fix exception")
     @Test
@@ -1109,7 +1109,7 @@ public class RealtimeCryptoTest extends ParameterizedTest {
 
     /**
      * Test Crypto.generateRandomKey.
-     * @see <a href="https://docs.ably.io/client-lib-development-guide/features/#RSE2">RSE2</a>
+     * @see <a href="https://docs.ably.com/client-lib-development-guide/features/#RSE2">RSE2</a>
      */
     @Test
     public void generate_random_key() {

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
@@ -935,7 +935,7 @@ public class RealtimeMessageTest extends ParameterizedTest {
      * Publish a message that contains extras of arbitrary creation. Validate that when we receive that message
      * echoed back from the service that those extras remain intact.
      *
-     * @see <a href="https://docs.ably.io/client-lib-development-guide/features/#RSL6a2">RSL6a2</a>
+     * @see <a href="https://docs.ably.com/client-lib-development-guide/features/#RSL6a2">RSL6a2</a>
      */
     @Ignore("FIXME: fix exception")
     @Test

--- a/lib/src/test/java/io/ably/lib/util/CryptoTest.java
+++ b/lib/src/test/java/io/ably/lib/util/CryptoTest.java
@@ -26,7 +26,7 @@ import io.ably.lib.util.CryptoMessageTest.FixtureSet;
 public class CryptoTest {
     /**
      * Test Crypto.getDefaultParams.
-     * @see <a href="https://docs.ably.io/client-lib-development-guide/features/#RSE1">RSE1</a>
+     * @see <a href="https://docs.ably.com/client-lib-development-guide/features/#RSE1">RSE1</a>
      */
     @Test
     public void cipher_params() throws AblyException, NoSuchAlgorithmException {


### PR DESCRIPTION
Updated `ably.io` documentation links to `ably.com` docs links.