### PR TITLE
Change visibility of SDK dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ subprojects {
             dependencies {
                 implementation 'org.msgpack:msgpack-core:0.9.1'
                 implementation 'org.java-websocket:Java-WebSocket:1.5.3'
-                implementation 'com.google.code.gson:gson:2.9.0'
+                api 'com.google.code.gson:gson:2.9.0'
                 implementation 'com.davidehrmann.vcdiff:vcdiff-core:0.1.1'
                 testImplementation 'org.hamcrest:hamcrest-all:1.3'
                 testImplementation 'junit:junit:4.12'

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -11,7 +11,7 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-    implementation project(':lib')
+    api project(':lib')
     // Enable access to test classes from the :lib module for integration test cases sharing
     testImplementation project(path: ':lib', configuration: 'sharedTestClasses')
 }

--- a/lib/src/main/java/io/ably/lib/types/Message.java
+++ b/lib/src/main/java/io/ably/lib/types/Message.java
@@ -176,7 +176,7 @@ public class Message extends BaseMessage {
             this(channels.toArray(new String[0]), messages.toArray(new Message[0]));
         }
 
-        public void writeMsgpack(MessagePacker packer) throws IOException {
+        void writeMsgpack(MessagePacker packer) throws IOException {
             packer.packMapHeader(2);
             packer.packString("channels");
             packer.packArrayHeader(channels.length);

--- a/lib/src/main/java/io/ably/lib/types/MessageSerializer.java
+++ b/lib/src/main/java/io/ably/lib/types/MessageSerializer.java
@@ -26,7 +26,7 @@ public class MessageSerializer {
      *            Msgpack decode
      ****************************************/
 
-    public static Message[] readMsgpackArray(MessageUnpacker unpacker) throws IOException {
+    static Message[] readMsgpackArray(MessageUnpacker unpacker) throws IOException {
         int count = unpacker.unpackArrayHeader();
         Message[] result = new Message[count];
         for(int i = 0; i < count; i++)
@@ -65,7 +65,7 @@ public class MessageSerializer {
         } catch(IOException e) { return null; }
     }
 
-    public static void writeMsgpackArray(Message[] messages, MessagePacker packer) {
+    static void writeMsgpackArray(Message[] messages, MessagePacker packer) {
         try {
             int count = messages.length;
             packer.packArrayHeader(count);
@@ -74,7 +74,7 @@ public class MessageSerializer {
         } catch(IOException e) {}
     }
 
-    public static void write(final Map<String, String> map, final MessagePacker packer) throws IOException {
+    static void write(final Map<String, String> map, final MessagePacker packer) throws IOException {
         packer.packMapHeader(map.size());
         for (final Map.Entry<String, String> entry : map.entrySet()) {
             packer.packString(entry.getKey());
@@ -82,7 +82,7 @@ public class MessageSerializer {
         }
     }
 
-    public static Map<String, String> readStringMap(final MessageUnpacker unpacker) throws IOException {
+    static Map<String, String> readStringMap(final MessageUnpacker unpacker) throws IOException {
         final Map<String, String> map = new HashMap<>();
         final int fieldCount = unpacker.unpackMapHeader();
         for(int i = 0; i < fieldCount; i++) {

--- a/lib/src/main/java/io/ably/lib/types/PresenceSerializer.java
+++ b/lib/src/main/java/io/ably/lib/types/PresenceSerializer.java
@@ -22,7 +22,7 @@ public class PresenceSerializer {
      *            Msgpack decode
      ****************************************/
 
-    public static PresenceMessage[] readMsgpackArray(MessageUnpacker unpacker) throws IOException {
+    static PresenceMessage[] readMsgpackArray(MessageUnpacker unpacker) throws IOException {
         int count = unpacker.unpackArrayHeader();
         PresenceMessage[] result = new PresenceMessage[count];
         for(int i = 0; i < count; i++)
@@ -53,7 +53,7 @@ public class PresenceSerializer {
         } catch(IOException e) { return null; }
     }
 
-    public static void writeMsgpackArray(PresenceMessage[] messages, MessagePacker packer) {
+    static void writeMsgpackArray(PresenceMessage[] messages, MessagePacker packer) {
         try {
             int count = messages.length;
             packer.packArrayHeader(count);


### PR DESCRIPTION
- Classes from `lib` are now visible when someone uses `ably-java`
- Classes from `gson` are now visible (unfortunately, it is used in our API)
- Hidden classes from `msgpack` from the public API by changing utility methods visibility