### PR TITLE
Update dependencies that contain known vulnerabilities

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@
 // in java/build.gradle and android/build.gradle for maven.
 dependencies {
     implementation 'org.msgpack:msgpack-core:0.8.11'
-    implementation 'org.java-websocket:Java-WebSocket:1.4.0'
+    implementation 'org.java-websocket:Java-WebSocket:1.5.3'
     implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'com.davidehrmann.vcdiff:vcdiff-core:0.1.1'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,7 +3,7 @@
 dependencies {
     implementation 'org.msgpack:msgpack-core:0.8.11'
     implementation 'org.java-websocket:Java-WebSocket:1.4.0'
-    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'com.davidehrmann.vcdiff:vcdiff-core:0.1.1'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
We've found out that the `gson` and `Java-WebSocket` dependency versions have known vulnerabilities. Therefore, we should update them to use the new, secure versions.