### PR TITLE
Fix Java-WebSocket problem on Android below 24

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -164,7 +164,7 @@ public class WebSocketTransport implements ITransport {
          * https://github.com/TooTallNate/Java-WebSocket/wiki/No-such-method-error-setEndpointIdentificationAlgorithm#workaround
          */
         private boolean isHostnameVerified(String hostname) {
-            SSLSession session = getSSLSession();
+            final SSLSession session = getSSLSession();
             if (HttpsURLConnection.getDefaultHostnameVerifier().verify(hostname, session)) {
                 Log.i(TAG, "Successfully verified hostname");
                 return true;

--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -154,7 +154,6 @@ public class WebSocketTransport implements ITransport {
                 connectListener.onTransportAvailable(WebSocketTransport.this);
                 flagActivity();
             } else {
-                connectListener.onTransportUnavailable(WebSocketTransport.this, ConnectionManager.REASON_REFUSED);
                 close();
             }
         }

--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -166,7 +166,7 @@ public class WebSocketTransport implements ITransport {
         private boolean isHostnameVerified(String hostname) {
             final SSLSession session = getSSLSession();
             if (HttpsURLConnection.getDefaultHostnameVerifier().verify(hostname, session)) {
-                Log.i(TAG, "Successfully verified hostname");
+                Log.v(TAG, "Successfully verified hostname");
                 return true;
             } else {
                 Log.e(TAG, "Hostname verification failed, expected " + hostname + ", found " + session.getPeerHost());


### PR DESCRIPTION
There's a [known issue](https://github.com/TooTallNate/Java-WebSocket/wiki/No-such-method-error-setEndpointIdentificationAlgorithm) in the Java-WebSocket library that has affected us after the recent upgrade. Luckily, there's a [workaround](https://github.com/TooTallNate/Java-WebSocket/wiki/No-such-method-error-setEndpointIdentificationAlgorithm#workaround) that we have added to make it work.