### PR TITLE
Add `finalize()` and `AutoCloseable` support to `AblyRest` instances

### DIFF
--- a/android/src/main/java/io/ably/lib/rest/AblyRest.java
+++ b/android/src/main/java/io/ably/lib/rest/AblyRest.java
@@ -7,6 +7,12 @@ import io.ably.lib.types.ClientOptions;
 import io.ably.lib.util.AndroidPlatformAgentProvider;
 import io.ably.lib.util.Log;
 
+/**
+ * The top-level class to be instanced for the Ably REST library for Android.
+ *
+ * This class implements {@link AutoCloseable} so you can use it in
+ * try-with-resources constructs and have the JDK close it for you.
+ */
 public class AblyRest extends AblyBase {
     /**
      * Instance the Ably library using a key only.

--- a/java/src/main/java/io/ably/lib/rest/AblyRest.java
+++ b/java/src/main/java/io/ably/lib/rest/AblyRest.java
@@ -4,6 +4,12 @@ import io.ably.lib.types.AblyException;
 import io.ably.lib.types.ClientOptions;
 import io.ably.lib.util.JavaPlatformAgentProvider;
 
+/**
+ * The top-level class to be instanced for the Ably REST library for JRE.
+ *
+ * This class implements {@link AutoCloseable} so you can use it in
+ * try-with-resources constructs and have the JDK close it for you.
+ */
 public class AblyRest extends AblyBase {
     /**
      * Instance the Ably library using a key only.

--- a/lib/src/main/java/io/ably/lib/http/AsyncHttpScheduler.java
+++ b/lib/src/main/java/io/ably/lib/http/AsyncHttpScheduler.java
@@ -13,17 +13,17 @@ import io.ably.lib.util.Log;
  */
 public class AsyncHttpScheduler extends HttpScheduler {
     public AsyncHttpScheduler(HttpCore httpCore, ClientOptions options) {
-        super(httpCore, new WrappedExecutor(options));
+        super(httpCore, new CloseableThreadPoolExecutor(options));
     }
 
     private static final long KEEP_ALIVE_TIME = 2000L;
 
     protected static final String TAG = AsyncHttpScheduler.class.getName();
 
-    private static class WrappedExecutor implements CloseableExecutor {
+    private static class CloseableThreadPoolExecutor implements CloseableExecutor {
         private final ThreadPoolExecutor executor;
 
-        WrappedExecutor(final ClientOptions options) {
+        CloseableThreadPoolExecutor(final ClientOptions options) {
             executor = new ThreadPoolExecutor(
                 options.asyncHttpThreadpoolSize,
                 options.asyncHttpThreadpoolSize,

--- a/lib/src/main/java/io/ably/lib/http/AsyncHttpScheduler.java
+++ b/lib/src/main/java/io/ably/lib/http/AsyncHttpScheduler.java
@@ -14,18 +14,7 @@ public class AsyncHttpScheduler extends HttpScheduler<ThreadPoolExecutor> {
         super(httpCore, new ThreadPoolExecutor(options.asyncHttpThreadpoolSize, options.asyncHttpThreadpoolSize, KEEP_ALIVE_TIME, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>()));
     }
 
-    public void dispose() {
-        ThreadPoolExecutor threadPoolExecutor = executor;
-        threadPoolExecutor.shutdown();
-        try {
-            threadPoolExecutor.awaitTermination(SHUTDOWN_TIME, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-            threadPoolExecutor.shutdownNow();
-        }
-    }
-
     private static final long KEEP_ALIVE_TIME = 2000L;
-    private static final long SHUTDOWN_TIME = 5000L;
 
     protected static final String TAG = AsyncHttpScheduler.class.getName();
 }

--- a/lib/src/main/java/io/ably/lib/http/AsyncHttpScheduler.java
+++ b/lib/src/main/java/io/ably/lib/http/AsyncHttpScheduler.java
@@ -2,19 +2,49 @@ package io.ably.lib.http;
 
 import io.ably.lib.types.ClientOptions;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import io.ably.lib.util.Log;
+
 /**
  * A HttpScheduler that uses a thread pool to run HTTP operations.
  */
-public class AsyncHttpScheduler extends HttpScheduler<ThreadPoolExecutor> {
+public class AsyncHttpScheduler extends HttpScheduler {
     public AsyncHttpScheduler(HttpCore httpCore, ClientOptions options) {
-        super(httpCore, new ThreadPoolExecutor(options.asyncHttpThreadpoolSize, options.asyncHttpThreadpoolSize, KEEP_ALIVE_TIME, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>()));
+        super(httpCore, new WrappedExecutor(options));
     }
 
     private static final long KEEP_ALIVE_TIME = 2000L;
 
     protected static final String TAG = AsyncHttpScheduler.class.getName();
+
+    private static class WrappedExecutor implements Executor {
+        private final ThreadPoolExecutor executor;
+
+        WrappedExecutor(final ClientOptions options) {
+            executor = new ThreadPoolExecutor(
+                options.asyncHttpThreadpoolSize,
+                options.asyncHttpThreadpoolSize,
+                KEEP_ALIVE_TIME,
+                TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<Runnable>()
+            );
+        }
+
+        @Override
+        public void execute(final Runnable command) {
+            executor.execute(command);
+        }
+
+        @Override
+        protected void finalize() throws Throwable {
+            final int drainedCount = executor.shutdownNow().size();
+            if (drainedCount > 0) {
+                Log.w(TAG, "finalize() drained (cancelled) task count: " + drainedCount);
+            }
+        }
+    }
 }

--- a/lib/src/main/java/io/ably/lib/http/AsyncHttpScheduler.java
+++ b/lib/src/main/java/io/ably/lib/http/AsyncHttpScheduler.java
@@ -12,7 +12,6 @@ import java.util.concurrent.TimeUnit;
 public class AsyncHttpScheduler extends HttpScheduler<ThreadPoolExecutor> {
     public AsyncHttpScheduler(HttpCore httpCore, ClientOptions options) {
         super(httpCore, new ThreadPoolExecutor(options.asyncHttpThreadpoolSize, options.asyncHttpThreadpoolSize, KEEP_ALIVE_TIME, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>()));
-        executor.allowsCoreThreadTimeOut();
     }
 
     public void dispose() {

--- a/lib/src/main/java/io/ably/lib/http/CloseableExecutor.java
+++ b/lib/src/main/java/io/ably/lib/http/CloseableExecutor.java
@@ -1,0 +1,6 @@
+package io.ably.lib.http;
+
+import java.util.concurrent.Executor;
+
+public interface CloseableExecutor extends Executor, AutoCloseable {
+}

--- a/lib/src/main/java/io/ably/lib/http/Http.java
+++ b/lib/src/main/java/io/ably/lib/http/Http.java
@@ -7,13 +7,18 @@ import io.ably.lib.types.ErrorInfo;
 /**
  * A high level wrapper of both a sync and an async HttpScheduler.
  */
-public class Http {
+public class Http implements AutoCloseable {
     private final AsyncHttpScheduler asyncHttp;
     private final SyncHttpScheduler syncHttp;
 
     public Http(AsyncHttpScheduler asyncHttp, SyncHttpScheduler syncHttp) {
         this.asyncHttp = asyncHttp;
         this.syncHttp = syncHttp;
+    }
+
+    @Override
+    public void close() throws Exception {
+        asyncHttp.close();
     }
 
     public class Request<Result> {

--- a/lib/src/main/java/io/ably/lib/http/Http.java
+++ b/lib/src/main/java/io/ably/lib/http/Http.java
@@ -60,7 +60,7 @@ public class Http {
             @Override
             public void execute(HttpScheduler http, final Callback<Result> callback) throws AblyException {
                 //throw e;
-                http.executor.execute(new Runnable() {
+                http.execute(new Runnable() {
                 @Override
                 public void run() {
                     callback.onError(e.errorInfo);

--- a/lib/src/main/java/io/ably/lib/http/HttpCore.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpCore.java
@@ -136,16 +136,6 @@ public class HttpCore {
         auth.assertAuthorizationHeader(renew);
     }
 
-    synchronized void dispose() {
-        if(!isDisposed) {
-            isDisposed = true;
-        }
-    }
-
-    public void finalize() {
-        dispose();
-    }
-
     /**
      * Make a synchronous HTTP request specified by URL and proxy
      * @param url
@@ -520,7 +510,6 @@ public class HttpCore {
     private final ProxyOptions proxyOptions;
     private HttpAuth proxyAuth;
     private Proxy proxy = Proxy.NO_PROXY;
-    private boolean isDisposed;
     private final PlatformAgentProvider platformAgentProvider;
 
     private static final String TAG = HttpCore.class.getName();

--- a/lib/src/main/java/io/ably/lib/http/HttpScheduler.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpScheduler.java
@@ -20,7 +20,7 @@ import io.ably.lib.util.Log;
  *
  * Internal; use Http instead.
  */
-public class HttpScheduler {
+public class HttpScheduler implements AutoCloseable {
     /**
      * Async HTTP GET for Ably host, with fallbacks
      * @param path
@@ -353,9 +353,14 @@ public class HttpScheduler {
         protected boolean isDone = false;
     }
 
-    protected HttpScheduler(HttpCore httpCore, Executor executor) {
+    protected HttpScheduler(HttpCore httpCore, CloseableExecutor executor) {
         this.httpCore = httpCore;
         this.executor = executor;
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.executor.close();
     }
 
     /**
@@ -435,7 +440,7 @@ public class HttpScheduler {
         return request;
     }
 
-    private final Executor executor;
+    private final CloseableExecutor executor;
     private final HttpCore httpCore;
 
     protected static final String TAG = HttpScheduler.class.getName();

--- a/lib/src/main/java/io/ably/lib/http/HttpScheduler.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpScheduler.java
@@ -437,9 +437,18 @@ public class HttpScheduler<Executor extends java.util.concurrent.Executor> {
         return request;
     }
 
-    protected final Executor executor;
+    private final Executor executor;
     private final HttpCore httpCore;
 
     protected static final String TAG = HttpScheduler.class.getName();
 
+    /**
+     * Adds a {@link Runnable} to the {@link Executor} used by this scheduler instance.
+     * @apiNote This is pretty hacky and is here to support the current Push Notifications implementation.
+     *
+     * @param runnable The code to be executed.
+     */
+    public void execute(Runnable runnable) {
+        executor.execute(runnable);
+    }
 }

--- a/lib/src/main/java/io/ably/lib/http/HttpScheduler.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpScheduler.java
@@ -4,6 +4,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Locale;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -18,11 +19,8 @@ import io.ably.lib.util.Log;
  * HttpScheduler schedules HttpCore operations to an Executor, exposing a generic async API.
  *
  * Internal; use Http instead.
- *
- * @param <Executor> The Executor that will run blocking operations.
  */
-public class HttpScheduler<Executor extends java.util.concurrent.Executor> {
-
+public class HttpScheduler {
     /**
      * Async HTTP GET for Ably host, with fallbacks
      * @param path

--- a/lib/src/main/java/io/ably/lib/http/SyncHttpScheduler.java
+++ b/lib/src/main/java/io/ably/lib/http/SyncHttpScheduler.java
@@ -5,8 +5,7 @@ import io.ably.lib.util.CurrentThreadExecutor;
 /**
  * A HttpScheduler that runs everything in the current thread.
  */
-public class SyncHttpScheduler extends HttpScheduler<CurrentThreadExecutor> {
-
+public class SyncHttpScheduler extends HttpScheduler {
     public SyncHttpScheduler(HttpCore httpCore) {
         super(httpCore, CurrentThreadExecutor.INSTANCE);
     }

--- a/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
+++ b/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
@@ -15,14 +15,12 @@ import io.ably.lib.util.InternalMap;
 import io.ably.lib.util.Log;
 
 /**
- * AblyRealtime
  * The top-level class to be instanced for the Ably Realtime library.
  *
  * This class implements {@link AutoCloseable} so you can use it in
  * try-with-resources constructs and have the JDK close it for you.
  */
-public class AblyRealtime extends AblyRest implements AutoCloseable {
-
+public class AblyRealtime extends AblyRest {
     /**
      * The {@link Connection} object for this instance.
      */
@@ -79,6 +77,16 @@ public class AblyRealtime extends AblyRest implements AutoCloseable {
      */
     @Override
     public void close() {
+        try {
+            super.close(); // throws checked exception
+        } catch (final Exception exception) {
+            // Convert to unchecked exception.
+            // This is because our close() method has never declared that it throws a checked exception.
+            // Which is confusing, given AutoCloseable declares that it does.
+            // TODO captured in https://github.com/ably/ably-java/issues/806
+            throw new RuntimeException(exception);
+        }
+
         connection.close();
     }
 

--- a/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
+++ b/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
@@ -80,11 +80,13 @@ public class AblyRealtime extends AblyRest {
         try {
             super.close(); // throws checked exception
         } catch (final Exception exception) {
-            // Convert to unchecked exception.
+            // Soften to Log, rather than throw.
             // This is because our close() method has never declared that it throws a checked exception.
             // Which is confusing, given AutoCloseable declares that it does.
             // TODO captured in https://github.com/ably/ably-java/issues/806
-            throw new RuntimeException(exception);
+            // It's also because this particular piece of resource cleanup, focussed on thread pool resources used by
+            // our REST code in the base class, is being introduced in an SDK patch release for version 1.2.
+            Log.e(TAG, "There was an exception releasing client instance base resources.", exception);
         }
 
         connection.close();

--- a/lib/src/main/java/io/ably/lib/rest/AblyBase.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyBase.java
@@ -39,8 +39,10 @@ import io.ably.lib.util.Serialisation;
  * AblyBase
  * The top-level class to be instanced for the Ably REST library.
  *
+ * This class implements {@link AutoCloseable} so you can use it in
+ * try-with-resources constructs and have the JDK close it for you.
  */
-public abstract class AblyBase {
+public abstract class AblyBase implements AutoCloseable {
 
     public final ClientOptions options;
     public final Http http;
@@ -94,6 +96,11 @@ public abstract class AblyBase {
 
         platform = new Platform();
         push = new Push(this);
+    }
+
+    @Override
+    public void close() throws Exception {
+        http.close();
     }
 
     /**

--- a/lib/src/main/java/io/ably/lib/util/CurrentThreadExecutor.java
+++ b/lib/src/main/java/io/ably/lib/util/CurrentThreadExecutor.java
@@ -1,12 +1,17 @@
 package io.ably.lib.util;
 
-import java.util.concurrent.Executor;
+import io.ably.lib.http.CloseableExecutor;
 
-public class CurrentThreadExecutor implements Executor {
+public class CurrentThreadExecutor implements CloseableExecutor {
     public static CurrentThreadExecutor INSTANCE = new CurrentThreadExecutor();
 
     @Override
     public void execute(Runnable runnable) {
         runnable.run();
+    }
+
+    @Override
+    public void close() throws Exception {
+        // nothing to do
     }
 }


### PR DESCRIPTION
A dual pronged approach to resolve #801.

Either:

- The addition of `finalize()` implementation in https://github.com/ably/ably-java/commit/f29e497760b5bfcbe95271d9c80e0303c391e787 will _passively_ clean up the thread pool executor once GC catches cleans up the `AsyncHttpScheduler` instance (once it's no longer referenced by the `AblyRest` instance that created it)
- The adoption of `AutoCloseable` in https://github.com/ably/ably-java/commit/56593e5822b2baf808bbcbe36e1d9b2940dacdbf will allow app developers to explicitly call `close()` on their `AblyRest` instances, or use [try-with-resources](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html)