### PR TITLE
Add new renew async method

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
+++ b/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
@@ -102,7 +102,7 @@ public class AblyRealtime extends AblyRest {
     }
 
     @Override
-    protected Future<AblyException> onAuthUpdatedAsync(String token)  {
+    protected Future<Void> onAuthUpdatedAsync(String token)  {
         return connection.connectionManager.onAuthUpdatedAsync(token);
     }
 

--- a/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
+++ b/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
@@ -2,6 +2,7 @@ package io.ably.lib.realtime;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.Future;
 
 import io.ably.lib.rest.AblyRest;
 import io.ably.lib.transport.ConnectionManager;
@@ -98,6 +99,11 @@ public class AblyRealtime extends AblyRest {
     @Override
     protected void onAuthUpdated(String token, boolean waitForResponse) throws AblyException {
         connection.connectionManager.onAuthUpdated(token, waitForResponse);
+    }
+
+    @Override
+    protected Future<AblyException> onAuthUpdatedAsync(String token)  {
+        return connection.connectionManager.onAuthUpdatedAsync(token);
     }
 
     /**

--- a/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
+++ b/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
@@ -2,9 +2,9 @@ package io.ably.lib.realtime;
 
 import java.util.Iterator;
 import java.util.Map;
-import java.util.concurrent.Future;
 
 import io.ably.lib.rest.AblyRest;
+import io.ably.lib.rest.Auth;
 import io.ably.lib.transport.ConnectionManager;
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.ChannelOptions;
@@ -101,9 +101,12 @@ public class AblyRealtime extends AblyRest {
         connection.connectionManager.onAuthUpdated(token, waitForResponse);
     }
 
+    /**
+     * Authentication token has changed. Async version
+     */
     @Override
-    protected Future<Void> onAuthUpdatedAsync(String token)  {
-        return connection.connectionManager.onAuthUpdatedAsync(token);
+    protected void onAuthUpdatedAsync(String token, Auth.AuthUpdateResult authUpdateResult)  {
+        connection.connectionManager.onAuthUpdatedAsync(token,authUpdateResult);
     }
 
     /**

--- a/lib/src/main/java/io/ably/lib/rest/AblyBase.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyBase.java
@@ -1,5 +1,6 @@
 package io.ably.lib.rest;
 
+import java.util.concurrent.Future;
 import io.ably.annotation.Experimental;
 import io.ably.lib.http.AsyncHttpScheduler;
 import io.ably.lib.http.Http;
@@ -314,6 +315,15 @@ public abstract class AblyBase implements AutoCloseable {
      */
     protected void onAuthUpdated(String token, boolean waitForResponse) throws AblyException {
         /* Default is to do nothing. Overridden by subclass. */
+    }
+
+    /**
+     * Override this method in AblyRealtime and pass updated token to ConnectionManager
+     * @param token new token
+     */
+    protected Future<AblyException> onAuthUpdatedAsync(String token)  {
+        //this must be overriden by subclass
+        return null;
     }
 
     /**

--- a/lib/src/main/java/io/ably/lib/rest/AblyBase.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyBase.java
@@ -321,7 +321,7 @@ public abstract class AblyBase implements AutoCloseable {
      * Override this method in AblyRealtime and pass updated token to ConnectionManager
      * @param token new token
      */
-    protected Future<AblyException> onAuthUpdatedAsync(String token)  {
+    protected Future<Void> onAuthUpdatedAsync(String token)  {
         //this must be overriden by subclass
         return null;
     }

--- a/lib/src/main/java/io/ably/lib/rest/AblyBase.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyBase.java
@@ -1,6 +1,5 @@
 package io.ably.lib.rest;
 
-import java.util.concurrent.Future;
 import io.ably.annotation.Experimental;
 import io.ably.lib.http.AsyncHttpScheduler;
 import io.ably.lib.http.Http;
@@ -320,10 +319,10 @@ public abstract class AblyBase implements AutoCloseable {
     /**
      * Override this method in AblyRealtime and pass updated token to ConnectionManager
      * @param token new token
+     * @param authUpdateResult Callback result
      */
-    protected Future<Void> onAuthUpdatedAsync(String token)  {
+    protected void onAuthUpdatedAsync(String token, Auth.AuthUpdateResult authUpdateResult)  {
         //this must be overriden by subclass
-        return null;
     }
 
     /**

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -827,7 +827,11 @@ public class Auth {
      * Renew auth credentials.
      * Will obtain a new token, even if we already have an apparently valid one.
      * Authorization will use the parameters supplied on construction.
+
+     * @deprecated this method is deprecated
+     * Please use  {@link Auth#renewAuth()} instead.
      */
+    @Deprecated
     public TokenDetails renew() throws AblyException {
         TokenDetails tokenDetails = assertValidToken(this.tokenParams, this.authOptions, true);
         ably.onAuthUpdated(tokenDetails.token, false);

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -834,6 +834,19 @@ public class Auth {
         return tokenDetails;
     }
 
+    /**
+     * Renew auth credentials.
+     * Will obtain a new token, even if we already have an apparently valid one.
+     * Authorization will use the parameters supplied on construction.
+     */
+    public TokenDetails renewAuth() throws AblyException {
+        TokenDetails tokenDetails = assertValidToken(this.tokenParams, this.authOptions, true);
+        ably.onAuthUpdated(tokenDetails.token, true);
+        return tokenDetails;
+    }
+
+    //add a new method renewAuthorization -
+
     public void onAuthError(ErrorInfo err) {
         /* we're only interested in token expiry errors */
         if(err.code >= 40140 && err.code < 40150)

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -847,10 +847,9 @@ public class Auth {
      *
      * @return
      * A single entry that contain a token detail and a future that represent an asynchronous result
-     * Clients must wait for the future result to finish before processing. If there is an exception happened during
-     * asynchronous operation the future will contain an AblyException
+     * Clients must wait for the future result to finish before processing.
      */
-    public Map.Entry<TokenDetails, Future<AblyException>> renewAuth() throws AblyException {
+    public Map.Entry<TokenDetails, Future<Void>> renewAuth() throws AblyException {
         final TokenDetails tokenDetails = assertValidToken(this.tokenParams, this.authOptions, true);
         return new AbstractMap.SimpleImmutableEntry<>(tokenDetails, ably.onAuthUpdatedAsync(tokenDetails.token));
     }

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -829,7 +829,9 @@ public class Auth {
      * Renew auth credentials.
      * Will obtain a new token, even if we already have an apparently valid one.
      * Authorization will use the parameters supplied on construction.
-     * @deprecated Use {@link Auth#renewAuth} instead
+     * @deprecated Because the method returns early before renew() completes and does not provide a completion
+     * handler for callers.
+     * Please use {@link Auth#renewAuth} instead
      */
     @Deprecated
     public TokenDetails renew() throws AblyException {

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -20,7 +20,6 @@ import io.ably.lib.http.HttpConstants;
 import io.ably.lib.http.HttpCore;
 import io.ably.lib.http.HttpHelpers;
 import io.ably.lib.http.HttpUtils;
-import io.ably.lib.realtime.ConnectionState;
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.BaseMessage;
 import io.ably.lib.types.Capability;
@@ -35,6 +34,7 @@ import io.ably.lib.util.Serialisation;
  * Token-generation and authentication operations for the Ably API.
  * See the Ably Authentication documentation for details of the
  * authentication methods available.
+ *
  */
 public class Auth {
 
@@ -121,13 +121,11 @@ public class Auth {
         /**
          * Default constructor
          */
-        public AuthOptions() {
-        }
+        public AuthOptions() {}
 
         /**
          * Convenience constructor, to create an AuthOptions based
          * on the key string obtained from the application dashboard.
-         *
          * @param key the full key string as obtained from the dashboard
          * @throws AblyException
          */
@@ -138,7 +136,7 @@ public class Auth {
             if (key.isEmpty()) {
                 throw new IllegalArgumentException("Key string cannot be empty");
             }
-            if (key.indexOf(':') > -1)
+            if(key.indexOf(':') > -1)
                 this.key = key;
             else
                 this.token = key;
@@ -188,6 +186,7 @@ public class Auth {
     /**
      * A class providing details of a token and its associated metadata,
      * provided when the system successfully requests a token from the system.
+     *
      */
     public static class TokenDetails {
 
@@ -219,17 +218,12 @@ public class Auth {
          */
         public String clientId;
 
-        public TokenDetails() {
-        }
-
-        public TokenDetails(String token) {
-            this.token = token;
-        }
+        public TokenDetails() {}
+        public TokenDetails(String token) { this.token = token; }
 
         /**
          * Convert a JSON response body to a TokenDetails.
          * Deprecated: use fromJson() instead
-         *
          * @param json
          * @return
          */
@@ -241,7 +235,6 @@ public class Auth {
         /**
          * Convert a JSON element response body to a TokenDetails.
          * Spec: TD7
-         *
          * @param json
          * @return
          */
@@ -251,7 +244,6 @@ public class Auth {
 
         /**
          * Convert a JSON element response body to a TokenDetails.
-         *
          * @param json
          * @return
          */
@@ -263,7 +255,7 @@ public class Auth {
          * Convert a TokenDetails into a JSON object.
          */
         public JsonObject asJsonElement() {
-            return (JsonObject) Serialisation.gson.toJsonTree(this);
+            return (JsonObject)Serialisation.gson.toJsonTree(this);
         }
 
         /**
@@ -275,20 +267,19 @@ public class Auth {
 
         /**
          * Check equality of a TokenDetails
-         *
          * @param obj
          */
         @Override
         public boolean equals(Object obj) {
-            TokenDetails details = (TokenDetails) obj;
+            TokenDetails details = (TokenDetails)obj;
             return equalNullableStrings(this.token, details.token) &
-                equalNullableStrings(this.capability, details.capability) &
-                equalNullableStrings(this.clientId, details.clientId) &
-                (this.issued == details.issued) &
-                (this.expires == details.expires);
+                    equalNullableStrings(this.capability, details.capability) &
+                    equalNullableStrings(this.clientId, details.clientId) &
+                    (this.issued == details.issued) &
+                    (this.expires == details.expires);
         }
 
-    }
+}
 
     /**
      * A class providing parameters of a token request.
@@ -300,7 +291,7 @@ public class Auth {
          * is successful, the TTL of the returned token will be less
          * than or equal to this value depending on application settings
          * and the attributes of the issuing key.
-         * <p>
+         *
          * 0 means Ably will set it to the default value.
          */
         public long ttl;
@@ -327,30 +318,28 @@ public class Auth {
 
         /**
          * Internal; convert a TokenParams to a collection of Params
-         *
          * @return
          */
         public Map<String, Param> asMap() {
             Map<String, Param> params = new HashMap<String, Param>();
-            if (ttl > 0) params.put("ttl", new Param("ttl", String.valueOf(ttl)));
-            if (capability != null) params.put("capability", new Param("capability", capability));
-            if (clientId != null) params.put("clientId", new Param("clientId", clientId));
-            if (timestamp > 0) params.put("timestamp", new Param("timestamp", String.valueOf(timestamp)));
+            if(ttl > 0) params.put("ttl", new Param("ttl", String.valueOf(ttl)));
+            if(capability != null) params.put("capability", new Param("capability", capability));
+            if(clientId != null) params.put("clientId", new Param("clientId", clientId));
+            if(timestamp > 0) params.put("timestamp", new Param("timestamp", String.valueOf(timestamp)));
             return params;
         }
 
         /**
          * Check equality of a TokenParams
-         *
          * @param obj
          */
         @Override
         public boolean equals(Object obj) {
-            TokenParams params = (TokenParams) obj;
+            TokenParams params = (TokenParams)obj;
             return (this.ttl == params.ttl) &
-                equalNullableStrings(this.capability, params.capability) &
-                equalNullableStrings(this.clientId, params.clientId) &
-                (this.timestamp == params.timestamp);
+                    equalNullableStrings(this.capability, params.capability) &
+                    equalNullableStrings(this.clientId, params.clientId) &
+                    (this.timestamp == params.timestamp);
         }
 
         /**
@@ -388,8 +377,7 @@ public class Auth {
      */
     public static class TokenRequest extends TokenParams {
 
-        public TokenRequest() {
-        }
+        public TokenRequest() {}
 
         public TokenRequest(TokenParams params) {
             this.ttl = params.ttl;
@@ -419,7 +407,6 @@ public class Auth {
         /**
          * Convert a JSON serialisation to a TokenParams.
          * Deprecated: use fromJson() instead
-         *
          * @param json
          * @return
          */
@@ -430,7 +417,6 @@ public class Auth {
 
         /**
          * Convert a parsed JSON response body to a TokenParams.
-         *
          * @param json
          * @return
          */
@@ -441,7 +427,6 @@ public class Auth {
         /**
          * Convert a string JSON response body to a TokenParams.
          * Spec: TE6
-         *
          * @param json
          * @return
          */
@@ -453,7 +438,7 @@ public class Auth {
          * Convert a TokenParams into a JSON object.
          */
         public JsonObject asJsonElement() {
-            JsonObject o = (JsonObject) Serialisation.gson.toJsonTree(this);
+            JsonObject o = (JsonObject)Serialisation.gson.toJsonTree(this);
             if (this.ttl == 0) {
                 o.remove("ttl");
             }
@@ -472,16 +457,15 @@ public class Auth {
 
         /**
          * Check equality of a TokenRequest
-         *
          * @param obj
          */
         @Override
         public boolean equals(Object obj) {
-            TokenRequest request = (TokenRequest) obj;
+            TokenRequest request = (TokenRequest)obj;
             return super.equals(obj) &
-                equalNullableStrings(this.keyName, request.keyName) &
-                equalNullableStrings(this.nonce, request.nonce) &
-                equalNullableStrings(this.mac, request.mac);
+                    equalNullableStrings(this.keyName, request.keyName) &
+                    equalNullableStrings(this.nonce, request.nonce) &
+                    equalNullableStrings(this.mac, request.mac);
         }
     }
 
@@ -506,26 +490,28 @@ public class Auth {
      * Authorization will use the parameters supplied on construction except
      * where overridden with the options supplied in the call.
      *
-     * @param params  an object containing the request params:
-     *                - key:        (optional) the key to use; if not specified, the key
-     *                passed in constructing the Rest interface may be used
-     *                <p>
-     *                - ttl:        (optional) the requested life of any new token in ms. If none
-     *                is specified a default of 1 hour is provided. The maximum lifetime
-     *                is 24hours; any request exceeding that lifetime will be rejected
-     *                with an error.
-     *                <p>
-     *                - capability: (optional) the capability to associate with the access token.
-     *                If none is specified, a token will be requested with all of the
-     *                capabilities of the specified key.
-     *                <p>
-     *                - clientId:   (optional) a client Id to associate with the token
-     *                <p>
-     *                - timestamp:  (optional) the time in ms since the epoch. If none is specified,
-     *                the system will be queried for a time value to use.
-     *                <p>
-     *                - queryTime   (optional) boolean indicating that the Ably system should be
-     *                queried for the current time when none is specified explicitly.
+     * @param params
+     * an object containing the request params:
+     * - key:        (optional) the key to use; if not specified, the key
+     *               passed in constructing the Rest interface may be used
+     *
+     * - ttl:        (optional) the requested life of any new token in ms. If none
+     *               is specified a default of 1 hour is provided. The maximum lifetime
+     *               is 24hours; any request exceeding that lifetime will be rejected
+     *               with an error.
+     *
+     * - capability: (optional) the capability to associate with the access token.
+     *               If none is specified, a token will be requested with all of the
+     *               capabilities of the specified key.
+     *
+     * - clientId:   (optional) a client Id to associate with the token
+     *
+     * - timestamp:  (optional) the time in ms since the epoch. If none is specified,
+     *               the system will be queried for a time value to use.
+     *
+     * - queryTime   (optional) boolean indicating that the Ably system should be
+     *               queried for the current time when none is specified explicitly.
+     *
      * @param options
      */
     public TokenDetails authorize(TokenParams params, AuthOptions options) throws AblyException {
@@ -545,7 +531,7 @@ public class Auth {
             authOptions.tokenDetails = new TokenDetails(authOptions.token);
         }
         TokenDetails tokenDetails;
-        if (authOptions.tokenDetails != null) {
+        if(authOptions.tokenDetails != null) {
             tokenDetails = authOptions.tokenDetails;
             setTokenDetails(tokenDetails);
         } else {
@@ -573,8 +559,7 @@ public class Auth {
     /**
      * Make a token request. This will make a token request now, even if the library already
      * has a valid token. It would typically be used to issue tokens for use by other clients.
-     *
-     * @param params       : see {@link #authorize} for params
+     * @param params : see {@link #authorize} for params
      * @param tokenOptions : see {@link #authorize} for options
      * @return the TokenDetails
      * @throws AblyException
@@ -585,30 +570,30 @@ public class Auth {
         params = (params == null) ? this.tokenParams : params.copy();
 
         /* Spec: RSA7d */
-        if (params.clientId == null) {
+        if(params.clientId == null) {
             params.clientId = ably.options.clientId;
         }
         params.capability = Capability.c14n(params.capability);
 
         /* get the signed token request */
         TokenRequest signedTokenRequest;
-        if (tokenOptions.authCallback != null) {
+        if(tokenOptions.authCallback != null) {
             Log.i("Auth.requestToken()", "using token auth with auth_callback");
             try {
                 /* the callback can return either a signed token request, or a TokenDetails */
                 Object authCallbackResponse = tokenOptions.authCallback.getTokenRequest(params);
-                if (authCallbackResponse instanceof String)
-                    return new TokenDetails((String) authCallbackResponse);
-                if (authCallbackResponse instanceof TokenDetails)
-                    return (TokenDetails) authCallbackResponse;
-                if (authCallbackResponse instanceof TokenRequest)
-                    signedTokenRequest = (TokenRequest) authCallbackResponse;
+                if(authCallbackResponse instanceof String)
+                    return new TokenDetails((String)authCallbackResponse);
+                if(authCallbackResponse instanceof TokenDetails)
+                    return (TokenDetails)authCallbackResponse;
+                if(authCallbackResponse instanceof TokenRequest)
+                    signedTokenRequest = (TokenRequest)authCallbackResponse;
                 else
                     throw AblyException.fromErrorInfo(new ErrorInfo("Invalid authCallback response", 400, 40000));
-            } catch (AblyException e) {
+            } catch(AblyException e) {
                 throw AblyException.fromErrorInfo(e, new ErrorInfo("authCallback failed with an exception", 401, 80019));
             }
-        } else if (tokenOptions.authUrl != null) {
+        } else if(tokenOptions.authUrl != null) {
             Log.i("Auth.requestToken()", "using token auth with auth_url");
 
             /* the auth request can return either a signed token request as a TokenParams, or a TokenDetails */
@@ -617,39 +602,39 @@ public class Auth {
                 HttpCore.ResponseHandler<Object> responseHandler = new HttpCore.ResponseHandler<Object>() {
                     @Override
                     public Object handleResponse(HttpCore.Response response, ErrorInfo error) throws AblyException {
-                        if (error != null) {
+                        if(error != null) {
                             throw AblyException.fromErrorInfo(error);
                         }
                         try {
                             String contentType = response.contentType;
                             byte[] body = response.body;
-                            if (body == null || body.length == 0) {
+                            if(body == null || body.length == 0) {
                                 return null;
                             }
-                            if (contentType != null) {
-                                if (contentType.startsWith("text/plain") || contentType.startsWith("application/jwt")) {
+                            if(contentType != null) {
+                                if(contentType.startsWith("text/plain") || contentType.startsWith("application/jwt")) {
                                     /* assumed to be token string */
                                     String token = new String(body);
                                     return new TokenDetails(token);
                                 }
-                                if (!contentType.startsWith("application/json")) {
+                                if(!contentType.startsWith("application/json")) {
                                     throw AblyException.fromErrorInfo(new ErrorInfo("Unacceptable content type from auth callback", 406, 40170));
                                 }
                             }
                             /* if not explicitly indicated, we will just assume it's JSON */
                             JsonElement json = Serialisation.gsonParser.parse(new String(body));
-                            if (!(json instanceof JsonObject)) {
+                            if(!(json instanceof JsonObject)) {
                                 throw AblyException.fromErrorInfo(new ErrorInfo("Unexpected response type from auth callback", 406, 40170));
                             }
-                            JsonObject jsonObject = (JsonObject) json;
-                            if (jsonObject.has("issued")) {
+                            JsonObject jsonObject = (JsonObject)json;
+                            if(jsonObject.has("issued")) {
                                 /* we assume this is a token details */
                                 return TokenDetails.fromJsonElement(jsonObject);
                             } else {
                                 /* otherwise it's a signed token request */
                                 return TokenRequest.fromJsonElement(jsonObject);
                             }
-                        } catch (JsonParseException e) {
+                        } catch(JsonParseException e) {
                             throw AblyException.fromErrorInfo(new ErrorInfo("Unable to parse response from auth callback", 406, 40170));
                         }
                     }
@@ -659,15 +644,15 @@ public class Auth {
                 Map<String, Param> urlParams = null;
                 URL authUrl = HttpUtils.parseUrl(authOptions.authUrl);
                 String queryString = authUrl.getQuery();
-                if (queryString != null && !queryString.isEmpty()) {
+                if(queryString != null && !queryString.isEmpty()) {
                     urlParams = HttpUtils.decodeParams(queryString);
                 }
                 Map<String, Param> tokenParams = params.asMap();
-                if (tokenOptions.authParams != null) {
-                    for (Param p : tokenOptions.authParams) {
+                if(tokenOptions.authParams != null) {
+                    for(Param p : tokenOptions.authParams) {
                         /* (RSA8c2) TokenParams take precedence over any configured
                          * authParams when a name conflict occurs */
-                        if (!tokenParams.containsKey(p.key)) {
+                        if(!tokenParams.containsKey(p.key)) {
                             tokenParams.put(p.key, p);
                         }
                     }
@@ -678,19 +663,19 @@ public class Auth {
                     Map<String, Param> requestParams = (urlParams != null) ? HttpUtils.mergeParams(urlParams, tokenParams) : tokenParams;
                     authUrlResponse = HttpHelpers.getUri(ably.httpCore, tokenOptions.authUrl, tokenOptions.authHeaders, HttpUtils.flattenParams(requestParams), responseHandler);
                 }
-            } catch (AblyException e) {
+            } catch(AblyException e) {
                 throw AblyException.fromErrorInfo(e, new ErrorInfo("authUrl failed with an exception", e.errorInfo.statusCode, 80019));
             }
-            if (authUrlResponse == null) {
+            if(authUrlResponse == null) {
                 throw AblyException.fromErrorInfo(null, new ErrorInfo("Empty response received from authUrl", 401, 80019));
             }
-            if (authUrlResponse instanceof TokenDetails) {
+            if(authUrlResponse instanceof TokenDetails) {
                 /* we're done */
-                return (TokenDetails) authUrlResponse;
+                return (TokenDetails)authUrlResponse;
             }
             /* otherwise it's a signed token request */
-            signedTokenRequest = (TokenRequest) authUrlResponse;
-        } else if (tokenOptions.key != null) {
+            signedTokenRequest = (TokenRequest)authUrlResponse;
+        } else if(tokenOptions.key != null) {
             Log.i("Auth.requestToken()", "using token auth with client-side signing");
             signedTokenRequest = createTokenRequest(params, tokenOptions);
         } else {
@@ -701,14 +686,14 @@ public class Auth {
         return HttpHelpers.postSync(ably.http, tokenPath, null, null, new HttpUtils.JsonRequestBody(signedTokenRequest.asJsonElement().toString()), new HttpCore.ResponseHandler<TokenDetails>() {
             @Override
             public TokenDetails handleResponse(HttpCore.Response response, ErrorInfo error) throws AblyException {
-                if (error != null) {
+                if(error != null) {
                     throw AblyException.fromErrorInfo(error);
                 }
                 try {
                     String jsonText = new String(response.body);
-                    JsonObject json = (JsonObject) Serialisation.gsonParser.parse(jsonText);
+                    JsonObject json = (JsonObject)Serialisation.gsonParser.parse(jsonText);
                     return TokenDetails.fromJsonElement(json);
-                } catch (JsonParseException e) {
+                } catch(JsonParseException e) {
                     throw AblyException.fromThrowable(e);
                 }
             }
@@ -719,8 +704,7 @@ public class Auth {
      * Create a signed token request based on known credentials
      * and the given token params. This would typically be used if creating
      * signed requests for submission by another client.
-     *
-     * @param params  : see {@link #authorize} for params
+     * @param params : see {@link #authorize} for params
      * @param options : see {@link #authorize} for options
      * @return the params augmented with the mac.
      * @throws AblyException
@@ -734,17 +718,17 @@ public class Auth {
         TokenRequest request = new TokenRequest(params);
 
         String key = options.key;
-        if (key == null)
+        if(key == null)
             throw AblyException.fromErrorInfo(new ErrorInfo("No key specified", 401, 40101));
 
         String[] keyParts = key.split(":");
-        if (keyParts.length != 2)
+        if(keyParts.length != 2)
             throw AblyException.fromErrorInfo(new ErrorInfo("Invalid key specified", 401, 40101));
 
         String keyName = keyParts[0], keySecret = keyParts[1];
-        if (request.keyName == null)
+        if(request.keyName == null)
             request.keyName = keyName;
-        else if (!request.keyName.equals(keyName))
+        else if(!request.keyName.equals(keyName))
             throw AblyException.fromErrorInfo(new ErrorInfo("Incompatible keys specified", 401, 40102));
 
         /* expires */
@@ -758,14 +742,14 @@ public class Auth {
         String clientIdText = (request.clientId == null) ? "" : request.clientId;
 
         /* timestamp */
-        if (request.timestamp == 0) {
-            if (options.queryTime) {
+        if(request.timestamp == 0) {
+            if(options.queryTime) {
                 long oldNanoTimeDelta = nanoTimeDelta;
-                long currentNanoTimeDelta = System.currentTimeMillis() - System.nanoTime() / (1000 * 1000);
+                long currentNanoTimeDelta = System.currentTimeMillis() - System.nanoTime()/(1000*1000);
 
                 if (timeDelta != Long.MAX_VALUE) {
                     /* system time changed by more than 500ms since last time? */
-                    if (Math.abs(oldNanoTimeDelta - currentNanoTimeDelta) > 500)
+                    if(Math.abs(oldNanoTimeDelta - currentNanoTimeDelta) > 500)
                         timeDelta = Long.MAX_VALUE;
                 }
 
@@ -776,7 +760,8 @@ public class Auth {
                     request.timestamp = ably.time();
                     timeDelta = request.timestamp - timestamp();
                 }
-            } else {
+            }
+            else {
                 request.timestamp = timestamp();
             }
         }
@@ -800,7 +785,6 @@ public class Auth {
 
     /**
      * Get the authentication method for this library instance.
-     *
      * @return
      */
     public AuthMethod getAuthMethod() {
@@ -809,7 +793,6 @@ public class Auth {
 
     /**
      * Get the credentials for HTTP basic auth, if available.
-     *
      * @return
      */
     public String getBasicCredentials() {
@@ -818,20 +801,19 @@ public class Auth {
 
     /**
      * Get query params representing the current authentication method and credentials.
-     *
      * @return
      * @throws AblyException
      */
     public Param[] getAuthParams() throws AblyException {
         Param[] params = null;
-        switch (method) {
-            case basic:
-                params = new Param[]{new Param("key", authOptions.key)};
-                break;
-            case token:
-                assertValidToken();
-                params = new Param[]{new Param("accessToken", getTokenDetails().token)};
-                break;
+        switch(method) {
+        case basic:
+            params = new Param[]{new Param("key", authOptions.key) };
+            break;
+        case token:
+            assertValidToken();
+            params = new Param[]{new Param("accessToken", getTokenDetails().token) };
+            break;
         }
         return params;
     }
@@ -847,9 +829,7 @@ public class Auth {
      * Renew auth credentials.
      * Will obtain a new token, even if we already have an apparently valid one.
      * Authorization will use the parameters supplied on construction.
-     *
-     * @deprecated this method is deprecated
-     * Please use  {@link Auth#renewAuth()} instead.
+     * @deprecated Use {@link Auth#renewAuth} instead
      */
     @Deprecated
     public TokenDetails renew() throws AblyException {
@@ -862,23 +842,24 @@ public class Auth {
      * Renew auth credentials.
      * Will obtain a new token, even if we already have an apparently valid one.
      * Authorization will use the parameters supplied on construction.
+     *
+     * @return
+     * A single entry that contain a token detail and a future that represent an asynchronous result
+     * Clients must wait for the future result to finish before processing. If there is an exception happened during
+     * asynchronous operation the future will contain an AblyException
      */
     public Map.Entry<TokenDetails, Future<AblyException>> renewAuth() throws AblyException {
         final TokenDetails tokenDetails = assertValidToken(this.tokenParams, this.authOptions, true);
         return new AbstractMap.SimpleImmutableEntry<>(tokenDetails, ably.onAuthUpdatedAsync(tokenDetails.token));
     }
 
-    //add a new method renewAuthorization -
-
     public void onAuthError(ErrorInfo err) {
         /* we're only interested in token expiry errors */
-        if (err.code >= 40140 && err.code < 40150)
+        if(err.code >= 40140 && err.code < 40150)
             clearTokenDetails();
     }
 
-    public static long timestamp() {
-        return System.currentTimeMillis();
-    }
+    public static long timestamp() { return System.currentTimeMillis(); }
 
     /********************
      * internal
@@ -886,7 +867,6 @@ public class Auth {
 
     /**
      * Private constructor.
-     *
      * @param ably
      * @param options
      * @throws AblyException
@@ -895,11 +875,11 @@ public class Auth {
         this.ably = ably;
         authOptions = options;
         tokenParams = options.defaultTokenParams != null ?
-            options.defaultTokenParams : new TokenParams();
+                options.defaultTokenParams : new TokenParams();
 
         /* set clientId (spec Rsa7b1) */
-        if (options.clientId != null) {
-            if (options.clientId.equals(WILDCARD_CLIENTID)) {
+        if(options.clientId != null) {
+            if(options.clientId.equals(WILDCARD_CLIENTID)) {
                 /* RSA7c */
                 throw AblyException.fromErrorInfo(new ErrorInfo("Disallowed wildcard clientId in ClientOptions", 400, 40000));
             }
@@ -910,12 +890,12 @@ public class Auth {
         }
 
         /* decide default auth method (spec: RSA4) */
-        if (authOptions.key != null) {
-            if (!options.useTokenAuth &&
-                options.token == null &&
-                options.tokenDetails == null &&
-                options.authCallback == null &&
-                options.authUrl == null) {
+        if(authOptions.key != null) {
+            if(!options.useTokenAuth &&
+                    options.token == null &&
+                    options.tokenDetails == null &&
+                    options.authCallback == null &&
+                    options.authUrl == null) {
                 /* we have the key and do not need to authenticate the client,
                  * so default to using basic auth */
                 Log.i("Auth()", "anonymous, using basic auth");
@@ -927,21 +907,22 @@ public class Auth {
         }
         /* using token auth, but decide the method */
         this.method = AuthMethod.token;
-        if (authOptions.token != null) {
+        if(authOptions.token != null) {
             setTokenDetails(authOptions.token);
-        } else if (authOptions.tokenDetails != null) {
+        }
+        else if(authOptions.tokenDetails != null) {
             setTokenDetails(authOptions.tokenDetails);
         }
 
-        if (authOptions.authCallback != null) {
+        if(authOptions.authCallback != null) {
             Log.i("Auth()", "using token auth with authCallback");
-        } else if (authOptions.authUrl != null) {
+        } else if(authOptions.authUrl != null) {
             /* verify configured URL parses */
             HttpUtils.parseUrl(authOptions.authUrl);
             Log.i("Auth()", "using token auth with authUrl");
-        } else if (authOptions.key != null) {
+        } else if(authOptions.key != null) {
             Log.i("Auth()", "using token auth with client-side signing");
-        } else if (tokenDetails != null) {
+        } else if(tokenDetails != null) {
             Log.i("Auth()", "using token auth with supplied token only");
         } else {
             /* no means to authenticate (Spec: RSA14) */
@@ -986,8 +967,8 @@ public class Auth {
 
     private TokenDetails assertValidToken(TokenParams params, AuthOptions options, boolean force) throws AblyException {
         Log.i("Auth.assertValidToken()", "");
-        if (tokenDetails != null) {
-            if (!force && (tokenDetails.expires == 0 || tokenValid(tokenDetails))) {
+        if(tokenDetails != null) {
+            if(!force && (tokenDetails.expires == 0 || tokenValid(tokenDetails))) {
                 Log.i("Auth.assertValidToken()", "using cached token; expires = " + tokenDetails.expires);
                 return tokenDetails;
             } else {
@@ -1008,16 +989,15 @@ public class Auth {
 
     /**
      * Get the Authorization header, forcing the creation of a new token if requested
-     *
      * @param forceRenew
      * @return
      * @throws AblyException
      */
     public void assertAuthorizationHeader(boolean forceRenew) throws AblyException {
-        if (authHeader != null && !forceRenew) {
+        if(authHeader != null && !forceRenew) {
             return;
         }
-        if (getAuthMethod() == AuthMethod.basic) {
+        if(getAuthMethod() == AuthMethod.basic) {
             authHeader = "Basic " + Base64Coder.encodeString(getBasicCredentials());
         } else {
             if (forceRenew) {
@@ -1033,9 +1013,7 @@ public class Auth {
         return authHeader;
     }
 
-    private static String random() {
-        return String.format(Locale.ROOT, "%016d", (long) (Math.random() * 1E16));
-    }
+    private static String random() { return String.format(Locale.ROOT, "%016d", (long)(Math.random() * 1E16)); }
 
     private static boolean equalNullableStrings(String one, String two) {
         return (one == null) ? (two == null) : one.equals(two);
@@ -1046,38 +1024,34 @@ public class Auth {
             Mac mac = Mac.getInstance("HmacSHA256");
             mac.init(new SecretKeySpec(key.getBytes(Charset.forName("UTF-8")), "HmacSHA256"));
             return new String(Base64Coder.encode(mac.doFinal(text.getBytes(Charset.forName("UTF-8")))));
-        } catch (GeneralSecurityException e) {
-            Log.e("Auth.hmac", "Unexpected exception", e);
-            return null;
-        }
+        } catch (GeneralSecurityException e) { Log.e("Auth.hmac", "Unexpected exception", e); return null; }
     }
 
     /**
      * Set the clientId, after first initialisation in the construction of the library
      * therefore an existing null value is significant - it means that ClientOptions.clientId
      * was null
-     *
      * @param clientId
      * @throws AblyException
      */
     public void setClientId(String clientId) throws AblyException {
-        if (clientId == null) {
+        if(clientId == null) {
             /* do nothing - we received a token without a clientId */
             return;
         }
 
-        if (this.clientId == null) {
+        if(this.clientId == null) {
             /* RSA12a, RSA12b, RSA7b2, RSA7b3, RSA7b4: the given clientId is now our clientId */
             this.clientId = clientId;
             this.ably.onClientIdSet(clientId);
             return;
         }
         /* now this.clientId != null */
-        if (this.clientId.equals(clientId)) {
+        if(this.clientId.equals(clientId)) {
             /* this includes the wildcard case RSA7b4 */
             return;
         }
-        if (WILDCARD_CLIENTID.equals(clientId)) {
+        if(WILDCARD_CLIENTID.equals(clientId)) {
             /* this signifies that the credentials permit the use of any specific clientId */
             return;
         }
@@ -1087,10 +1061,9 @@ public class Auth {
     /**
      * Verify that a message, possibly containing a clientId,
      * is compatible with Auth.clientId if it is set
-     *
      * @param msg
      * @param allowNullClientId true if it is ok for there to be no resolved clientId
-     * @param connected         true if connected; if false it is ok for the library to be unidentified
+     * @param connected true if connected; if false it is ok for the library to be unidentified
      * @return the resolved clientId
      * @throws AblyException
      */
@@ -1098,22 +1071,22 @@ public class Auth {
         /* Check that the message doesn't contain the disallowed wildcard clientId
          * RTL6g3 */
         String msgClientId = msg.clientId;
-        if (WILDCARD_CLIENTID.equals(msgClientId)) {
+        if(WILDCARD_CLIENTID.equals(msgClientId)) {
             throw AblyException.fromErrorInfo(new ErrorInfo("Invalid wildcard clientId specified in message", 400, 40000));
         }
 
         /* Check that any clientId given in the message is compatible with the library clientId */
         boolean undeterminedClientId = (clientId == null && !connected);
-        if (msgClientId != null) {
-            if (msgClientId.equals(clientId) || WILDCARD_CLIENTID.equals(clientId) || undeterminedClientId) {
+        if(msgClientId != null) {
+            if(msgClientId.equals(clientId) || WILDCARD_CLIENTID.equals(clientId) || undeterminedClientId) {
                 /* RTL6g4: be lenient checking against a null clientId if we're not connected */
                 return msgClientId;
             }
             throw AblyException.fromErrorInfo(new ErrorInfo("Incompatible clientId specified in message", 400, 40012));
         }
 
-        if (clientId == null || clientId.equals(WILDCARD_CLIENTID)) {
-            if (allowNullClientId || undeterminedClientId) {
+        if(clientId == null || clientId.equals(WILDCARD_CLIENTID)) {
+            if(allowNullClientId || undeterminedClientId) {
                 /* the message is sent with no clientId */
                 return null;
             }
@@ -1152,10 +1125,9 @@ public class Auth {
      * Time delta between System.nanoTime() and System.currentTimeMillis. If it changes significantly it
      * suggests device time/date has changed
      */
-    private long nanoTimeDelta = System.currentTimeMillis() - System.nanoTime() / (1000 * 1000);
+    private long nanoTimeDelta = System.currentTimeMillis() - System.nanoTime()/(1000*1000);
 
     public static final String WILDCARD_CLIENTID = "*";
-
     /**
      * For testing purposes we need method to clear cached timeDelta
      */

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -3,9 +3,11 @@ package io.ably.lib.rest;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.security.GeneralSecurityException;
+import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.Future;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -18,6 +20,7 @@ import io.ably.lib.http.HttpConstants;
 import io.ably.lib.http.HttpCore;
 import io.ably.lib.http.HttpHelpers;
 import io.ably.lib.http.HttpUtils;
+import io.ably.lib.realtime.ConnectionState;
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.BaseMessage;
 import io.ably.lib.types.Capability;
@@ -32,7 +35,6 @@ import io.ably.lib.util.Serialisation;
  * Token-generation and authentication operations for the Ably API.
  * See the Ably Authentication documentation for details of the
  * authentication methods available.
- *
  */
 public class Auth {
 
@@ -119,11 +121,13 @@ public class Auth {
         /**
          * Default constructor
          */
-        public AuthOptions() {}
+        public AuthOptions() {
+        }
 
         /**
          * Convenience constructor, to create an AuthOptions based
          * on the key string obtained from the application dashboard.
+         *
          * @param key the full key string as obtained from the dashboard
          * @throws AblyException
          */
@@ -134,7 +138,7 @@ public class Auth {
             if (key.isEmpty()) {
                 throw new IllegalArgumentException("Key string cannot be empty");
             }
-            if(key.indexOf(':') > -1)
+            if (key.indexOf(':') > -1)
                 this.key = key;
             else
                 this.token = key;
@@ -184,7 +188,6 @@ public class Auth {
     /**
      * A class providing details of a token and its associated metadata,
      * provided when the system successfully requests a token from the system.
-     *
      */
     public static class TokenDetails {
 
@@ -216,12 +219,17 @@ public class Auth {
          */
         public String clientId;
 
-        public TokenDetails() {}
-        public TokenDetails(String token) { this.token = token; }
+        public TokenDetails() {
+        }
+
+        public TokenDetails(String token) {
+            this.token = token;
+        }
 
         /**
          * Convert a JSON response body to a TokenDetails.
          * Deprecated: use fromJson() instead
+         *
          * @param json
          * @return
          */
@@ -233,6 +241,7 @@ public class Auth {
         /**
          * Convert a JSON element response body to a TokenDetails.
          * Spec: TD7
+         *
          * @param json
          * @return
          */
@@ -242,6 +251,7 @@ public class Auth {
 
         /**
          * Convert a JSON element response body to a TokenDetails.
+         *
          * @param json
          * @return
          */
@@ -253,7 +263,7 @@ public class Auth {
          * Convert a TokenDetails into a JSON object.
          */
         public JsonObject asJsonElement() {
-            return (JsonObject)Serialisation.gson.toJsonTree(this);
+            return (JsonObject) Serialisation.gson.toJsonTree(this);
         }
 
         /**
@@ -265,19 +275,20 @@ public class Auth {
 
         /**
          * Check equality of a TokenDetails
+         *
          * @param obj
          */
         @Override
         public boolean equals(Object obj) {
-            TokenDetails details = (TokenDetails)obj;
+            TokenDetails details = (TokenDetails) obj;
             return equalNullableStrings(this.token, details.token) &
-                    equalNullableStrings(this.capability, details.capability) &
-                    equalNullableStrings(this.clientId, details.clientId) &
-                    (this.issued == details.issued) &
-                    (this.expires == details.expires);
+                equalNullableStrings(this.capability, details.capability) &
+                equalNullableStrings(this.clientId, details.clientId) &
+                (this.issued == details.issued) &
+                (this.expires == details.expires);
         }
 
-}
+    }
 
     /**
      * A class providing parameters of a token request.
@@ -289,7 +300,7 @@ public class Auth {
          * is successful, the TTL of the returned token will be less
          * than or equal to this value depending on application settings
          * and the attributes of the issuing key.
-         *
+         * <p>
          * 0 means Ably will set it to the default value.
          */
         public long ttl;
@@ -316,28 +327,30 @@ public class Auth {
 
         /**
          * Internal; convert a TokenParams to a collection of Params
+         *
          * @return
          */
         public Map<String, Param> asMap() {
             Map<String, Param> params = new HashMap<String, Param>();
-            if(ttl > 0) params.put("ttl", new Param("ttl", String.valueOf(ttl)));
-            if(capability != null) params.put("capability", new Param("capability", capability));
-            if(clientId != null) params.put("clientId", new Param("clientId", clientId));
-            if(timestamp > 0) params.put("timestamp", new Param("timestamp", String.valueOf(timestamp)));
+            if (ttl > 0) params.put("ttl", new Param("ttl", String.valueOf(ttl)));
+            if (capability != null) params.put("capability", new Param("capability", capability));
+            if (clientId != null) params.put("clientId", new Param("clientId", clientId));
+            if (timestamp > 0) params.put("timestamp", new Param("timestamp", String.valueOf(timestamp)));
             return params;
         }
 
         /**
          * Check equality of a TokenParams
+         *
          * @param obj
          */
         @Override
         public boolean equals(Object obj) {
-            TokenParams params = (TokenParams)obj;
+            TokenParams params = (TokenParams) obj;
             return (this.ttl == params.ttl) &
-                    equalNullableStrings(this.capability, params.capability) &
-                    equalNullableStrings(this.clientId, params.clientId) &
-                    (this.timestamp == params.timestamp);
+                equalNullableStrings(this.capability, params.capability) &
+                equalNullableStrings(this.clientId, params.clientId) &
+                (this.timestamp == params.timestamp);
         }
 
         /**
@@ -375,7 +388,8 @@ public class Auth {
      */
     public static class TokenRequest extends TokenParams {
 
-        public TokenRequest() {}
+        public TokenRequest() {
+        }
 
         public TokenRequest(TokenParams params) {
             this.ttl = params.ttl;
@@ -405,6 +419,7 @@ public class Auth {
         /**
          * Convert a JSON serialisation to a TokenParams.
          * Deprecated: use fromJson() instead
+         *
          * @param json
          * @return
          */
@@ -415,6 +430,7 @@ public class Auth {
 
         /**
          * Convert a parsed JSON response body to a TokenParams.
+         *
          * @param json
          * @return
          */
@@ -425,6 +441,7 @@ public class Auth {
         /**
          * Convert a string JSON response body to a TokenParams.
          * Spec: TE6
+         *
          * @param json
          * @return
          */
@@ -436,7 +453,7 @@ public class Auth {
          * Convert a TokenParams into a JSON object.
          */
         public JsonObject asJsonElement() {
-            JsonObject o = (JsonObject)Serialisation.gson.toJsonTree(this);
+            JsonObject o = (JsonObject) Serialisation.gson.toJsonTree(this);
             if (this.ttl == 0) {
                 o.remove("ttl");
             }
@@ -455,15 +472,16 @@ public class Auth {
 
         /**
          * Check equality of a TokenRequest
+         *
          * @param obj
          */
         @Override
         public boolean equals(Object obj) {
-            TokenRequest request = (TokenRequest)obj;
+            TokenRequest request = (TokenRequest) obj;
             return super.equals(obj) &
-                    equalNullableStrings(this.keyName, request.keyName) &
-                    equalNullableStrings(this.nonce, request.nonce) &
-                    equalNullableStrings(this.mac, request.mac);
+                equalNullableStrings(this.keyName, request.keyName) &
+                equalNullableStrings(this.nonce, request.nonce) &
+                equalNullableStrings(this.mac, request.mac);
         }
     }
 
@@ -488,28 +506,26 @@ public class Auth {
      * Authorization will use the parameters supplied on construction except
      * where overridden with the options supplied in the call.
      *
-     * @param params
-     * an object containing the request params:
-     * - key:        (optional) the key to use; if not specified, the key
-     *               passed in constructing the Rest interface may be used
-     *
-     * - ttl:        (optional) the requested life of any new token in ms. If none
-     *               is specified a default of 1 hour is provided. The maximum lifetime
-     *               is 24hours; any request exceeding that lifetime will be rejected
-     *               with an error.
-     *
-     * - capability: (optional) the capability to associate with the access token.
-     *               If none is specified, a token will be requested with all of the
-     *               capabilities of the specified key.
-     *
-     * - clientId:   (optional) a client Id to associate with the token
-     *
-     * - timestamp:  (optional) the time in ms since the epoch. If none is specified,
-     *               the system will be queried for a time value to use.
-     *
-     * - queryTime   (optional) boolean indicating that the Ably system should be
-     *               queried for the current time when none is specified explicitly.
-     *
+     * @param params  an object containing the request params:
+     *                - key:        (optional) the key to use; if not specified, the key
+     *                passed in constructing the Rest interface may be used
+     *                <p>
+     *                - ttl:        (optional) the requested life of any new token in ms. If none
+     *                is specified a default of 1 hour is provided. The maximum lifetime
+     *                is 24hours; any request exceeding that lifetime will be rejected
+     *                with an error.
+     *                <p>
+     *                - capability: (optional) the capability to associate with the access token.
+     *                If none is specified, a token will be requested with all of the
+     *                capabilities of the specified key.
+     *                <p>
+     *                - clientId:   (optional) a client Id to associate with the token
+     *                <p>
+     *                - timestamp:  (optional) the time in ms since the epoch. If none is specified,
+     *                the system will be queried for a time value to use.
+     *                <p>
+     *                - queryTime   (optional) boolean indicating that the Ably system should be
+     *                queried for the current time when none is specified explicitly.
      * @param options
      */
     public TokenDetails authorize(TokenParams params, AuthOptions options) throws AblyException {
@@ -529,7 +545,7 @@ public class Auth {
             authOptions.tokenDetails = new TokenDetails(authOptions.token);
         }
         TokenDetails tokenDetails;
-        if(authOptions.tokenDetails != null) {
+        if (authOptions.tokenDetails != null) {
             tokenDetails = authOptions.tokenDetails;
             setTokenDetails(tokenDetails);
         } else {
@@ -557,7 +573,8 @@ public class Auth {
     /**
      * Make a token request. This will make a token request now, even if the library already
      * has a valid token. It would typically be used to issue tokens for use by other clients.
-     * @param params : see {@link #authorize} for params
+     *
+     * @param params       : see {@link #authorize} for params
      * @param tokenOptions : see {@link #authorize} for options
      * @return the TokenDetails
      * @throws AblyException
@@ -568,30 +585,30 @@ public class Auth {
         params = (params == null) ? this.tokenParams : params.copy();
 
         /* Spec: RSA7d */
-        if(params.clientId == null) {
+        if (params.clientId == null) {
             params.clientId = ably.options.clientId;
         }
         params.capability = Capability.c14n(params.capability);
 
         /* get the signed token request */
         TokenRequest signedTokenRequest;
-        if(tokenOptions.authCallback != null) {
+        if (tokenOptions.authCallback != null) {
             Log.i("Auth.requestToken()", "using token auth with auth_callback");
             try {
                 /* the callback can return either a signed token request, or a TokenDetails */
                 Object authCallbackResponse = tokenOptions.authCallback.getTokenRequest(params);
-                if(authCallbackResponse instanceof String)
-                    return new TokenDetails((String)authCallbackResponse);
-                if(authCallbackResponse instanceof TokenDetails)
-                    return (TokenDetails)authCallbackResponse;
-                if(authCallbackResponse instanceof TokenRequest)
-                    signedTokenRequest = (TokenRequest)authCallbackResponse;
+                if (authCallbackResponse instanceof String)
+                    return new TokenDetails((String) authCallbackResponse);
+                if (authCallbackResponse instanceof TokenDetails)
+                    return (TokenDetails) authCallbackResponse;
+                if (authCallbackResponse instanceof TokenRequest)
+                    signedTokenRequest = (TokenRequest) authCallbackResponse;
                 else
                     throw AblyException.fromErrorInfo(new ErrorInfo("Invalid authCallback response", 400, 40000));
-            } catch(AblyException e) {
+            } catch (AblyException e) {
                 throw AblyException.fromErrorInfo(e, new ErrorInfo("authCallback failed with an exception", 401, 80019));
             }
-        } else if(tokenOptions.authUrl != null) {
+        } else if (tokenOptions.authUrl != null) {
             Log.i("Auth.requestToken()", "using token auth with auth_url");
 
             /* the auth request can return either a signed token request as a TokenParams, or a TokenDetails */
@@ -600,39 +617,39 @@ public class Auth {
                 HttpCore.ResponseHandler<Object> responseHandler = new HttpCore.ResponseHandler<Object>() {
                     @Override
                     public Object handleResponse(HttpCore.Response response, ErrorInfo error) throws AblyException {
-                        if(error != null) {
+                        if (error != null) {
                             throw AblyException.fromErrorInfo(error);
                         }
                         try {
                             String contentType = response.contentType;
                             byte[] body = response.body;
-                            if(body == null || body.length == 0) {
+                            if (body == null || body.length == 0) {
                                 return null;
                             }
-                            if(contentType != null) {
-                                if(contentType.startsWith("text/plain") || contentType.startsWith("application/jwt")) {
+                            if (contentType != null) {
+                                if (contentType.startsWith("text/plain") || contentType.startsWith("application/jwt")) {
                                     /* assumed to be token string */
                                     String token = new String(body);
                                     return new TokenDetails(token);
                                 }
-                                if(!contentType.startsWith("application/json")) {
+                                if (!contentType.startsWith("application/json")) {
                                     throw AblyException.fromErrorInfo(new ErrorInfo("Unacceptable content type from auth callback", 406, 40170));
                                 }
                             }
                             /* if not explicitly indicated, we will just assume it's JSON */
                             JsonElement json = Serialisation.gsonParser.parse(new String(body));
-                            if(!(json instanceof JsonObject)) {
+                            if (!(json instanceof JsonObject)) {
                                 throw AblyException.fromErrorInfo(new ErrorInfo("Unexpected response type from auth callback", 406, 40170));
                             }
-                            JsonObject jsonObject = (JsonObject)json;
-                            if(jsonObject.has("issued")) {
+                            JsonObject jsonObject = (JsonObject) json;
+                            if (jsonObject.has("issued")) {
                                 /* we assume this is a token details */
                                 return TokenDetails.fromJsonElement(jsonObject);
                             } else {
                                 /* otherwise it's a signed token request */
                                 return TokenRequest.fromJsonElement(jsonObject);
                             }
-                        } catch(JsonParseException e) {
+                        } catch (JsonParseException e) {
                             throw AblyException.fromErrorInfo(new ErrorInfo("Unable to parse response from auth callback", 406, 40170));
                         }
                     }
@@ -642,15 +659,15 @@ public class Auth {
                 Map<String, Param> urlParams = null;
                 URL authUrl = HttpUtils.parseUrl(authOptions.authUrl);
                 String queryString = authUrl.getQuery();
-                if(queryString != null && !queryString.isEmpty()) {
+                if (queryString != null && !queryString.isEmpty()) {
                     urlParams = HttpUtils.decodeParams(queryString);
                 }
                 Map<String, Param> tokenParams = params.asMap();
-                if(tokenOptions.authParams != null) {
-                    for(Param p : tokenOptions.authParams) {
+                if (tokenOptions.authParams != null) {
+                    for (Param p : tokenOptions.authParams) {
                         /* (RSA8c2) TokenParams take precedence over any configured
                          * authParams when a name conflict occurs */
-                        if(!tokenParams.containsKey(p.key)) {
+                        if (!tokenParams.containsKey(p.key)) {
                             tokenParams.put(p.key, p);
                         }
                     }
@@ -661,19 +678,19 @@ public class Auth {
                     Map<String, Param> requestParams = (urlParams != null) ? HttpUtils.mergeParams(urlParams, tokenParams) : tokenParams;
                     authUrlResponse = HttpHelpers.getUri(ably.httpCore, tokenOptions.authUrl, tokenOptions.authHeaders, HttpUtils.flattenParams(requestParams), responseHandler);
                 }
-            } catch(AblyException e) {
+            } catch (AblyException e) {
                 throw AblyException.fromErrorInfo(e, new ErrorInfo("authUrl failed with an exception", e.errorInfo.statusCode, 80019));
             }
-            if(authUrlResponse == null) {
+            if (authUrlResponse == null) {
                 throw AblyException.fromErrorInfo(null, new ErrorInfo("Empty response received from authUrl", 401, 80019));
             }
-            if(authUrlResponse instanceof TokenDetails) {
+            if (authUrlResponse instanceof TokenDetails) {
                 /* we're done */
-                return (TokenDetails)authUrlResponse;
+                return (TokenDetails) authUrlResponse;
             }
             /* otherwise it's a signed token request */
-            signedTokenRequest = (TokenRequest)authUrlResponse;
-        } else if(tokenOptions.key != null) {
+            signedTokenRequest = (TokenRequest) authUrlResponse;
+        } else if (tokenOptions.key != null) {
             Log.i("Auth.requestToken()", "using token auth with client-side signing");
             signedTokenRequest = createTokenRequest(params, tokenOptions);
         } else {
@@ -684,14 +701,14 @@ public class Auth {
         return HttpHelpers.postSync(ably.http, tokenPath, null, null, new HttpUtils.JsonRequestBody(signedTokenRequest.asJsonElement().toString()), new HttpCore.ResponseHandler<TokenDetails>() {
             @Override
             public TokenDetails handleResponse(HttpCore.Response response, ErrorInfo error) throws AblyException {
-                if(error != null) {
+                if (error != null) {
                     throw AblyException.fromErrorInfo(error);
                 }
                 try {
                     String jsonText = new String(response.body);
-                    JsonObject json = (JsonObject)Serialisation.gsonParser.parse(jsonText);
+                    JsonObject json = (JsonObject) Serialisation.gsonParser.parse(jsonText);
                     return TokenDetails.fromJsonElement(json);
-                } catch(JsonParseException e) {
+                } catch (JsonParseException e) {
                     throw AblyException.fromThrowable(e);
                 }
             }
@@ -702,7 +719,8 @@ public class Auth {
      * Create a signed token request based on known credentials
      * and the given token params. This would typically be used if creating
      * signed requests for submission by another client.
-     * @param params : see {@link #authorize} for params
+     *
+     * @param params  : see {@link #authorize} for params
      * @param options : see {@link #authorize} for options
      * @return the params augmented with the mac.
      * @throws AblyException
@@ -716,17 +734,17 @@ public class Auth {
         TokenRequest request = new TokenRequest(params);
 
         String key = options.key;
-        if(key == null)
+        if (key == null)
             throw AblyException.fromErrorInfo(new ErrorInfo("No key specified", 401, 40101));
 
         String[] keyParts = key.split(":");
-        if(keyParts.length != 2)
+        if (keyParts.length != 2)
             throw AblyException.fromErrorInfo(new ErrorInfo("Invalid key specified", 401, 40101));
 
         String keyName = keyParts[0], keySecret = keyParts[1];
-        if(request.keyName == null)
+        if (request.keyName == null)
             request.keyName = keyName;
-        else if(!request.keyName.equals(keyName))
+        else if (!request.keyName.equals(keyName))
             throw AblyException.fromErrorInfo(new ErrorInfo("Incompatible keys specified", 401, 40102));
 
         /* expires */
@@ -740,14 +758,14 @@ public class Auth {
         String clientIdText = (request.clientId == null) ? "" : request.clientId;
 
         /* timestamp */
-        if(request.timestamp == 0) {
-            if(options.queryTime) {
+        if (request.timestamp == 0) {
+            if (options.queryTime) {
                 long oldNanoTimeDelta = nanoTimeDelta;
-                long currentNanoTimeDelta = System.currentTimeMillis() - System.nanoTime()/(1000*1000);
+                long currentNanoTimeDelta = System.currentTimeMillis() - System.nanoTime() / (1000 * 1000);
 
                 if (timeDelta != Long.MAX_VALUE) {
                     /* system time changed by more than 500ms since last time? */
-                    if(Math.abs(oldNanoTimeDelta - currentNanoTimeDelta) > 500)
+                    if (Math.abs(oldNanoTimeDelta - currentNanoTimeDelta) > 500)
                         timeDelta = Long.MAX_VALUE;
                 }
 
@@ -758,8 +776,7 @@ public class Auth {
                     request.timestamp = ably.time();
                     timeDelta = request.timestamp - timestamp();
                 }
-            }
-            else {
+            } else {
                 request.timestamp = timestamp();
             }
         }
@@ -783,6 +800,7 @@ public class Auth {
 
     /**
      * Get the authentication method for this library instance.
+     *
      * @return
      */
     public AuthMethod getAuthMethod() {
@@ -791,6 +809,7 @@ public class Auth {
 
     /**
      * Get the credentials for HTTP basic auth, if available.
+     *
      * @return
      */
     public String getBasicCredentials() {
@@ -799,19 +818,20 @@ public class Auth {
 
     /**
      * Get query params representing the current authentication method and credentials.
+     *
      * @return
      * @throws AblyException
      */
     public Param[] getAuthParams() throws AblyException {
         Param[] params = null;
-        switch(method) {
-        case basic:
-            params = new Param[]{new Param("key", authOptions.key) };
-            break;
-        case token:
-            assertValidToken();
-            params = new Param[]{new Param("accessToken", getTokenDetails().token) };
-            break;
+        switch (method) {
+            case basic:
+                params = new Param[]{new Param("key", authOptions.key)};
+                break;
+            case token:
+                assertValidToken();
+                params = new Param[]{new Param("accessToken", getTokenDetails().token)};
+                break;
         }
         return params;
     }
@@ -827,7 +847,7 @@ public class Auth {
      * Renew auth credentials.
      * Will obtain a new token, even if we already have an apparently valid one.
      * Authorization will use the parameters supplied on construction.
-
+     *
      * @deprecated this method is deprecated
      * Please use  {@link Auth#renewAuth()} instead.
      */
@@ -843,21 +863,22 @@ public class Auth {
      * Will obtain a new token, even if we already have an apparently valid one.
      * Authorization will use the parameters supplied on construction.
      */
-    public TokenDetails renewAuth() throws AblyException {
-        TokenDetails tokenDetails = assertValidToken(this.tokenParams, this.authOptions, true);
-        ably.onAuthUpdated(tokenDetails.token, true);
-        return tokenDetails;
+    public Map.Entry<TokenDetails, Future<AblyException>> renewAuth() throws AblyException {
+        final TokenDetails tokenDetails = assertValidToken(this.tokenParams, this.authOptions, true);
+        return new AbstractMap.SimpleImmutableEntry<>(tokenDetails, ably.onAuthUpdatedAsync(tokenDetails.token));
     }
 
     //add a new method renewAuthorization -
 
     public void onAuthError(ErrorInfo err) {
         /* we're only interested in token expiry errors */
-        if(err.code >= 40140 && err.code < 40150)
+        if (err.code >= 40140 && err.code < 40150)
             clearTokenDetails();
     }
 
-    public static long timestamp() { return System.currentTimeMillis(); }
+    public static long timestamp() {
+        return System.currentTimeMillis();
+    }
 
     /********************
      * internal
@@ -865,6 +886,7 @@ public class Auth {
 
     /**
      * Private constructor.
+     *
      * @param ably
      * @param options
      * @throws AblyException
@@ -873,11 +895,11 @@ public class Auth {
         this.ably = ably;
         authOptions = options;
         tokenParams = options.defaultTokenParams != null ?
-                options.defaultTokenParams : new TokenParams();
+            options.defaultTokenParams : new TokenParams();
 
         /* set clientId (spec Rsa7b1) */
-        if(options.clientId != null) {
-            if(options.clientId.equals(WILDCARD_CLIENTID)) {
+        if (options.clientId != null) {
+            if (options.clientId.equals(WILDCARD_CLIENTID)) {
                 /* RSA7c */
                 throw AblyException.fromErrorInfo(new ErrorInfo("Disallowed wildcard clientId in ClientOptions", 400, 40000));
             }
@@ -888,12 +910,12 @@ public class Auth {
         }
 
         /* decide default auth method (spec: RSA4) */
-        if(authOptions.key != null) {
-            if(!options.useTokenAuth &&
-                    options.token == null &&
-                    options.tokenDetails == null &&
-                    options.authCallback == null &&
-                    options.authUrl == null) {
+        if (authOptions.key != null) {
+            if (!options.useTokenAuth &&
+                options.token == null &&
+                options.tokenDetails == null &&
+                options.authCallback == null &&
+                options.authUrl == null) {
                 /* we have the key and do not need to authenticate the client,
                  * so default to using basic auth */
                 Log.i("Auth()", "anonymous, using basic auth");
@@ -905,22 +927,21 @@ public class Auth {
         }
         /* using token auth, but decide the method */
         this.method = AuthMethod.token;
-        if(authOptions.token != null) {
+        if (authOptions.token != null) {
             setTokenDetails(authOptions.token);
-        }
-        else if(authOptions.tokenDetails != null) {
+        } else if (authOptions.tokenDetails != null) {
             setTokenDetails(authOptions.tokenDetails);
         }
 
-        if(authOptions.authCallback != null) {
+        if (authOptions.authCallback != null) {
             Log.i("Auth()", "using token auth with authCallback");
-        } else if(authOptions.authUrl != null) {
+        } else if (authOptions.authUrl != null) {
             /* verify configured URL parses */
             HttpUtils.parseUrl(authOptions.authUrl);
             Log.i("Auth()", "using token auth with authUrl");
-        } else if(authOptions.key != null) {
+        } else if (authOptions.key != null) {
             Log.i("Auth()", "using token auth with client-side signing");
-        } else if(tokenDetails != null) {
+        } else if (tokenDetails != null) {
             Log.i("Auth()", "using token auth with supplied token only");
         } else {
             /* no means to authenticate (Spec: RSA14) */
@@ -965,8 +986,8 @@ public class Auth {
 
     private TokenDetails assertValidToken(TokenParams params, AuthOptions options, boolean force) throws AblyException {
         Log.i("Auth.assertValidToken()", "");
-        if(tokenDetails != null) {
-            if(!force && (tokenDetails.expires == 0 || tokenValid(tokenDetails))) {
+        if (tokenDetails != null) {
+            if (!force && (tokenDetails.expires == 0 || tokenValid(tokenDetails))) {
                 Log.i("Auth.assertValidToken()", "using cached token; expires = " + tokenDetails.expires);
                 return tokenDetails;
             } else {
@@ -987,15 +1008,16 @@ public class Auth {
 
     /**
      * Get the Authorization header, forcing the creation of a new token if requested
+     *
      * @param forceRenew
      * @return
      * @throws AblyException
      */
     public void assertAuthorizationHeader(boolean forceRenew) throws AblyException {
-        if(authHeader != null && !forceRenew) {
+        if (authHeader != null && !forceRenew) {
             return;
         }
-        if(getAuthMethod() == AuthMethod.basic) {
+        if (getAuthMethod() == AuthMethod.basic) {
             authHeader = "Basic " + Base64Coder.encodeString(getBasicCredentials());
         } else {
             if (forceRenew) {
@@ -1011,7 +1033,9 @@ public class Auth {
         return authHeader;
     }
 
-    private static String random() { return String.format(Locale.ROOT, "%016d", (long)(Math.random() * 1E16)); }
+    private static String random() {
+        return String.format(Locale.ROOT, "%016d", (long) (Math.random() * 1E16));
+    }
 
     private static boolean equalNullableStrings(String one, String two) {
         return (one == null) ? (two == null) : one.equals(two);
@@ -1022,34 +1046,38 @@ public class Auth {
             Mac mac = Mac.getInstance("HmacSHA256");
             mac.init(new SecretKeySpec(key.getBytes(Charset.forName("UTF-8")), "HmacSHA256"));
             return new String(Base64Coder.encode(mac.doFinal(text.getBytes(Charset.forName("UTF-8")))));
-        } catch (GeneralSecurityException e) { Log.e("Auth.hmac", "Unexpected exception", e); return null; }
+        } catch (GeneralSecurityException e) {
+            Log.e("Auth.hmac", "Unexpected exception", e);
+            return null;
+        }
     }
 
     /**
      * Set the clientId, after first initialisation in the construction of the library
      * therefore an existing null value is significant - it means that ClientOptions.clientId
      * was null
+     *
      * @param clientId
      * @throws AblyException
      */
     public void setClientId(String clientId) throws AblyException {
-        if(clientId == null) {
+        if (clientId == null) {
             /* do nothing - we received a token without a clientId */
             return;
         }
 
-        if(this.clientId == null) {
+        if (this.clientId == null) {
             /* RSA12a, RSA12b, RSA7b2, RSA7b3, RSA7b4: the given clientId is now our clientId */
             this.clientId = clientId;
             this.ably.onClientIdSet(clientId);
             return;
         }
         /* now this.clientId != null */
-        if(this.clientId.equals(clientId)) {
+        if (this.clientId.equals(clientId)) {
             /* this includes the wildcard case RSA7b4 */
             return;
         }
-        if(WILDCARD_CLIENTID.equals(clientId)) {
+        if (WILDCARD_CLIENTID.equals(clientId)) {
             /* this signifies that the credentials permit the use of any specific clientId */
             return;
         }
@@ -1059,9 +1087,10 @@ public class Auth {
     /**
      * Verify that a message, possibly containing a clientId,
      * is compatible with Auth.clientId if it is set
+     *
      * @param msg
      * @param allowNullClientId true if it is ok for there to be no resolved clientId
-     * @param connected true if connected; if false it is ok for the library to be unidentified
+     * @param connected         true if connected; if false it is ok for the library to be unidentified
      * @return the resolved clientId
      * @throws AblyException
      */
@@ -1069,22 +1098,22 @@ public class Auth {
         /* Check that the message doesn't contain the disallowed wildcard clientId
          * RTL6g3 */
         String msgClientId = msg.clientId;
-        if(WILDCARD_CLIENTID.equals(msgClientId)) {
+        if (WILDCARD_CLIENTID.equals(msgClientId)) {
             throw AblyException.fromErrorInfo(new ErrorInfo("Invalid wildcard clientId specified in message", 400, 40000));
         }
 
         /* Check that any clientId given in the message is compatible with the library clientId */
         boolean undeterminedClientId = (clientId == null && !connected);
-        if(msgClientId != null) {
-            if(msgClientId.equals(clientId) || WILDCARD_CLIENTID.equals(clientId) || undeterminedClientId) {
+        if (msgClientId != null) {
+            if (msgClientId.equals(clientId) || WILDCARD_CLIENTID.equals(clientId) || undeterminedClientId) {
                 /* RTL6g4: be lenient checking against a null clientId if we're not connected */
                 return msgClientId;
             }
             throw AblyException.fromErrorInfo(new ErrorInfo("Incompatible clientId specified in message", 400, 40012));
         }
 
-        if(clientId == null || clientId.equals(WILDCARD_CLIENTID)) {
-            if(allowNullClientId || undeterminedClientId) {
+        if (clientId == null || clientId.equals(WILDCARD_CLIENTID)) {
+            if (allowNullClientId || undeterminedClientId) {
                 /* the message is sent with no clientId */
                 return null;
             }
@@ -1123,9 +1152,10 @@ public class Auth {
      * Time delta between System.nanoTime() and System.currentTimeMillis. If it changes significantly it
      * suggests device time/date has changed
      */
-    private long nanoTimeDelta = System.currentTimeMillis() - System.nanoTime()/(1000*1000);
+    private long nanoTimeDelta = System.currentTimeMillis() - System.nanoTime() / (1000 * 1000);
 
     public static final String WILDCARD_CLIENTID = "*";
+
     /**
      * For testing purposes we need method to clear cached timeDelta
      */

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1032,6 +1032,7 @@ public class ConnectionManager implements ConnectListener {
                     final ConnectionState connectionState = currentState.state;
                     switch (connectionState) {
                         case connected:
+                            authUpdateResult.onUpdate(true, null);
                             Log.v(TAG, "onAuthUpdated: got connected");
                             waitingForConnected = false;
                             break;
@@ -1048,7 +1049,6 @@ public class ConnectionManager implements ConnectListener {
                             waitingForConnected = false;
                     }
                 }
-                authUpdateResult.onUpdate(true, null);
             });
         } finally {
             waiter.close();

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -35,6 +35,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 public class ConnectionManager implements ConnectListener {
+    final ExecutorService singleThreadExecutor = Executors.newSingleThreadExecutor();
+    final ExecutorCompletionService<AblyException> executorCompletionService = new ExecutorCompletionService<>(singleThreadExecutor);
 
     /**************************************************************
      * ConnectionManager
@@ -1023,9 +1025,7 @@ public class ConnectionManager implements ConnectListener {
             /* Wait for a currentState transition into anything other than connecting or
              * disconnected asynchrously and return a Future to the caller signifying completion.
              * This is the async alternative of above   */
-            final ExecutorService executor = Executors.newSingleThreadExecutor();
-            final ExecutorCompletionService<AblyException> service = new ExecutorCompletionService<>(executor);
-            return service.submit(() -> {
+            return executorCompletionService.submit(() -> {
                 boolean waitingForConnected = true;
                 while (waitingForConnected) {
                     final ErrorInfo reason = waiter.waitForChange();
@@ -1049,8 +1049,6 @@ public class ConnectionManager implements ConnectListener {
                 }
                 return null;
             });
-
-
         } finally {
             waiter.close();
         }

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1,5 +1,17 @@
 package io.ably.lib.transport;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
 import io.ably.lib.debug.DebugOptions;
 import io.ably.lib.debug.DebugOptions.RawProtocolListener;
 import io.ably.lib.http.HttpHelpers;
@@ -12,6 +24,7 @@ import io.ably.lib.realtime.ConnectionStateListener;
 import io.ably.lib.realtime.ConnectionStateListener.ConnectionStateChange;
 import io.ably.lib.transport.ITransport.ConnectListener;
 import io.ably.lib.transport.ITransport.TransportParams;
+import io.ably.lib.transport.NetworkConnectivity.NetworkConnectivityListener;
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.ClientOptions;
 import io.ably.lib.types.ConnectionDetails;
@@ -19,16 +32,7 @@ import io.ably.lib.types.ErrorInfo;
 import io.ably.lib.types.ProtocolMessage;
 import io.ably.lib.types.ProtocolSerializer;
 import io.ably.lib.util.Log;
-import io.ably.lib.transport.NetworkConnectivity.NetworkConnectivityListener;
 import io.ably.lib.util.PlatformAgentProvider;
-
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 
 public class ConnectionManager implements ConnectListener {
 
@@ -71,7 +75,9 @@ public class ConnectionManager implements ConnectListener {
      */
     public interface Channels {
         void onMessage(ProtocolMessage msg);
+
         void suspendAll(ErrorInfo error, boolean notifyStateChange);
+
         Iterable<Channel> values();
     }
 
@@ -129,6 +135,7 @@ public class ConnectionManager implements ConnectListener {
         /**
          * Called on the current state to determine the response to a
          * give state change request.
+         *
          * @param target: the state change request or event
          * @return StateIndication result: the determined response to
          * the request with the required state transition, if any. A
@@ -138,6 +145,7 @@ public class ConnectionManager implements ConnectListener {
 
         /**
          * Called when the timeout occurs for the current state.
+         *
          * @return StateIndication result: the determined response to
          * the timeout with the required state transition, if any. A
          * null result indicates that there is no resulting transition.
@@ -148,18 +156,19 @@ public class ConnectionManager implements ConnectListener {
 
         /**
          * Perform a transition to this state.
+         *
          * @param stateIndication: the transition request that triggered this transition
-         * @param change: the change event corresponding to this transition.
+         * @param change:          the change event corresponding to this transition.
          */
         void enact(StateIndication stateIndication, ConnectionStateChange change) {
-            if(change != null) {
+            if (change != null) {
                 /* if now connected, send queued messages, etc */
-                if(sendEvents) {
+                if (sendEvents) {
                     sendQueuedMessages();
-                } else if(!queueEvents) {
+                } else if (!queueEvents) {
                     failQueuedMessages(stateIndication.reason);
                 }
-                for(final Channel channel : channels.values()) {
+                for (final Channel channel : channels.values()) {
                     enactForChannel(stateIndication, change, channel);
                 }
             }
@@ -167,11 +176,13 @@ public class ConnectionManager implements ConnectListener {
 
         /**
          * Perform a transition to this state for a given channel.
+         *
          * @param stateIndication: the transition request that triggered this transition
-         * @param change: the change event corresponding to this transition.
-         * @param channel: the channel
+         * @param change:          the change event corresponding to this transition.
+         * @param channel:         the channel
          */
-        void enactForChannel(StateIndication stateIndication, ConnectionStateChange change, Channel channel) {}
+        void enactForChannel(StateIndication stateIndication, ConnectionStateChange change, Channel channel) {
+        }
     }
 
     /**************************************************
@@ -186,7 +197,7 @@ public class ConnectionManager implements ConnectListener {
         @Override
         StateIndication validateTransition(StateIndication target) {
             /* we can transition to any other state, other than ourselves */
-            if(target.state == this.state) {
+            if (target.state == this.state) {
                 return null;
             }
             return target;
@@ -231,7 +242,7 @@ public class ConnectionManager implements ConnectListener {
 
         @Override
         StateIndication validateTransition(StateIndication target) {
-            if(target.state == this.state) {
+            if (target.state == this.state) {
                 /* RTN24: no currentState change, so no transition, required, but there will be an update event;
                  * connected is special case because we want to deliver reauth notifications to listeners as an update */
                 addAction(new UpdateAction(null));
@@ -263,11 +274,11 @@ public class ConnectionManager implements ConnectListener {
         @Override
         StateIndication validateTransition(StateIndication target) {
             /* we can't transition to ourselves */
-            if(target.state == this.state) {
+            if (target.state == this.state) {
                 return null;
             }
             /* a closing event will transition directly to closed */
-            if(target.state == ConnectionState.closing) {
+            if (target.state == ConnectionState.closing) {
                 return new StateIndication(ConnectionState.closed);
             }
             /* otherwise, the transition is valid */
@@ -290,10 +301,10 @@ public class ConnectionManager implements ConnectListener {
         void enact(StateIndication stateIndication, ConnectionStateChange change) {
             super.enact(stateIndication, change);
             clearTransport();
-            if(change.previous == ConnectionState.connected) {
+            if (change.previous == ConnectionState.connected) {
                 setSuspendTime();
                 /* we were connected, so retry immediately */
-                if(!suppressRetry) {
+                if (!suppressRetry) {
                     requestState(ConnectionState.connecting);
                 }
             }
@@ -315,11 +326,11 @@ public class ConnectionManager implements ConnectListener {
         @Override
         StateIndication validateTransition(StateIndication target) {
             /* we can't transition to ourselves */
-            if(target.state == this.state) {
+            if (target.state == this.state) {
                 return null;
             }
             /* a closing event will transition directly to closed */
-            if(target.state == ConnectionState.closing) {
+            if (target.state == ConnectionState.closing) {
                 return new StateIndication(ConnectionState.closed);
             }
             /* otherwise, the transition is valid */
@@ -352,11 +363,11 @@ public class ConnectionManager implements ConnectListener {
         @Override
         StateIndication validateTransition(StateIndication target) {
             /* we can't transition to ourselves */
-            if(target.state == this.state) {
+            if (target.state == this.state) {
                 return null;
             }
             /* any disconnection event will transition directly to closed */
-            if(target.state == ConnectionState.disconnected || target.state == ConnectionState.suspended) {
+            if (target.state == ConnectionState.disconnected || target.state == ConnectionState.suspended) {
                 return new StateIndication(ConnectionState.closed);
             }
             /* otherwise, the transition is valid */
@@ -372,7 +383,7 @@ public class ConnectionManager implements ConnectListener {
         void enact(StateIndication stateIndication, ConnectionStateChange change) {
             super.enact(stateIndication, change);
             boolean closed = closeImpl();
-            if(closed) {
+            if (closed) {
                 addAction(new AsynchronousStateChangeAction(ConnectionState.closed));
             }
         }
@@ -392,7 +403,7 @@ public class ConnectionManager implements ConnectListener {
         @Override
         StateIndication validateTransition(StateIndication target) {
             /* we only leave the closed state via a connection attempt */
-            if(target.state == ConnectionState.connecting) {
+            if (target.state == ConnectionState.connecting) {
                 return target;
             }
             /* otherwise, the transition is not valid */
@@ -425,7 +436,7 @@ public class ConnectionManager implements ConnectListener {
         @Override
         StateIndication validateTransition(StateIndication target) {
             /* we only leave the failed state via a connection attempt */
-            if(target.state == ConnectionState.connecting) {
+            if (target.state == ConnectionState.connecting) {
                 return target;
             }
             /* otherwise, the transition is not valid */
@@ -458,7 +469,7 @@ public class ConnectionManager implements ConnectListener {
 
     /**
      * Listens for connection state changes.
-     *
+     * <p>
      * The close() method must be called when the ConnectionWaiter is no longer needed.
      */
     private class ConnectionWaiter implements ConnectionStateListener {
@@ -482,7 +493,10 @@ public class ConnectionManager implements ConnectListener {
 
             Log.d(TAG, "ConnectionWaiter.waitFor()");
             if (change == null) {
-                try { wait(); } catch(InterruptedException e) {}
+                try {
+                    wait();
+                } catch (InterruptedException e) {
+                }
             }
             Log.d(TAG, "ConnectionWaiter.waitFor done: currentState=" + currentState + ")");
             ErrorInfo reason = change.reason;
@@ -520,7 +534,8 @@ public class ConnectionManager implements ConnectListener {
     /**
      * A class that encapsulates actions to perform by the ConnectionManager
      */
-    private interface Action extends Runnable {}
+    private interface Action extends Runnable {
+    }
 
     /**
      * An class that performs a state transition
@@ -544,15 +559,15 @@ public class ConnectionManager implements ConnectListener {
         }
 
         protected void enactState() {
-            if(change != null) {
-                if(change.current != change.previous) {
+            if (change != null) {
+                if (change.current != change.previous) {
                     /* broadcast currentState change */
                     connection.onConnectionStateChange(change);
                 }
 
                 /* implement the state change */
                 states.get(stateIndication.state).enact(stateIndication, change);
-                if(currentState.terminal) {
+                if (currentState.terminal) {
                     clearTransport();
                 }
             }
@@ -583,7 +598,7 @@ public class ConnectionManager implements ConnectListener {
      * asynchronously. This applies to all transitions that are not transitions away from
      * the connected state.
      */
-    private class AsynchronousStateChangeAction extends StateChangeAction implements Action{
+    private class AsynchronousStateChangeAction extends StateChangeAction implements Action {
         AsynchronousStateChangeAction(ConnectionState state) {
             super(null, new StateIndication(state, null));
         }
@@ -649,6 +664,7 @@ public class ConnectionManager implements ConnectListener {
 
     /**
      * Append an action to the pending action queue
+     *
      * @param action: the action
      */
     private synchronized void addAction(Action action) {
@@ -662,7 +678,7 @@ public class ConnectionManager implements ConnectListener {
     class ActionHandler implements Runnable {
 
         public void run() {
-            while(true) {
+            while (true) {
                 /*
                  * Until we're committed to exit we:
                  * - wait for an action or timeout
@@ -671,10 +687,10 @@ public class ConnectionManager implements ConnectListener {
                  */
 
                 /* Hold the lock until we obtain an action */
-                synchronized(ConnectionManager.this) {
-                    while(actionQueue.size() == 0) {
+                synchronized (ConnectionManager.this) {
+                    while (actionQueue.size() == 0) {
                         /* if we're in a terminal state, then this thread is done */
-                        if(currentState.terminal) {
+                        if (currentState.terminal) {
                             /* indicate that this thread is committed to die */
                             handlerThread = null;
                             stopConnectivityListener();
@@ -703,10 +719,10 @@ public class ConnectionManager implements ConnectListener {
 
                 /* perform outstanding actions, without the ConnectionManager locked */
                 Action deferredAction;
-                while((deferredAction = actionQueue.poll()) != null) {
+                while ((deferredAction = actionQueue.poll()) != null) {
                     try {
                         deferredAction.run();
-                    } catch(Exception e) {
+                    } catch (Exception e) {
                         Log.e(TAG, "Action invocation failed with exception: action = " + deferredAction.toString(), e);
                     }
                 }
@@ -730,7 +746,7 @@ public class ConnectionManager implements ConnectListener {
         /* debug options */
         ITransport.Factory transportFactory = null;
         RawProtocolListener protocolListener = null;
-        if(options instanceof DebugOptions) {
+        if (options instanceof DebugOptions) {
             protocolListener = ((DebugOptions) options).protocolListener;
             transportFactory = ((DebugOptions) options).transportFactory;
         }
@@ -771,7 +787,7 @@ public class ConnectionManager implements ConnectListener {
 
     public synchronized void connect() {
         /* connect() is the only action that will bring the ConnectionManager out of a terminal currentState */
-        if(currentState.terminal || currentState.state == ConnectionState.initialized) {
+        if (currentState.terminal || currentState.state == ConnectionState.initialized) {
             startup();
         }
         requestState(ConnectionState.connecting);
@@ -829,11 +845,11 @@ public class ConnectionManager implements ConnectListener {
 
     public void ping(final CompletionListener listener) {
         HeartbeatWaiter waiter = new HeartbeatWaiter(listener);
-        if(currentState.state != ConnectionState.connected) {
+        if (currentState.state != ConnectionState.connected) {
             waiter.onError(new ErrorInfo("Unable to ping service; not connected", 40000, 400));
             return;
         }
-        synchronized(heartbeatWaiters) {
+        synchronized (heartbeatWaiters) {
             heartbeatWaiters.add(waiter);
             waiter.start();
         }
@@ -856,21 +872,21 @@ public class ConnectionManager implements ConnectListener {
 
         private void onSuccess() {
             clear();
-            if(listener != null) {
+            if (listener != null) {
                 listener.onSuccess();
             }
         }
 
         private void onError(ErrorInfo reason) {
             clear();
-            if(listener != null) {
+            if (listener != null) {
                 listener.onError(reason);
             }
         }
 
         private boolean clear() {
             boolean pending = heartbeatWaiters.remove(this);
-            if(pending) {
+            if (pending) {
                 interrupt();
             }
             return pending;
@@ -879,14 +895,14 @@ public class ConnectionManager implements ConnectListener {
         @Override
         public void run() {
             boolean pending;
-            synchronized(heartbeatWaiters) {
+            synchronized (heartbeatWaiters) {
                 try {
                     heartbeatWaiters.wait(HEARTBEAT_TIMEOUT);
                 } catch (InterruptedException ie) {
                 }
                 pending = clear();
             }
-            if(pending) {
+            if (pending) {
                 onError(new ErrorInfo("Timed out waiting for heartbeat response", 50000, 500));
             } else {
                 onSuccess();
@@ -907,7 +923,7 @@ public class ConnectionManager implements ConnectListener {
     public void onAuthUpdated(final String token, final boolean waitForResponse) throws AblyException {
         final ConnectionWaiter waiter = new ConnectionWaiter();
         try {
-            switch(currentState.state) {
+            switch (currentState.state) {
                 case connected:
                     /* (RTC8a) If the connection is in the CONNECTED currentState and
                      * auth.authorize is called or Ably requests a re-authentication
@@ -941,7 +957,7 @@ public class ConnectionManager implements ConnectListener {
                     break;
             }
 
-            if(!waitForResponse) {
+            if (!waitForResponse) {
                 return;
             }
 
@@ -975,6 +991,80 @@ public class ConnectionManager implements ConnectListener {
         }
     }
 
+    public Future<AblyException> onAuthUpdatedAsync(final String token) {
+        final ConnectionWaiter waiter = new ConnectionWaiter();
+        try {
+            switch (currentState.state) {
+                case connected:
+                    /* (RTC8a) If the connection is in the CONNECTED currentState and
+                     * auth.authorize is called or Ably requests a re-authentication
+                     * (see RTN22), the client must obtain a new token, then send an
+                     * AUTH ProtocolMessage to Ably with an auth attribute
+                     * containing an AuthDetails object with the token string. */
+                    try {
+                        ProtocolMessage msg = new ProtocolMessage(ProtocolMessage.Action.auth);
+                        msg.auth = new ProtocolMessage.AuthDetails(token);
+                        send(msg, false, null);
+                    } catch (AblyException e) {
+                        /* The send failed. Close the transport; if a subsequent
+                         * reconnect succeeds, it will be with the new token. */
+                        Log.v(TAG, "onAuthUpdated: closing transport after send failure");
+                        transport.close();
+                    }
+                    break;
+
+                case connecting:
+                    /* Close the connecting transport. */
+                    Log.v(TAG, "onAuthUpdated: closing connecting transport");
+                    ErrorInfo disconnectError = new ErrorInfo("Aborting incomplete connection with superseded auth params", 503, 80003);
+                    requestState(new StateIndication(ConnectionState.disconnected, disconnectError, null, null));
+                    /* Start a new connection attempt. */
+                    connect();
+                    break;
+
+                default:
+                    /* Start a new connection attempt. */
+                    connect();
+                    break;
+            }
+
+            /* Wait for a currentState transition into anything other than connecting or
+             * disconnected asynchrously and return a Future to the caller signifying completion.
+             * This is the async alternative of above   */
+            final ExecutorService executor = Executors.newSingleThreadExecutor();
+            final ExecutorCompletionService<AblyException> service = new ExecutorCompletionService<>(executor);
+            return service.submit(() -> {
+                boolean waitingForConnected = true;
+                while (waitingForConnected) {
+                    final ErrorInfo reason = waiter.waitForChange();
+                    final ConnectionState connectionState = currentState.state;
+                    switch (connectionState) {
+                        case connected:
+                            Log.v(TAG, "onAuthUpdated: got connected");
+                            waitingForConnected = false;
+                            break;
+
+                        case connecting:
+                        case disconnected:
+                            Log.v(TAG, "onAuthUpdated: " + connectionState);
+                            break;
+
+                        default:
+                            /* suspended/closed/error: throw the error. */
+                            Log.v(TAG, "onAuthUpdated: throwing exception");
+                            return AblyException.fromErrorInfo(reason);
+                    }
+                }
+                return null;
+            });
+
+
+        } finally {
+            waiter.close();
+        }
+    }
+
+
     /**
      * Called when where was an error during authentication attempt
      *
@@ -983,7 +1073,7 @@ public class ConnectionManager implements ConnectListener {
     public void onAuthError(ErrorInfo errorInfo) {
         Log.i(TAG, String.format(Locale.ROOT, "onAuthError: (%d) %s", errorInfo.code, errorInfo.message));
 
-        if(errorInfo.statusCode == 403) {
+        if (errorInfo.statusCode == 403) {
             ConnectionStateChange failedStateChange =
                 new ConnectionStateChange(
                     connection.state,
@@ -1019,6 +1109,7 @@ public class ConnectionManager implements ConnectListener {
 
     /**
      * React on message from the transport
+     *
      * @param transport transport instance or null to bypass transport correctness check (for testing)
      * @param message
      * @throws AblyException
@@ -1031,23 +1122,23 @@ public class ConnectionManager implements ConnectListener {
             Log.v(TAG, "onMessage() (transport = " + transport + "): " + message.action + ": " + new String(ProtocolSerializer.writeJSON(message)));
         }
         try {
-            if(protocolListener != null) {
+            if (protocolListener != null) {
                 protocolListener.onRawMessageRecv(message);
             }
-            switch(message.action) {
+            switch (message.action) {
                 case heartbeat:
                     onHeartbeat(message);
                     break;
                 case error:
                     ErrorInfo reason = message.error;
-                    if(reason == null) {
+                    if (reason == null) {
                         Log.e(TAG, "onMessage(): ERROR message received (no error detail)");
                     } else {
                         Log.e(TAG, "onMessage(): ERROR message received; message = " + reason.message + "; code = " + reason.code);
                     }
 
                     /* an error message may signify an error currentState in a channel, or in the connection */
-                    if(message.channel != null) {
+                    if (message.channel != null) {
                         onChannelMessage(message);
                     } else {
                         onError(message);
@@ -1075,15 +1166,14 @@ public class ConnectionManager implements ConnectListener {
                 default:
                     onChannelMessage(message);
             }
-        }
-        catch(Exception e) {
+        } catch (Exception e) {
             // Prevent any non-AblyException to be thrown
             throw AblyException.fromThrowable(e);
         }
     }
 
     private void onChannelMessage(ProtocolMessage message) {
-        if(message.connectionSerial != null) {
+        if (message.connectionSerial != null) {
             connection.serial = message.connectionSerial.longValue();
             if (connection.key != null)
                 connection.recoveryKey = connection.key + ":" + message.connectionSerial;
@@ -1103,9 +1193,9 @@ public class ConnectionManager implements ConnectListener {
          * Suspend all channels attached to the previous id;
          * this will be reattached in setConnection() */
         ErrorInfo error = message.error;
-        if(connection.id != null && !message.connectionId.equals(connection.id)) {
+        if (connection.id != null && !message.connectionId.equals(connection.id)) {
             /* we need to suspend the original connection */
-            if(error == null) {
+            if (error == null) {
                 error = REASON_SUSPENDED;
             }
             channels.suspendAll(error, false);
@@ -1119,11 +1209,11 @@ public class ConnectionManager implements ConnectListener {
              * pending message queue (which fails the messages currently in
              * there). */
             pendingMessages.reset(msgSerial,
-                    new ErrorInfo("Connection resume failed", 500, 50000));
+                new ErrorInfo("Connection resume failed", 500, 50000));
             msgSerial = 0;
         }
         connection.id = message.connectionId;
-        if(message.connectionSerial != null) {
+        if (message.connectionSerial != null) {
             connection.serial = message.connectionSerial.longValue();
             if (connection.key != null)
                 connection.recoveryKey = connection.key + ":" + message.connectionSerial;
@@ -1149,14 +1239,14 @@ public class ConnectionManager implements ConnectListener {
 
     private synchronized void onDisconnected(ProtocolMessage message) {
         ErrorInfo reason = message.error;
-        if(reason != null && isTokenError(reason)) {
+        if (reason != null && isTokenError(reason)) {
             ably.auth.onAuthError(reason);
         }
         requestState(new StateIndication(ConnectionState.disconnected, reason));
     }
 
     private synchronized void onClosed(ProtocolMessage message) {
-        if(message.error != null) {
+        if (message.error != null) {
             this.onError(message);
         } else {
             connection.key = null;
@@ -1167,7 +1257,7 @@ public class ConnectionManager implements ConnectListener {
     private synchronized void onError(ProtocolMessage message) {
         connection.key = null;
         ErrorInfo reason = message.error;
-        if(isTokenError(reason)) {
+        if (isTokenError(reason)) {
             ably.auth.onAuthError(reason);
         }
         ConnectionState destinationState = isFatalError(reason) ? ConnectionState.failed : ConnectionState.disconnected;
@@ -1183,7 +1273,7 @@ public class ConnectionManager implements ConnectListener {
     }
 
     private void onHeartbeat(ProtocolMessage message) {
-        synchronized(heartbeatWaiters) {
+        synchronized (heartbeatWaiters) {
             heartbeatWaiters.clear();
             heartbeatWaiters.notifyAll();
         }
@@ -1194,24 +1284,24 @@ public class ConnectionManager implements ConnectListener {
      ******************************/
 
     private synchronized void startup() {
-        if(handlerThread == null) {
+        if (handlerThread == null) {
             (handlerThread = new Thread(new ActionHandler())).start();
             startConnectivityListener();
         }
     }
 
     private boolean checkConnectionStale() {
-        if(lastActivity == 0) {
+        if (lastActivity == 0) {
             return false;
         }
         long now = System.currentTimeMillis();
         long intervalSinceLastActivity = now - lastActivity;
-        if(intervalSinceLastActivity > (maxIdleInterval + connectionStateTtl)) {
+        if (intervalSinceLastActivity > (maxIdleInterval + connectionStateTtl)) {
             /* RTN15g1, RTN15g2 Force a new connection if the previous one is stale;
              * Clearing connection.key will ensure that we don't attempt to resume;
              * leaving the original connection.id will mean that we notice at
              * connection time that the connectionId has changed */
-            if(connection.key != null) {
+            if (connection.key != null) {
                 Log.v(TAG, "Clearing stale connection key to suppress resume");
                 connection.key = null;
                 connection.recoveryKey = null;
@@ -1228,11 +1318,12 @@ public class ConnectionManager implements ConnectListener {
     /**
      * After a connection attempt failed, check to
      * see whether we should attempt to use a fallback.
+     *
      * @param reason
      * @return StateIndication if a fallback connection attempt is required, otherwise null
      */
     private StateIndication checkFallback(ErrorInfo reason) {
-        if(pendingConnect != null && (reason == null || reason.statusCode >= 500)) {
+        if (pendingConnect != null && (reason == null || reason.statusCode >= 500)) {
             if (checkConnectivity()) {
                 /* we will try a fallback host */
                 String hostFallback = hosts.getFallback(pendingConnect.host);
@@ -1257,12 +1348,13 @@ public class ConnectionManager implements ConnectListener {
 
     private void tryWait(long timeout) {
         try {
-            if(timeout == 0) {
+            if (timeout == 0) {
                 wait();
             } else {
                 wait(timeout);
             }
-        } catch (InterruptedException e) {}
+        } catch (InterruptedException e) {
+        }
     }
 
     private void handleReauth() {
@@ -1295,7 +1387,7 @@ public class ConnectionManager implements ConnectListener {
             Log.v(TAG, "onTransportAvailable: ignoring connection event from superseded transport");
             return;
         }
-        if(protocolListener != null) {
+        if (protocolListener != null) {
             protocolListener.onRawConnect(transport.getURL());
         }
     }
@@ -1310,21 +1402,21 @@ public class ConnectionManager implements ConnectListener {
 
         /* if this is a failure of a pending connection attempt, decide whether or not to attempt a fallback host */
         StateIndication fallbackAttempt = checkFallback(reason);
-        if(fallbackAttempt != null) {
+        if (fallbackAttempt != null) {
             requestState(fallbackAttempt);
             return;
         }
 
         StateIndication stateIndication = null;
-        if(reason != null) {
-            if(isFatalError(reason)) {
+        if (reason != null) {
+            if (isFatalError(reason)) {
                 Log.e(TAG, "onTransportUnavailable: unexpected transport error: " + reason.message);
                 stateIndication = new StateIndication(ConnectionState.failed, reason);
-            } else if(isTokenError(reason)) {
+            } else if (isTokenError(reason)) {
                 ably.auth.onAuthError(reason);
             }
         }
-        if(stateIndication == null) {
+        if (stateIndication == null) {
             stateIndication = checkSuspended(reason);
         }
         addAction(new SynchronousStateChangeAction(transport, stateIndication));
@@ -1360,13 +1452,13 @@ public class ConnectionManager implements ConnectListener {
         ITransport transport;
         try {
             transport = transportFactory.getTransport(pendingConnect, this);
-        } catch(Exception e) {
+        } catch (Exception e) {
             String msg = "Unable to instance transport class";
             Log.e(getClass().getName(), msg, e);
             throw new RuntimeException(msg, e);
         }
         ITransport oldTransport;
-        synchronized(this) {
+        synchronized (this) {
             oldTransport = this.transport;
             this.transport = transport;
         }
@@ -1374,23 +1466,24 @@ public class ConnectionManager implements ConnectListener {
             oldTransport.close();
         }
         transport.connect(this);
-        if(protocolListener != null) {
+        if (protocolListener != null) {
             protocolListener.onRawConnectRequested(transport.getURL());
         }
     }
 
     /**
      * Close any existing transport
+     *
      * @return closed if true, otherwise awaiting closed indication
      */
     private boolean closeImpl() {
-        if(transport == null) {
+        if (transport == null) {
             return true;
         }
 
         /* if connected, send an explicit close message and await response */
         boolean isConnected = currentState.state == ConnectionState.connected;
-        if(isConnected) {
+        if (isConnected) {
             try {
                 Log.v(TAG, "Requesting connection close");
                 transport.send(new ProtocolMessage(ProtocolMessage.Action.close));
@@ -1409,7 +1502,7 @@ public class ConnectionManager implements ConnectListener {
     }
 
     private void clearTransport() {
-        if(transport != null) {
+        if (transport != null) {
             transport.close();
             transport = null;
         }
@@ -1420,12 +1513,13 @@ public class ConnectionManager implements ConnectListener {
      * without reference to a specific ably host. This is to determine whether
      * it is better to try a fallback host, or keep retrying with the default
      * host.
+     *
      * @return boolean, true if network is available
      */
     protected boolean checkConnectivity() {
         try {
             return HttpHelpers.getUrlString(ably.httpCore, INTERNET_CHECK_URL).contains(INTERNET_CHECK_OK);
-        } catch(AblyException e) {
+        } catch (AblyException e) {
             return false;
         }
     }
@@ -1441,6 +1535,7 @@ public class ConnectionManager implements ConnectListener {
     public static class QueuedMessage {
         public final ProtocolMessage msg;
         public final CompletionListener listener;
+
         public QueuedMessage(ProtocolMessage msg, CompletionListener listener) {
             this.msg = msg;
             this.listener = listener;
@@ -1449,13 +1544,13 @@ public class ConnectionManager implements ConnectListener {
 
     public void send(ProtocolMessage msg, boolean queueEvents, CompletionListener listener) throws AblyException {
         State state;
-        synchronized(this) {
+        synchronized (this) {
             state = this.currentState;
-            if(state.sendEvents) {
+            if (state.sendEvents) {
                 sendImpl(msg, listener);
                 return;
             }
-            if(state.queueEvents && queueEvents) {
+            if (state.queueEvents && queueEvents) {
                 queuedMessages.add(new QueuedMessage(msg, listener));
                 return;
             }
@@ -1464,39 +1559,39 @@ public class ConnectionManager implements ConnectListener {
     }
 
     private void sendImpl(ProtocolMessage message, CompletionListener listener) throws AblyException {
-        if(transport == null) {
+        if (transport == null) {
             Log.v(TAG, "sendImpl(): Discarding message; transport unavailable");
             return;
         }
-        if(ProtocolMessage.ackRequired(message)) {
+        if (ProtocolMessage.ackRequired(message)) {
             message.msgSerial = msgSerial++;
             pendingMessages.push(new QueuedMessage(message, listener));
         }
-        if(protocolListener != null) {
+        if (protocolListener != null) {
             protocolListener.onRawMessageSend(message);
         }
         transport.send(message);
     }
 
     private void sendImpl(QueuedMessage msg) throws AblyException {
-        if(transport == null) {
+        if (transport == null) {
             Log.v(TAG, "sendImpl(): Discarding message; transport unavailable");
             return;
         }
         ProtocolMessage message = msg.msg;
-        if(ProtocolMessage.ackRequired(message)) {
+        if (ProtocolMessage.ackRequired(message)) {
             message.msgSerial = msgSerial++;
             pendingMessages.push(msg);
         }
-        if(protocolListener != null) {
+        if (protocolListener != null) {
             protocolListener.onRawMessageSend(message);
         }
         transport.send(message);
     }
 
     private void sendQueuedMessages() {
-        synchronized(this) {
-            while(queuedMessages.size() > 0) {
+        synchronized (this) {
+            while (queuedMessages.size() > 0) {
                 try {
                     sendImpl(queuedMessages.get(0));
                 } catch (AblyException e) {
@@ -1509,8 +1604,8 @@ public class ConnectionManager implements ConnectListener {
     }
 
     private void failQueuedMessages(ErrorInfo reason) {
-        synchronized(this) {
-            for (QueuedMessage queued: queuedMessages) {
+        synchronized (this) {
+            for (QueuedMessage queued : queuedMessages) {
                 if (queued.listener != null) {
                     try {
                         queued.listener.onError(reason);
@@ -1536,50 +1631,50 @@ public class ConnectionManager implements ConnectListener {
 
         public void ack(long msgSerial, int count, ErrorInfo reason) {
             QueuedMessage[] ackMessages = null, nackMessages = null;
-            synchronized(this) {
-                if(msgSerial < startSerial) {
+            synchronized (this) {
+                if (msgSerial < startSerial) {
                     /* this is an error condition and shouldn't happen but
                      * we can handle it gracefully by only processing the
                      * relevant portion of the response */
-                    count -= (int)(startSerial - msgSerial);
-                    if(count < 0)
+                    count -= (int) (startSerial - msgSerial);
+                    if (count < 0)
                         count = 0;
                     msgSerial = startSerial;
                 }
-                if(msgSerial > startSerial) {
+                if (msgSerial > startSerial) {
                     /* this counts as a nack of the messages earlier than serial,
                      * as well as an ack */
-                    int nCount = (int)(msgSerial - startSerial);
+                    int nCount = (int) (msgSerial - startSerial);
                     List<QueuedMessage> nackList = queue.subList(0, nCount);
                     nackMessages = nackList.toArray(new QueuedMessage[nCount]);
                     nackList.clear();
                     startSerial = msgSerial;
                 }
-                if(msgSerial == startSerial) {
+                if (msgSerial == startSerial) {
                     List<QueuedMessage> ackList = queue.subList(0, count);
                     ackMessages = ackList.toArray(new QueuedMessage[count]);
                     ackList.clear();
                     startSerial += count;
                 }
             }
-            if(nackMessages != null) {
-                if(reason == null)
+            if (nackMessages != null) {
+                if (reason == null)
                     reason = new ErrorInfo("Unknown error", 500, 50000);
-                for(QueuedMessage msg : nackMessages) {
+                for (QueuedMessage msg : nackMessages) {
                     try {
-                        if(msg.listener != null)
+                        if (msg.listener != null)
                             msg.listener.onError(reason);
-                    } catch(Throwable t) {
+                    } catch (Throwable t) {
                         Log.e(TAG, "ack(): listener exception", t);
                     }
                 }
             }
-            if(ackMessages != null) {
-                for(QueuedMessage msg : ackMessages) {
+            if (ackMessages != null) {
+                for (QueuedMessage msg : ackMessages) {
                     try {
-                        if(msg.listener != null)
+                        if (msg.listener != null)
                             msg.listener.onSuccess();
-                    } catch(Throwable t) {
+                    } catch (Throwable t) {
                         Log.e(TAG, "ack(): listener exception", t);
                     }
                 }
@@ -1588,12 +1683,12 @@ public class ConnectionManager implements ConnectListener {
 
         public synchronized void nack(long serial, int count, ErrorInfo reason) {
             QueuedMessage[] nackMessages = null;
-            synchronized(this) {
-                if(serial != startSerial) {
+            synchronized (this) {
+                if (serial != startSerial) {
                     /* this is an error condition and shouldn't happen but
                      * we can handle it gracefully by only processing the
                      * relevant portion of the response */
-                    count -= (int)(startSerial - serial);
+                    count -= (int) (startSerial - serial);
                     serial = startSerial;
                 }
                 List<QueuedMessage> nackList = queue.subList(0, count);
@@ -1601,14 +1696,14 @@ public class ConnectionManager implements ConnectListener {
                 nackList.clear();
                 startSerial += count;
             }
-            if(nackMessages != null) {
-                if(reason == null)
+            if (nackMessages != null) {
+                if (reason == null)
                     reason = new ErrorInfo("Unknown error", 500, 50000);
-                for(QueuedMessage msg : nackMessages) {
+                for (QueuedMessage msg : nackMessages) {
                     try {
-                        if(msg.listener != null)
+                        if (msg.listener != null)
                             msg.listener.onError(reason);
-                    } catch(Throwable t) {
+                    } catch (Throwable t) {
                         Log.e(TAG, "nack(): listener exception", t);
                     }
                 }
@@ -1618,12 +1713,13 @@ public class ConnectionManager implements ConnectListener {
         /**
          * reset the pending message queue, failing any currently pending messages.
          * Used when a resume fails and we get a different connection id.
+         *
          * @param oldMsgSerial the next message serial number for the old
-         * connection, and thus one more than the highest message serial
-         * in the queue.
+         *                     connection, and thus one more than the highest message serial
+         *                     in the queue.
          */
         public synchronized void reset(long oldMsgSerial, ErrorInfo err) {
-            nack(startSerial, (int)(oldMsgSerial - startSerial), err);
+            nack(startSerial, (int) (oldMsgSerial - startSerial), err);
             startSerial = 0;
         }
 
@@ -1640,7 +1736,7 @@ public class ConnectionManager implements ConnectListener {
             ConnectionManager cm = ConnectionManager.this;
             ConnectionState currentState = cm.getConnectionState().state;
             Log.i(TAG, "onNetworkAvailable(): currentState = " + currentState.name());
-            if(currentState == ConnectionState.disconnected || currentState == ConnectionState.suspended) {
+            if (currentState == ConnectionState.disconnected || currentState == ConnectionState.suspended) {
                 Log.i(TAG, "onNetworkAvailable(): initiating reconnect");
                 cm.connect();
             }
@@ -1651,7 +1747,7 @@ public class ConnectionManager implements ConnectListener {
             ConnectionManager cm = ConnectionManager.this;
             ConnectionState currentState = cm.getConnectionState().state;
             Log.i(TAG, "onNetworkUnavailable(); currentState = " + currentState.name() + "; reason = " + reason.toString());
-            if(currentState == ConnectionState.connected || currentState == ConnectionState.connecting) {
+            if (currentState == ConnectionState.connected || currentState == ConnectionState.connecting) {
                 Log.i(TAG, "onNetworkUnavailable(): closing connected transport");
                 cm.requestState(new StateIndication(ConnectionState.disconnected, reason));
             }
@@ -1673,7 +1769,7 @@ public class ConnectionManager implements ConnectListener {
      ******************/
 
     void disconnectAndSuppressRetries() {
-        if(transport != null) {
+        if (transport != null) {
             transport.close();
         }
         suppressRetry = true;
@@ -1688,14 +1784,20 @@ public class ConnectionManager implements ConnectListener {
     }
 
     private boolean isFatalError(ErrorInfo err) {
-        if(err.code != 0) {
+        if (err.code != 0) {
             /* token errors are assumed to be recoverable */
-            if(isTokenError(err)) { return false; }
+            if (isTokenError(err)) {
+                return false;
+            }
             /* 400 codes assumed to be fatal */
-            if((err.code >= 40000) && (err.code < 50000)) { return true; }
+            if ((err.code >= 40000) && (err.code < 50000)) {
+                return true;
+            }
         }
         /* otherwise, use statusCode */
-        if(err.statusCode != 0 && err.statusCode < 500) { return true; }
+        if (err.statusCode != 0 && err.statusCode < 500) {
+            return true;
+        }
         return false;
     }
 

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1,27 +1,5 @@
 package io.ably.lib.transport;
 
-import io.ably.lib.debug.DebugOptions;
-import io.ably.lib.debug.DebugOptions.RawProtocolListener;
-import io.ably.lib.http.HttpHelpers;
-import io.ably.lib.realtime.AblyRealtime;
-import io.ably.lib.realtime.Channel;
-import io.ably.lib.realtime.CompletionListener;
-import io.ably.lib.realtime.Connection;
-import io.ably.lib.realtime.ConnectionState;
-import io.ably.lib.realtime.ConnectionStateListener;
-import io.ably.lib.realtime.ConnectionStateListener.ConnectionStateChange;
-import io.ably.lib.transport.ITransport.ConnectListener;
-import io.ably.lib.transport.ITransport.TransportParams;
-import io.ably.lib.types.AblyException;
-import io.ably.lib.types.ClientOptions;
-import io.ably.lib.types.ConnectionDetails;
-import io.ably.lib.types.ErrorInfo;
-import io.ably.lib.types.ProtocolMessage;
-import io.ably.lib.types.ProtocolSerializer;
-import io.ably.lib.util.Log;
-import io.ably.lib.transport.NetworkConnectivity.NetworkConnectivityListener;
-import io.ably.lib.util.PlatformAgentProvider;
-
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -34,9 +12,32 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import io.ably.lib.debug.DebugOptions;
+import io.ably.lib.debug.DebugOptions.RawProtocolListener;
+import io.ably.lib.http.HttpHelpers;
+import io.ably.lib.realtime.AblyRealtime;
+import io.ably.lib.realtime.Channel;
+import io.ably.lib.realtime.CompletionListener;
+import io.ably.lib.realtime.Connection;
+import io.ably.lib.realtime.ConnectionState;
+import io.ably.lib.realtime.ConnectionStateListener;
+import io.ably.lib.realtime.ConnectionStateListener.ConnectionStateChange;
+import io.ably.lib.transport.ITransport.ConnectListener;
+import io.ably.lib.transport.ITransport.TransportParams;
+import io.ably.lib.transport.NetworkConnectivity.NetworkConnectivityListener;
+import io.ably.lib.types.AblyException;
+import io.ably.lib.types.ClientOptions;
+import io.ably.lib.types.ConnectionDetails;
+import io.ably.lib.types.ErrorInfo;
+import io.ably.lib.types.ProtocolMessage;
+import io.ably.lib.types.ProtocolSerializer;
+import io.ably.lib.util.Log;
+import io.ably.lib.util.PlatformAgentProvider;
+
 public class ConnectionManager implements ConnectListener {
     final ExecutorService singleThreadExecutor = Executors.newSingleThreadExecutor();
-    final ExecutorCompletionService<AblyException> executorCompletionService = new ExecutorCompletionService<>(singleThreadExecutor);
+    final ExecutorCompletionService<Void> executorCompletionService =
+        new ExecutorCompletionService<>(singleThreadExecutor);
 
     /**************************************************************
      * ConnectionManager
@@ -985,7 +986,7 @@ public class ConnectionManager implements ConnectListener {
     /**
      * Async version of onAuthUpdated that returns a Future that includes an option Ably exception
      * **/
-    public Future<AblyException> onAuthUpdatedAsync(final String token) {
+    public Future<Void> onAuthUpdatedAsync(final String token) {
         final ConnectionWaiter waiter = new ConnectionWaiter();
         try {
             switch (currentState.state) {
@@ -1044,7 +1045,7 @@ public class ConnectionManager implements ConnectListener {
                         default:
                             /* suspended/closed/error: throw the error. */
                             Log.v(TAG, "onAuthUpdated: throwing exception");
-                            return AblyException.fromErrorInfo(reason);
+                            throw  AblyException.fromErrorInfo(reason);
                     }
                 }
                 return null;

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
@@ -861,6 +861,76 @@ public class RealtimeAuthTest extends ParameterizedTest {
         }
     }
 
+
+    /**
+     * Call renewAuth() whilst connecting; verify there's no crash (see https://github.com/ably/ably-java/issues/503)
+     */
+    @Test
+    public void auth_renewAuth_whilst_connecting() {
+        try {
+            /* get a TokenDetails */
+            final String testKey = testVars.keys[0].keyStr;
+            ClientOptions optsForToken = createOptions(testKey);
+            final AblyRest ablyForToken = new AblyRest(optsForToken);
+
+            final TokenDetails tokenDetails = ablyForToken.auth.requestToken(new Auth.TokenParams(){{ ttl = 1000L; }}, null);
+            assertNotNull("Expected token value", tokenDetails.token);
+
+            /* create Ably realtime instance with token and authCallback */
+            class ProtocolListener extends DebugOptions implements DebugOptions.RawProtocolListener {
+                ProtocolListener() {
+                    Setup.getTestVars().fillInOptions(this);
+                    protocolListener = this;
+                }
+                @Override
+                public void onRawConnectRequested(String url) {
+                    synchronized(this) {
+                        notify();
+                    }
+                }
+
+                @Override
+                public void onRawConnect(String url) {}
+                @Override
+                public void onRawMessageSend(ProtocolMessage message) {}
+                @Override
+                public void onRawMessageRecv(ProtocolMessage message) {}
+            }
+
+            ProtocolListener opts = new ProtocolListener();
+            opts.autoConnect = false;
+            opts.tokenDetails = tokenDetails;
+            opts.authCallback = new Auth.TokenCallback() {
+                /* implement callback, using Ably instance with key */
+                @Override
+                public Object getTokenRequest(Auth.TokenParams params) {
+                    return tokenDetails;
+                }
+            };
+
+            final AblyRealtime ably = new AblyRealtime(opts);
+            synchronized (opts) {
+                ably.connect();
+                try {
+                    opts.wait();
+                } catch(InterruptedException ie) {}
+                ably.auth.renewAuth();
+            }
+
+            Helpers.ConnectionWaiter connectionWaiter = new Helpers.ConnectionWaiter(ably.connection);
+            boolean isConnected = connectionWaiter.waitFor(ConnectionState.connected, 1, 4000L);
+            if(isConnected) {
+                /* done */
+                ably.close();
+            } else {
+                fail("auth_expired_token_expire_renew: unable to connect; final state = " + ably.connection.state);
+            }
+        } catch (AblyException e) {
+            e.printStackTrace();
+            fail("auth_expired_token_expire_renew: Unexpected exception instantiating library");
+        }
+    }
+
     /**
      * Verify that with queryTime=false, when instancing with an already-expired token and authCallback,
      * connection can succeed

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
@@ -914,7 +914,9 @@ public class RealtimeAuthTest extends ParameterizedTest {
                 try {
                     opts.wait();
                 } catch(InterruptedException ie) {}
-                ably.auth.renewAuth();
+                ably.auth.renewAuth((success, tokenDetails1, errorInfo) -> {
+                    //Ignore completion handling
+                });
             }
 
             Helpers.ConnectionWaiter connectionWaiter = new Helpers.ConnectionWaiter(ably.connection);


### PR DESCRIPTION
On this PR,

I added a new `renewAuth` to `Auth` that accepts a token and a completion handler. I also deprecated the old `renew`. This is done to prevent callers blocked and provide a handler for completion. 

The essential change here is moving the "waiting for connection state change" part to a background thread and invoking a callback on completion

Related to https://github.com/ably/ably-asset-tracking-android/issues/695

Closes https://github.com/ably/ably-java/issues/814