### PR TITLE
Update SDK dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ Visit https://www.ably.com/docs for a complete API reference and more examples.
 
 For Java, JRE 7 or later is required. Note that the [Java Unlimited JCE extensions](http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html) must be installed in the Java runtime environment.
 
-For Android, 4.1 (API level 16) or later is required.
+For Android, 4.4 (API level 19) or later is required.
 
 ## Support, feedback and troubleshooting
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,7 @@ android {
     compileSdkVersion 30
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 24
         versionCode 1
         versionName version
@@ -77,7 +77,7 @@ tasks.withType(com.android.build.gradle.internal.tasks.AndroidTestTask) { task -
 apply from: '../dependencies.gradle'
 dependencies {
     api project(':lib')
-    implementation 'com.google.firebase:firebase-messaging:22.0.0'
+    implementation 'com.google.firebase:firebase-messaging:23.0.4'
     // Enable access to test classes from the :lib module for integration test cases sharing
     testImplementation project(path: ':lib', configuration: 'sharedTestClasses')
     androidTestImplementation 'com.android.support.test:runner:1.0.2'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,9 +1,9 @@
 // These dependencies have to be in lib/build.gradle for compilation _and_
 // in java/build.gradle and android/build.gradle for maven.
 dependencies {
-    implementation 'org.msgpack:msgpack-core:0.8.12'
-    implementation 'org.java-websocket:Java-WebSocket:1.4.0'
-    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'org.msgpack:msgpack-core:0.9.1'
+    implementation 'org.java-websocket:Java-WebSocket:1.5.3'
+    implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'com.davidehrmann.vcdiff:vcdiff-core:0.1.1'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
I've updated all production dependencies of the SDK that were able to be updated.

Updating the Firebase SDK forced us to increase the minimum supported Android OS level from `16` to `19`.