### PR TITLE
Add publishing configuration to the shared "lib" module

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -12,6 +12,7 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 apply from: '../dependencies.gradle'
+apply from: 'publish.gradle'
 
 // Added to make test classes from this module available in other modules
 task testJar(type: Jar) {

--- a/lib/publish.gradle
+++ b/lib/publish.gradle
@@ -1,0 +1,94 @@
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+final String GROUP_ID = 'io.ably'
+final String ARTIFACT_ID = 'lib'
+
+task sourcesJar(type: Jar) {
+    // Copy files from main source directories to the JAR.
+    from sourceSets.main.allJava
+    // Specify the JAR type (it will be appended to its filename).
+    archiveClassifier.set('sources')
+}
+
+task javadocJar(type: Jar) {
+    // Generate the javadocs.
+    dependsOn javadoc
+    // Copy files from the javadocs directory to the jar.
+    from javadoc.destinationDir
+    // Specify the JAR type (it will be appended to its filename).
+    archiveClassifier.set('javadoc')
+}
+
+afterEvaluate {
+    // Based on: https://developer.android.com/studio/build/maven-publish-plugin
+    // See: https://docs.gradle.org/current/dsl/org.gradle.api.publish.PublishingExtension.html
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.java
+
+                groupId GROUP_ID
+                artifactId ARTIFACT_ID
+                version version
+
+                // Add a JAR with source code (to enable viewing the code when the library is included from a maven repository).
+                artifact sourcesJar
+                // Add a JAR with javadocs.
+                artifact javadocJar
+
+                // Add POM metadata
+                pom {
+                    name = 'Ably client shared code'
+                    description = 'A module containing shared code used by Java based Ably clients.'
+                    packaging = 'jar'
+                    inceptionYear = '2022'
+                    url = 'https://www.github.com/ably/ably-java'
+                    developers {
+                        // https://docs.gradle.org/current/dsl/org.gradle.api.publish.maven.MavenPomDeveloper.html
+                        developer {
+                            id = 'ably' // our company org in GitHub: https://github.com/ably
+                            name = 'Ably' // UK based company: Ably Real-time Ltd
+                            email = 'support@ably.com'
+                            url = 'https://ably.com/'
+                        }
+                    }
+                    scm {
+                        url = 'https://github.com/ably/ably-java'
+                        connection = 'scm:git:git://github.com/ably/ably-java.git'
+                        developerConnection = 'scm:git:ssh://github.com/ably/ably-java.git'
+                        tag = 'v' + version
+                    }
+                    organization {
+                        name = 'Ably' // UK based company: Ably Real-time Ltd
+                        url = 'https://ably.com/'
+                    }
+                    issueManagement {
+                        system = 'Github'
+                        url = 'https://github.com/ably/ably-java/issues'
+                    }
+                    licenses {
+                        license {
+                            name = 'The Apache Software License, Version 2.0'
+                            url = 'https://raw.github.com/ably/ably-java/main/LICENSE'
+                            distribution = 'repo'
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Sign the artifacts
+signing {
+    // According to signing plugin docs we should be providing the secret key in the ascii-armored format.
+    // This means that the bytes of the key should be converted to a Base64 encoded string.
+    // https://docs.gradle.org/current/userguide/signing_plugin.html#using_in_memory_ascii_armored_openpgp_subkeys
+    useInMemoryPgpKeys(
+        findProperty('SIGNING_KEY_ID'),
+        findProperty('SIGNING_KEY_BASE64'),
+        findProperty('SIGNING_PASSWORD'),
+    )
+    sign publishing.publications
+}


### PR DESCRIPTION
I've added a configuration that allows to publish the new `lib` module to the Maven Central.

~I'm submitting this as a draft as I'm not sure about those fields I've used in the POM:~
- ~ARTIFACT_ID~
- ~name~
- ~description~
- ~inceptionYear~