### PR TITLE
Minimum API Level supported for Android is 19 (KitKat, v.4.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ Visit https://www.ably.com/docs for a complete API reference and more examples.
 
 For Java, JRE 7 or later is required. Note that the [Java Unlimited JCE extensions](http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html) must be installed in the Java runtime environment.
 
-For Android, 4.1 (API level 16) or later is required.
+For Android, 4.4 KitKat (API level 19) or later is required.
 
 ## Support, feedback and troubleshooting
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,8 +28,8 @@ android {
     defaultConfig {
         buildConfigField 'String', 'LIBRARY_NAME', '"android"'
         buildConfigField 'String', 'VERSION', "\"$version\""
-        minSdkVersion 16
-        targetSdkVersion 24
+        minSdkVersion 19
+        targetSdkVersion 30
         versionCode 1
         versionName version
         setProperty('archivesBaseName', "ably-android-$versionName")


### PR DESCRIPTION
We were declaring incorrectly.

I propose releasing this with our next version `1.2` patch and, as such, am treating this change as foundational to my fix for #801.