### PR TITLE
Increase minimum JRE version to 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ Visit https://www.ably.com/docs for a complete API reference and more examples.
 
 ## Requirements
 
-For Java, JRE 7 or later is required. Note that the [Java Unlimited JCE extensions](http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html) must be installed in the Java runtime environment.
+For Java, JRE 8 or later is required. Note that the [Java Unlimited JCE extensions](https://www.oracle.com/uk/java/technologies/javase-jce8-downloads.html) must be installed in the Java runtime environment.
 
 For Android, 4.4 KitKat (API level 19) or later is required.
 

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -9,8 +9,8 @@ apply plugin: 'idea'
 apply from: '../common.gradle'
 apply from: 'maven.gradle'
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 apply from: '../dependencies.gradle'
 


### PR DESCRIPTION
Somehow we were building for Android at 1.8 already anyway.

Common to my statement on #804, I propose releasing this with our next version `1.2` patch and, as such, am treating this change as foundational to my fix for #801.

I will be very surprised if we have any customers still building against JDK 1.7 and/or targeting JRE 1.7 specifically. If there are any, this will break at build time for them so does not represent a runtime risk, so I am happy to take on the support burden of assisting those customers if this becomes an issue for them.

FYI, @paddybyers @stmoreau 