### PR TITLE
Remove unused Gradle configurations and tasks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,10 +25,6 @@ The JRE-specific library JAR is built with:
 
     ./gradlew java:jar
 
-There is also a task to build a fat JAR containing the dependencies:
-
-    ./gradlew java:fullJar
-
 The Android-specific library AAR is built with:
 
     ./gradlew android:assemble

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ repositories {
 }
 ```
 
-We only support installation via Maven / Gradle from the Maven Central repository. If you want to use a standalone fat JAR (i.e. containing all dependencies), it can be generated via a Gradle task (see [building](#building) below), creating a "Java" (JRE) library variant only. There is no standalone / self-contained AAR build option. Checkout [requirements](#requirements).
+We only support installation via Maven / Gradle from the Maven Central repository. Checkout [requirements](#requirements).
 
 ## Runtime Requirements
 

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -10,19 +10,6 @@ apply from: 'publish.gradle'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
-// Default jar: add io.ably classes from :lib dependency.
-jar {
-    baseName = 'ably-java'
-    from {
-        configurations.compile.collect { file ->
-            file.directory ? file : zipTree(file)
-        }
-    }
-    includes = ['**/io/ably/**']
-    includeEmptyDirs false
-    exclude 'META-INF/**'
-}
-
 // fullJar: add all classes from dependencies transitively.
 task fullJar(type: Jar) {
     baseName = 'ably-java'

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -18,10 +18,6 @@ dependencies {
 
 publish.dependsOn checkstyleMain
 
-configurations {
-    testsConfiguration
-}
-
 task testRealtimeSuite(type: Test) {
     filter {
         includeTestsMatching '*RealtimeSuite'

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -10,35 +10,16 @@ apply from: 'publish.gradle'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
-// fullJar: add all classes from dependencies transitively.
-task fullJar(type: Jar) {
-    baseName = 'ably-java'
-    classifier = 'full'
-    from {
-        configurations.compile.collect { file ->
-            file.directory ? file : zipTree(file)
-        }
-    }
-    with jar
-    exclude 'META-INF/**'
-}
-
 dependencies {
     implementation project(':lib')
     // Enable access to test classes from the :lib module for integration test cases sharing
     testImplementation project(path: ':lib', configuration: 'sharedTestClasses')
 }
 
-assemble.dependsOn fullJar
 publish.dependsOn checkstyleMain
 
 configurations {
-    fullConfiguration
     testsConfiguration
-}
-
-artifacts {
-    fullConfiguration fullJar
 }
 
 task testRealtimeSuite(type: Test) {


### PR DESCRIPTION
- Removed the "fat JAR" task as this is no longer required.
- Removed the custom `jar` task for `ably-java` which included the "lib" folder in the final JAR. This is unnecessary as the code from "lib" is now published as a separate module.
- Removed unnecessary test configuration from `ably-java`