### PR TITLE
Add multiple android emulation devices

### DIFF
--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        android-api-level: [ 19, 24, 30 ]
+        android-api-level: [ 19, 24, 29 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - feature/emulation_test
 
 jobs:
   check:

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -7,12 +7,17 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        android-api-level: [ 19, 24, 31 ]
+
     steps:
       - uses: actions/checkout@v2
 
       - uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 24
+          api-level: ${{ matrix.android-api-level }}
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           script: ./gradlew :android:connectedAndroidTest
 

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        android-api-level: [ 19, 24, 31 ]
+        android-api-level: [ 19, 24, 30 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -19,7 +19,8 @@ jobs:
       - uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.android-api-level }}
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
           script: ./gradlew :android:connectedAndroidTest
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        android-api-level: [ 19, 24, 29 ]
+        android-api-level: [ 19, 21, 24, 29 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/emulate.yml
+++ b/.github/workflows/emulate.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - feature/emulation_test
 
 jobs:
   check:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -91,6 +91,7 @@ dependencies {
     androidTestImplementation 'com.crittercism.dexmaker:dexmaker:1.4'
     androidTestImplementation 'com.crittercism.dexmaker:dexmaker-dx:1.4'
     androidTestImplementation 'com.crittercism.dexmaker:dexmaker-mockito:1.4'
+    androidTestImplementation 'net.sourceforge.streamsupport:android-retrostreams:1.7.4'
 }
 
 configurations {

--- a/android/src/androidTest/java/io/ably/lib/test/android/AndroidPushTest.java
+++ b/android/src/androidTest/java/io/ably/lib/test/android/AndroidPushTest.java
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.os.Build;
 import android.preference.PreferenceManager;
 import android.support.test.runner.AndroidJUnit4;
 import android.util.Log;
@@ -55,6 +56,8 @@ import io.ably.lib.util.Base64Coder;
 import io.ably.lib.util.IntentUtils;
 import io.ably.lib.util.JsonUtils;
 import io.ably.lib.util.Serialisation;
+import java9.util.stream.StreamSupport;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -1466,7 +1469,11 @@ public class AndroidPushTest {
 
         assertInstanceOf(NotActivated.class, activation.machine.current);
         // Since the event doesn't have a nullary constructor, it should be dropped.
-        assertEquals(0, activation.machine.pendingEvents.stream().filter(e -> e instanceof SyncRegistrationFailed).count());
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            assertEquals(0, activation.machine.pendingEvents.stream().filter(e -> e instanceof SyncRegistrationFailed).count());
+        } else {
+            assertEquals(0, StreamSupport.stream(activation.machine.pendingEvents).filter(e -> e instanceof SyncRegistrationFailed).count());
+        }
     }
 
     // This is all copied and pasted from ParameterizedTest, since I can't inherit from it.

--- a/android/src/androidTest/java/io/ably/lib/test/android/AndroidPushTest.java
+++ b/android/src/androidTest/java/io/ably/lib/test/android/AndroidPushTest.java
@@ -1,5 +1,6 @@
 package io.ably.lib.test.android;
 
+import android.annotation.TargetApi;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -80,6 +81,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 @RunWith(AndroidJUnit4.class)
 public class AndroidPushTest {
@@ -975,6 +977,7 @@ public class AndroidPushTest {
     // RSH3d3
     @Test
     public void WaitingForNewPushDeviceDetails_on_GotPushDeviceDetails() throws Exception {
+        assumeTrue("Can only run on API Level 21 or newer because HttpURLConnection does not support PATCH", Build.VERSION.SDK_INT >= 21);
         new UpdateRegistrationTest() {
             @Override
             protected void setUpMachineState(TestCase testCase) throws AblyException {


### PR DESCRIPTION
Added Android 19(KitKat) as SDK minimum supported and 29(Android 10) as the latest default target available in [Android emulator runner](https://github.com/ReactiveCircus/android-emulator-runner) to workflow.