### PR TITLE
Add automated publishing to Maven Central workflow

### DIFF
--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -30,9 +30,9 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-          ORG_GRADLE_PROJECT_SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-          ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          ORG_GRADLE_PROJECT_SIGNING_KEY_BASE64: ${{ secrets.SIGNING_KEY_RING_FILE_BASE64 }}
+          ORG_GRADLE_PROJECT_SIGNING_KEY_ID: ${{ secrets.MAVEN_SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.MAVEN_SIGNING_KEY_PASSWORD }}
+          ORG_GRADLE_PROJECT_SIGNING_KEY_BASE64: ${{ secrets.MAVEN_SIGNING_KEY_RING_FILE_BASE64 }}
         run: |
           echo "Publishing version ${{ github.event.inputs.version }} to MavenCentral..."
           ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -1,0 +1,38 @@
+# This is a manually triggered workflow (hence on: workflow_dispatch).
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#manual-events
+
+name: Publish to Maven Central
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version, without v prefix, appended to v to locate tag'
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: v${{ github.event.inputs.version }}
+
+      # Gradle 7 requires Java 11 to run
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Publish to Repositories
+        env:
+          ORG_GRADLE_PROJECT_OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+          ORG_GRADLE_PROJECT_SIGNING_KEY_BASE64: ${{ secrets.SIGNING_KEY_RING_FILE_BASE64 }}
+        run: |
+          echo "Publishing version ${{ github.event.inputs.version }} to MavenCentral..."
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,14 +183,23 @@ signing.secretKeyRingFile=/Users/username/.ably/ably-java-secring.gpg
 
 You may wish to make changes to Ably Java or Ably Android, and test it immediately in a separate project. For example, during development for [Ably Flutter](https://github.com/ably/ably-flutter) which depends on `ably-android`, a bug was found in `ably-android`. A small fix was done, the AAR was built and tested in [Ably Flutter](https://github.com/ably/ably-flutter).
 
-- Build the AAR: See [Building an Android Archive (AAR) file locally](#building-an-android-archive-aar-file-locally)
-- Open the directory printed from the output of that command. Inside that folder, get the `ably-android-x.y.z.aar`, and place it your Android project's `libs/` directory. Create this directory if it doesn't exist.
-- Add an `implementation` dependency on the `.aar`:
+### How to publish to the local repository
+
+1. Comment out the `signing { ... }` block in each of the `publish.gradle` files from modules you want to publish
+2. Run the `./gradlew publishToMavenLocal` to publish all modules or prefix the command with `:module-name:` if you want to publish only a specified module (e.g. `./gradlew :android:publishToMavenLocal`)
+3. The files can be found in the [local repository location](https://maven.apache.org/guides/mini/guide-configuring-maven.html#configuring-your-local-repository) on your computer. (e.g. `~/.m2/repository/io/ably/ably-android`)
+
+### How to use the published SDKs in another project
+
+Add the local maven repository to the **top** of the repositories block in your `build.gradle` file. This will result in Gradle looking firstly into the local repository for the Ably SDKs.
+Gradle [discourages the usage of mavenLocal()](https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:case-for-maven-local) repository, so this should only be used during development.
+
 ```groovy
-implementation files('libs/ably-android-1.2.12.aar')
+repositories {
+  mavenLocal()
+  // other repositories
+}
 ```
-- Add the `implementation` (not `testImplementation`) dependencies found in `dependencies.gradle` to your project. This is because the `.aar` does not contain dependencies.
-- Build/run your application.
 
 ## Release Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,9 +213,9 @@ defined to be used by our publishing workflows.
 to be used by Gradle's
 [Signing Plugin](https://docs.gradle.org/current/userguide/signing_plugin.html):
 
-- `SIGNING_KEY_ID`: The public key ID.
-- `SIGNING_KEY_PASSWORD`: The passphrase that was used to protect the private key.
-- `SIGNING_KEY_RING_FILE_BASE64`: The contents of the secret key ring file that contains the private key, base64 encoded so that it can be injected as a GitHub secret (encode from macOS using `openssl base64 < signing.key.gpg | pbcopy`).
+- `MAVEN_SIGNING_KEY_ID`: The public key ID.
+- `MAVEN_SIGNING_KEY_PASSWORD`: The passphrase that was used to protect the private key.
+- `MAVEN_SIGNING_KEY_RING_FILE_BASE64`: The contents of the secret key ring file that contains the private key, base64 encoded so that it can be injected as a GitHub secret (encode from macOS using `openssl base64 < signing.key.gpg | pbcopy`).
 
 ### Sonatype for Maven Central
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,6 +201,29 @@ repositories {
 }
 ```
 
+## Secrets Required to Release
+
+This section defines the names of the
+[GitHub secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
+defined to be used by our publishing workflows.
+
+### Code Signing
+
+[OpenGPG Signatory Credentials](https://docs.gradle.org/current/userguide/signing_plugin.html#sec:signatory_credentials)
+to be used by Gradle's
+[Signing Plugin](https://docs.gradle.org/current/userguide/signing_plugin.html):
+
+- `SIGNING_KEY_ID`: The public key ID.
+- `SIGNING_KEY_PASSWORD`: The passphrase that was used to protect the private key.
+- `SIGNING_KEY_RING_FILE_BASE64`: The contents of the secret key ring file that contains the private key, base64 encoded so that it can be injected as a GitHub secret (encode from macOS using `openssl base64 < signing.key.gpg | pbcopy`).
+
+### Sonatype for Maven Central
+
+Details for the Sonatype identity to be used to publish to our Ably's `io.ably` project ([OSSRH-52871](https://issues.sonatype.org/browse/OSSRH-52871)):
+
+- `OSSRH_USERNAME`: The Sonatype user.
+- `OSSRH_PASSWORD`: The password for the Sonatype user.
+
 ## Release Process
 
 This library uses [semantic versioning](http://semver.org/). For each release, the following needs to be done:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,19 +202,18 @@ This library uses [semantic versioning](http://semver.org/). For each release, t
 4. Commit [CHANGELOG](./CHANGELOG.md)
 5. Make a PR against `main`
 6. Once the PR is approved, merge it into `main`
-7. From the updated `main` branch on your local workstation, assemble and upload:
-    1. Run `./gradlew java:publish` to build and upload `ably-java` to Nexus staging repository
-    2. Run `./gradlew android:publish` to build and upload `ably-android` to Nexus staging repository
-    3. Find the new staging repository using the [Nexus Repository Manager](https://oss.sonatype.org/#stagingRepositories)
-    4. Check that it contains `ably-android` and `ably-java` releases
-    5. "Close" it - this will take a few minutes during which time it will say (after a refresh of your browser) that "Activity: Operation in Progress"
-    6. Once it has closed you will have "Release" available. You can allow it to "automatically drop" after successful release. A refresh or two later of the browser and the staging repository will have disappeared from the list (i.e. it's been dropped which implies it was released successfully)
-    7. A [search for Ably packages](https://oss.sonatype.org/#nexus-search;quick~io.ably) should now list the new version for both `ably-android` and `ably-java`
-8. Add a tag and push to origin - e.g.: `git tag v1.2.4 && git push origin v1.2.4`
+7. Add a tag and push to origin - e.g.: `git tag v1.2.4 && git push origin v1.2.4`
+8. Run the publish workflow:
+  - It is manually triggered, where you supply the version number so the script publishes only up to that tag
+  - It must be run from the `main` branch
+  - Run the [Maven Central](https://github.com/ably/ably-java/blob/main/.github/workflows/publish-maven-central.yml) workflow
+  - After a successful release, a [search for Ably packages](https://oss.sonatype.org/#nexus-search;quick~io.ably) should list the new version for both `ably-android` and `ably-java`
 9. Create the release on Github including populating the release notes
 10. Create the entry on the [Ably Changelog](https://changelog.ably.com/) (via [headwayapp](https://headwayapp.co/))
 
 ### Signing
+
+The signing is performed by the CI workflow and there's no need to do it manually. However, if such need arises, below are instructions on how to sign the SDKs locally.
 
 If you've not configured the signing key in your [Gradle properties](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties) then release builds will complain:
 

--- a/maven-central.gradle
+++ b/maven-central.gradle
@@ -1,12 +1,9 @@
 // MavenCentral publishing Sonatype configuration
-final String mavenUser = hasProperty('ossrhUsername') ? ossrhUsername : ''
-final String mavenPassword = hasProperty('ossrhPassword') ? ossrhPassword : ''
-
 nexusPublishing {
     repositories {
         sonatype {
-            username = mavenUser
-            password = mavenPassword
+            username = findProperty('OSSRH_USERNAME') ?: ''
+            password = findProperty('OSSRH_PASSWORD') ?: ''
         }
     }
 }


### PR DESCRIPTION
I've added a workflow for automatically publishing SDKs to the Maven Central. Also updated the instructions for publishing and testing the SDKs locally in the contributing guide.