### PR TITLE
Update Gradle version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.0.4'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,8 +26,6 @@ android {
     compileSdkVersion 30
 
     defaultConfig {
-        buildConfigField 'String', 'LIBRARY_NAME', '"android"'
-        buildConfigField 'String', 'VERSION', "\"$version\""
         minSdkVersion 16
         targetSdkVersion 24
         versionCode 1

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     api project(':lib')
     implementation 'com.google.firebase:firebase-messaging:22.0.0'
     // Enable access to test classes from the :lib module for integration test cases sharing
-    testImplementation project(path: ':lib', configuration: 'testRuntime')
+    testImplementation project(path: ':lib', configuration: 'sharedTestClasses')
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation 'com.crittercism.dexmaker:dexmaker:1.4'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -67,10 +67,10 @@ android {
 /* Fix for android test logging. Source: https://code.google.com/p/android/issues/detail?id=182307 */
 tasks.withType(com.android.build.gradle.internal.tasks.AndroidTestTask) { task ->
     task.doFirst {
-        logging.level = LogLevel.INFO
+        logging.levelInternal = LogLevel.INFO
     }
     task.doLast {
-        logging.level = LogLevel.LIFECYCLE
+        logging.levelInternal = LogLevel.LIFECYCLE
     }
 }
 

--- a/android/publish.gradle
+++ b/android/publish.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-final String GROUP_ID = 'io.ably'
-final String ARTIFACT_ID = 'ably-android'
+final String sdkGroupId = 'io.ably'
+final String sdkArtifactId = 'ably-android'
 
 task sourcesJar(type: Jar) {
     // Copy files from main source directories to the JAR.
@@ -39,8 +39,8 @@ afterEvaluate {
             release(MavenPublication) {
                 from components.release
 
-                groupId GROUP_ID
-                artifactId ARTIFACT_ID
+                groupId sdkGroupId
+                artifactId sdkArtifactId
                 version version
 
                 // Add a JAR with source code (to enable viewing the code when the library is included from a maven repository).

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id 'de.fuerstenau.buildconfig' version '1.1.8'
     id 'checkstyle'
     id 'org.gradle.test-retry' version '1.2.0'
 }
@@ -13,12 +12,6 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 apply from: '../dependencies.gradle'
-
-buildConfig {
-    packageName 'io.ably.lib'
-    clsName 'BuildConfig'
-    buildConfigField 'String', 'LIBRARY_NAME', 'java'
-}
 
 // Default jar: add io.ably classes from :lib dependency.
 jar {

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -42,7 +42,7 @@ task fullJar(type: Jar) {
 dependencies {
     implementation project(':lib')
     // Enable access to test classes from the :lib module for integration test cases sharing
-    testImplementation project(path: ':lib', configuration: 'testRuntime')
+    testImplementation project(path: ':lib', configuration: 'sharedTestClasses')
 }
 
 assemble.dependsOn fullJar

--- a/java/publish.gradle
+++ b/java/publish.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-final String GROUP_ID = 'io.ably'
-final String ARTIFACT_ID = 'ably-java'
+final String sdkGroupId = 'io.ably'
+final String sdkArtifactId = 'ably-java'
 
 task sourcesJar(type: Jar) {
     // Copy files from main source directories to the JAR.
@@ -28,8 +28,8 @@ afterEvaluate {
             release(MavenPublication) {
                 from components.java
 
-                groupId GROUP_ID
-                artifactId ARTIFACT_ID
+                groupId sdkGroupId
+                artifactId sdkArtifactId
                 version version
 
                 // Add a JAR with source code (to enable viewing the code when the library is included from a maven repository).

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,7 +1,6 @@
 plugins {
-    id 'de.fuerstenau.buildconfig' version '1.1.8'
+    id 'com.github.gmazzo.buildconfig' version '3.0.3'
     id 'checkstyle'
-    id 'org.gradle.test-retry' version '1.2.0'
     id 'java-library'
     id 'idea'
 }
@@ -13,6 +12,16 @@ targetCompatibility = 1.7
 
 apply from: '../dependencies.gradle'
 apply from: 'publish.gradle'
+
+// Make gradle properties accessible from the SDK code
+buildConfig {
+    // Set the package name of the generated class
+    packageName 'io.ably.lib'
+    // Set the class name of the generated class
+    className 'BuildConfig'
+    // Add SDK version field to the generated class
+    buildConfigField 'String', 'VERSION', "\"$version\""
+}
 
 // Added to make test classes from this module available in other modules
 task testJar(type: Jar) {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -16,12 +16,15 @@ apply from: 'publish.gradle'
 // Make gradle properties accessible from the SDK code
 buildConfig {
     // Set the package name of the generated class
-    packageName 'io.ably.lib'
+    packageName 'io.ably.generated'
     // Set the class name of the generated class
     className 'BuildConfig'
     // Add SDK version field to the generated class
     buildConfigField 'String', 'VERSION', "\"$version\""
 }
+
+// Exclude all files from any 'generated' directory when performing checkstyle check (added to exclude BuildConfig)
+checkstyleMain.exclude '**/generated/*'
 
 // Added to make test classes from this module available in other modules
 task testJar(type: Jar) {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -30,8 +30,13 @@ task testJar(type: Jar) {
 }
 
 // Added to make test classes from this module available in other modules
+configurations {
+    sharedTestClasses
+}
+
+// Added to make test classes from this module available in other modules
 artifacts {
-    testRuntime testJar
+    sharedTestClasses testJar
 }
 
 /*

--- a/lib/publish.gradle
+++ b/lib/publish.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-final String GROUP_ID = 'io.ably'
-final String ARTIFACT_ID = 'lib'
+final String sdkGroupId = 'io.ably'
+final String sdkArtifactId = 'lib'
 
 task sourcesJar(type: Jar) {
     // Copy files from main source directories to the JAR.
@@ -28,8 +28,8 @@ afterEvaluate {
             release(MavenPublication) {
                 from components.java
 
-                groupId GROUP_ID
-                artifactId ARTIFACT_ID
+                groupId sdkGroupId
+                artifactId sdkArtifactId
                 version version
 
                 // Add a JAR with source code (to enable viewing the code when the library is included from a maven repository).

--- a/lib/src/main/java/io/ably/lib/transport/Defaults.java
+++ b/lib/src/main/java/io/ably/lib/transport/Defaults.java
@@ -1,6 +1,6 @@
 package io.ably.lib.transport;
 
-import io.ably.BuildConfig;
+import io.ably.lib.BuildConfig;
 import io.ably.lib.types.ClientOptions;
 
 import java.text.DecimalFormat;

--- a/lib/src/main/java/io/ably/lib/transport/Defaults.java
+++ b/lib/src/main/java/io/ably/lib/transport/Defaults.java
@@ -1,6 +1,6 @@
 package io.ably.lib.transport;
 
-import io.ably.lib.BuildConfig;
+import io.ably.generated.BuildConfig;
 import io.ably.lib.types.ClientOptions;
 
 import java.text.DecimalFormat;

--- a/maven-central.gradle
+++ b/maven-central.gradle
@@ -1,12 +1,12 @@
 // MavenCentral publishing Sonatype configuration
-final String MAVEN_USER = hasProperty('ossrhUsername') ? ossrhUsername : ''
-final String MAVEN_PASSWORD = hasProperty('ossrhPassword') ? ossrhPassword : ''
+final String mavenUser = hasProperty('ossrhUsername') ? ossrhUsername : ''
+final String mavenPassword = hasProperty('ossrhPassword') ? ossrhPassword : ''
 
 nexusPublishing {
     repositories {
         sonatype {
-            username = MAVEN_USER
-            password = MAVEN_PASSWORD
+            username = mavenUser
+            password = mavenPassword
         }
     }
 }


### PR DESCRIPTION
I've updated the Gradle version and Android Gradle plugin version. After upgrading from `4.x` to `7.x` I had to use another BuildConfig plugin (as the old one was last time updated 5 years ago) and change the test sharing configuration (as the `testRuntime` was removed in Gradle 7).

While I was replacing the BuildConfig plugin I noticed that we only use it in the `lib` module, so I've removed it from the other ones. I also had to exclude it from the checkstyle as it was complaining about the generated code and that's something we can't change.

After the upgrade the Gradle lint tool was complaining about variables naming conventions, so I've changed the `SNAKE_CASE` names to `camelCase` ones.