### PR TITLE
Use the "java-library" plugin instead of the "java" one

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'org.gradle.test-retry' version '1.2.0'
 }
 
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'idea'
 apply from: '../common.gradle'
 apply from: 'publish.gradle'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'de.fuerstenau.buildconfig' version '1.1.8'
     id 'checkstyle'
     id 'org.gradle.test-retry' version '1.2.0'
-    id 'java'
+    id 'java-library'
     id 'idea'
 }
 


### PR DESCRIPTION
I've replaced the `java` plugin with `java-library` which is an extended version of the `java` one.