### PR TITLE
Document thread policy for callbacks and add missing documentation for callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Log.setHandler(null);
 #### Threads
 
 AblyRealtime will invoke all callbacks on background thread. 
-If you are using Ably in Android application it is advised to switch to main thread to update UI. 
+If you are using Ably in Android application you must switch to main thread to update UI. 
 
 ```java
 channel.presence.enter("john.doe", new CompletionListener() {

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Log.setHandler(null);
 
 #### Threads
 
-AblyRealtime will return all callbacks on background thread. 
+AblyRealtime will invoke all callbacks on background thread. 
 If you are using Ably in Android application it is advised to switch to main thread to update UI. 
 
 ```java

--- a/README.md
+++ b/README.md
@@ -397,6 +397,35 @@ import io.ably.lib.util.Log;
 Log.setHandler(null);
 ```
 
+#### Threads
+
+AblyRealtime will return all callbacks on background thread. 
+If you are using Ably in Android application it is advised to switch to main thread to update UI. 
+
+```java
+channel.presence.enter("john.doe", new CompletionListener() {
+    @Override
+    public void onSuccess() {
+        //If you are in Activity
+        runOnUiThread(new Runnable() {
+        @Override
+        public void run() {
+            //Update your UI here
+            }
+        });
+        
+        //If you are in fragment or other class
+        Handler handler = new Handler(Looper.getMainLooper());
+        handler.post(new Runnable() {
+            @Override
+            public void run() {
+                //Update your UI here
+            }
+        });
+    }
+});
+```
+
 ### Using the Push API
 
 #### Delivering push notifications

--- a/README.md
+++ b/README.md
@@ -410,11 +410,11 @@ channel.presence.enter("john.doe", new CompletionListener() {
         runOnUiThread(new Runnable() {
         @Override
         public void run() {
-            //Update your UI here
+                //Update your UI here
             }
         });
         
-        //If you are in fragment or other class
+        //If you are in Fragment or other class
         Handler handler = new Handler(Looper.getMainLooper());
         handler.post(new Runnable() {
             @Override

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -127,11 +127,11 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
      * attach() is called implicitly when publishing or subscribing
      * on this channel, so it is not usually necessary for a client
      * to call attach() explicitly.
-     * <p>
-     * This listener is invoked on a background thread.
      *
      * @param listener When the channel is attached successfully or the attach fails and
      * the ErrorInfo error is passed as an argument to the callback
+     * <p>
+     * This listener is invoked on a background thread.
      * @throws AblyException
      */
     public void attach(CompletionListener listener) throws  AblyException {
@@ -209,9 +209,11 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
      * Detach from this channel.
      * This call initiates the detach request, and the response
      * is indicated asynchronously in the resulting state change.
+     *
+     * @param listener When the channel is detached successfully or the detach fails and
+     * the ErrorInfo error is passed as an argument to the callback
      * <p>
      * This listener is invoked on a background thread.
-     *
      * @throws AblyException
      */
     public void detach(CompletionListener listener) throws AblyException {
@@ -609,10 +611,10 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Subscribe for messages on this channel. This implicitly attaches the channel if
      * not already attached.
-     * <p>
-     * This listener is invoked on a background thread.
      *
      * @param listener the MessageListener
+     * <p>
+     * This listener is invoked on a background thread.
      * @throws AblyException
      */
     public synchronized void subscribe(MessageListener listener) throws AblyException {
@@ -623,10 +625,10 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
 
     /**
      * Unsubscribe a previously subscribed listener from this channel.
-     * <p>
-     * This listener is invoked on a background thread.
      *
      * @param listener the previously subscribed listener.
+     * <p>
+     * This listener is invoked on a background thread.
      */
     public synchronized void unsubscribe(MessageListener listener) {
         Log.v(TAG, "unsubscribe(); channel = " + this.name);
@@ -639,11 +641,11 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Subscribe for messages with a specific event name on this channel.
      * This implicitly attaches the channel if not already attached.
-     * <p>
-     * This listener is invoked on a background thread.
      *
      * @param name the event name
      * @param listener the MessageListener
+     * <p>
+     * This listener is invoked on a background thread.
      * @throws AblyException
      */
     public synchronized void subscribe(String name, MessageListener listener) throws AblyException {
@@ -654,11 +656,11 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
 
     /**
      * Unsubscribe a previously subscribed event listener from this channel.
-     * <p>
-     * This listener is invoked on a background thread.
      *
      * @param name the event name
      * @param listener the previously subscribed listener.
+     * <p>
+     * This listener is invoked on a background thread.
      */
     public synchronized void unsubscribe(String name, MessageListener listener) {
         Log.v(TAG, "unsubscribe(); channel = " + this.name + "; event = " + name);
@@ -668,11 +670,11 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Subscribe for messages with an array of event names on this channel.
      * This implicitly attaches the channel if not already attached.
-     * <p>
-     * This listener is invoked on a background thread.
      *
      * @param names the event names
      * @param listener the MessageListener
+     * <p>
+     * This listener is invoked on a background thread.
      * @throws AblyException
      */
     public synchronized void subscribe(String[] names, MessageListener listener) throws AblyException {
@@ -684,11 +686,11 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
 
     /**
      * Unsubscribe a previously subscribed event listener from this channel.
-     * <p>
-     * This listener is invoked on a background thread.
      *
      * @param names the event names
      * @param listener the previously subscribed listener.
+     * <p>
+     * This listener is invoked on a background thread.
      */
     public synchronized void unsubscribe(String[] names, MessageListener listener) {
         Log.v(TAG, "unsubscribe(); channel = " + this.name + "; (multiple events)");
@@ -870,12 +872,12 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Publish a message on this channel. This implicitly attaches the channel if
      * not already attached.
-     * <p>
-     * This listener is invoked on a background thread.
      *
      * @param name the event name
      * @param data the message payload. See {@link io.ably.types.Data} for supported datatypes
      * @param listener a listener to be notified of the outcome of this message.
+     * <p>
+     * This listener is invoked on a background thread.
      * @throws AblyException
      */
     public void publish(String name, Object data, CompletionListener listener) throws AblyException {
@@ -886,11 +888,11 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Publish a message on this channel. This implicitly attaches the channel if
      * not already attached.
-     * <p>
-     * This listener is invoked on a background thread.
      *
      * @param message the message
      * @param listener a listener to be notified of the outcome of this message.
+     * <p>
+     * This listener is invoked on a background thread.
      * @throws AblyException
      */
     public void publish(Message message, CompletionListener listener) throws AblyException {
@@ -901,11 +903,11 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Publish an array of messages on this channel. This implicitly attaches the channel if
      * not already attached.
-     * <p>
-     * This listener is invoked on a background thread.
      *
      * @param messages the message
      * @param listener a listener to be notified of the outcome of this message.
+     * <p>
+     * This listener is invoked on a background thread.
      * @throws AblyException
      */
     public synchronized void publish(Message[] messages, CompletionListener listener) throws AblyException {

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -127,6 +127,8 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
      * attach() is called implicitly when publishing or subscribing
      * on this channel, so it is not usually necessary for a client
      * to call attach() explicitly.
+     * <p>
+     * This listener is invoked on a background thread.
      *
      * @param listener When the channel is attached successfully or the attach fails and
      * the ErrorInfo error is passed as an argument to the callback
@@ -207,6 +209,9 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
      * Detach from this channel.
      * This call initiates the detach request, and the response
      * is indicated asynchronously in the resulting state change.
+     * <p>
+     * This listener is invoked on a background thread.
+     *
      * @throws AblyException
      */
     public void detach(CompletionListener listener) throws AblyException {
@@ -604,6 +609,9 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Subscribe for messages on this channel. This implicitly attaches the channel if
      * not already attached.
+     * <p>
+     * This listener is invoked on a background thread.
+     *
      * @param listener the MessageListener
      * @throws AblyException
      */
@@ -615,6 +623,9 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
 
     /**
      * Unsubscribe a previously subscribed listener from this channel.
+     * <p>
+     * This listener is invoked on a background thread.
+     *
      * @param listener the previously subscribed listener.
      */
     public synchronized void unsubscribe(MessageListener listener) {
@@ -628,6 +639,9 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Subscribe for messages with a specific event name on this channel.
      * This implicitly attaches the channel if not already attached.
+     * <p>
+     * This listener is invoked on a background thread.
+     *
      * @param name the event name
      * @param listener the MessageListener
      * @throws AblyException
@@ -640,6 +654,9 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
 
     /**
      * Unsubscribe a previously subscribed event listener from this channel.
+     * <p>
+     * This listener is invoked on a background thread.
+     *
      * @param name the event name
      * @param listener the previously subscribed listener.
      */
@@ -651,6 +668,9 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Subscribe for messages with an array of event names on this channel.
      * This implicitly attaches the channel if not already attached.
+     * <p>
+     * This listener is invoked on a background thread.
+     *
      * @param names the event names
      * @param listener the MessageListener
      * @throws AblyException
@@ -664,6 +684,9 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
 
     /**
      * Unsubscribe a previously subscribed event listener from this channel.
+     * <p>
+     * This listener is invoked on a background thread.
+     *
      * @param names the event names
      * @param listener the previously subscribed listener.
      */
@@ -847,6 +870,9 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Publish a message on this channel. This implicitly attaches the channel if
      * not already attached.
+     * <p>
+     * This listener is invoked on a background thread.
+     *
      * @param name the event name
      * @param data the message payload. See {@link io.ably.types.Data} for supported datatypes
      * @param listener a listener to be notified of the outcome of this message.
@@ -860,6 +886,9 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Publish a message on this channel. This implicitly attaches the channel if
      * not already attached.
+     * <p>
+     * This listener is invoked on a background thread.
+     *
      * @param message the message
      * @param listener a listener to be notified of the outcome of this message.
      * @throws AblyException
@@ -872,6 +901,9 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Publish an array of messages on this channel. This implicitly attaches the channel if
      * not already attached.
+     * <p>
+     * This listener is invoked on a background thread.
+     *
      * @param messages the message
      * @param listener a listener to be notified of the outcome of this message.
      * @throws AblyException

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelStateListener.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelStateListener.java
@@ -7,6 +7,13 @@ import io.ably.lib.types.ErrorInfo;
  */
 public interface ChannelStateListener {
 
+    /**
+     * Called when channel state changes.
+     * <p>
+     * This callback is triggered on background thread.
+     *
+     * @param stateChange information about the new state. Check {@link ChannelState ChannelState} - for all states available.
+     */
     void onChannelStateChanged(ChannelStateChange stateChange);
 
     /**

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelStateListener.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelStateListener.java
@@ -9,9 +9,6 @@ public interface ChannelStateListener {
 
     /**
      * Called when channel state changes.
-     * <p>
-     * This callback is triggered on background thread.
-     *
      * @param stateChange information about the new state. Check {@link ChannelState ChannelState} - for all states available.
      */
     void onChannelStateChanged(ChannelStateChange stateChange);

--- a/lib/src/main/java/io/ably/lib/realtime/CompletionListener.java
+++ b/lib/src/main/java/io/ably/lib/realtime/CompletionListener.java
@@ -11,15 +11,11 @@ import io.ably.lib.types.Callback;
 public interface CompletionListener {
     /**
      * Called when the associated operation completes successfully.
-     * <p>
-     * This callback is triggered on background thread.
      */
     void onSuccess();
 
     /**
      * Called when the associated operation completes with an error.
-     * <p>
-     * This callback is triggered on background thread.
      * @param reason information about the error.
      */
     void onError(ErrorInfo reason);

--- a/lib/src/main/java/io/ably/lib/realtime/CompletionListener.java
+++ b/lib/src/main/java/io/ably/lib/realtime/CompletionListener.java
@@ -10,12 +10,16 @@ import io.ably.lib.types.Callback;
  */
 public interface CompletionListener {
     /**
-     * Called when the associated operation completes successfully,
+     * Called when the associated operation completes successfully.
+     * <p>
+     * This callback is triggered on background thread.
      */
     void onSuccess();
 
     /**
      * Called when the associated operation completes with an error.
+     * <p>
+     * This callback is triggered on background thread.
      * @param reason information about the error.
      */
     void onError(ErrorInfo reason);

--- a/lib/src/main/java/io/ably/lib/realtime/ConnectionStateListener.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ConnectionStateListener.java
@@ -2,8 +2,18 @@ package io.ably.lib.realtime;
 
 import io.ably.lib.types.ErrorInfo;
 
+/**
+ * An interface whereby a client may be notified of state changes for a connection.
+ */
 public interface ConnectionStateListener {
 
+    /**
+     * Called when connection state changes.
+     * <p>
+     * This callback is triggered on background thread.
+     *
+     * @param state information about the new state. Check {@link ConnectionState ConnectionState} - for all states available.
+     */
     void onConnectionStateChanged(ConnectionStateListener.ConnectionStateChange state);
 
     class ConnectionStateChange {

--- a/lib/src/main/java/io/ably/lib/realtime/ConnectionStateListener.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ConnectionStateListener.java
@@ -9,9 +9,6 @@ public interface ConnectionStateListener {
 
     /**
      * Called when connection state changes.
-     * <p>
-     * This callback is triggered on background thread.
-     *
      * @param state information about the new state. Check {@link ConnectionState ConnectionState} - for all states available.
      */
     void onConnectionStateChanged(ConnectionStateListener.ConnectionStateChange state);

--- a/lib/src/main/java/io/ably/lib/realtime/Presence.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Presence.java
@@ -101,6 +101,9 @@ public class Presence {
     /**
      * Subscribe to presence events on the associated Channel. This implicitly
      * attaches the Channel if it is not already attached.
+     * <p>
+     * These listeners are invoked on a background thread.
+     *
      * @param listener the listener to me notified on arrival of presence messages.
      * @param completionListener listener to be called on success/failure
      * @throws AblyException
@@ -112,6 +115,8 @@ public class Presence {
 
     /**
      * Same as above without completion listener
+     * <p>
+     * This listener is invoked on a background thread.
      */
     public void subscribe(PresenceListener listener) throws AblyException {
         subscribe(listener, null);
@@ -131,6 +136,8 @@ public class Presence {
     /**
      * Subscribe to presence events with a specific action on the associated Channel.
      * This implicitly attaches the Channel if it is not already attached.
+     * <p>
+     * These listeners are invoked on a background thread.
      *
      * @param action to be observed
      * @param listener
@@ -397,6 +404,9 @@ public class Presence {
     /**
      * Enter this client into this channel. This client will be added to the presence set
      * and presence subscribers will see an enter message for this client.
+     * <p>
+     * This listener is invoked on a background thread.
+     *
      * @param data optional data (eg a status message) for this member.
      * See {@link io.ably.types.Data} for the supported data types.
      * @param listener a listener to be notified on completion of the operation.
@@ -411,6 +421,9 @@ public class Presence {
      * Update the presence data for this client. If the client is not already a member of
      * the presence set it will be added, and presence subscribers will see an enter or
      * update message for this client.
+     * <p>
+     * This listener is invoked on a background thread.
+     *
      * @param data optional data (eg a status message) for this member.
      * See {@link io.ably.types.Data} for the supported data types.
      * @param listener a listener to be notified on completion of the operation.
@@ -424,6 +437,9 @@ public class Presence {
     /**
      * Leave this client from this channel. This client will be removed from the presence
      * set and presence subscribers will see a leave message for this client.
+     * <p>
+     * This listener is invoked on a background thread.
+     *
      * @param data optional data (eg a status message) for this member.
      * See {@link io.ably.types.Data} for the supported data types.
      * @param listener a listener to be notified on completion of the operation.
@@ -437,6 +453,9 @@ public class Presence {
     /**
      * Leave this client from this channel. This client will be removed from the presence
      * set and presence subscribers will see a leave message for this client.
+     * <p>
+     * This listener is invoked on a background thread.
+     *
      * @param listener a listener to be notified on completion of the operation.
      * @throws AblyException
      */
@@ -480,6 +499,9 @@ public class Presence {
      * server instances) that act on behalf of multiple clientIds. In order to be able to
      * enter the channel with this method, the client library must have been instanced
      * either with a key, or with a token bound to the wildcard clientId.
+     * <p>
+     * This listener is invoked on a background thread.
+     *
      * @param clientId the id of the client.
      * @param data optional data (eg a status message) for this member.
      * @param listener a listener to be notified on completion of the operation.
@@ -531,6 +553,9 @@ public class Presence {
      * presence subscribers will see an enter or update message for this client.
      * As for #enterClient above, the connection must be authenticated in a way that
      * enables it to represent an arbitrary clientId.
+     * <p>
+     * This listener is invoked on a background thread.
+     *
      * @param clientId the id of the client.
      * @param data optional data (eg a status message) for this member.
      * @param listener a listener to be notified on completion of the operation.
@@ -574,6 +599,9 @@ public class Presence {
     /**
      * Leave a given client from this channel. This client will be removed from the
      * presence set and presence subscribers will see a leave message for this client.
+     * <p>
+     * This listener is invoked on a background thread.
+     *
      * @param clientId the id of the client.
      * @param data optional data (eg a status message) for this member.
      * @param listener a listener to be notified on completion of the operation.
@@ -596,6 +624,9 @@ public class Presence {
      * Update the presence for this channel with a given PresenceMessage update.
      * The connection must be authenticated in a way that enables it to represent
      * the clientId in the message.
+     * <p>
+     * This listener is invoked on a background thread.
+     *
      * @param msg the presence message
      * @param listener a listener to be notified on completion of the operation.
      * @throws AblyException

--- a/lib/src/main/java/io/ably/lib/realtime/Presence.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Presence.java
@@ -101,11 +101,11 @@ public class Presence {
     /**
      * Subscribe to presence events on the associated Channel. This implicitly
      * attaches the Channel if it is not already attached.
-     * <p>
-     * These listeners are invoked on a background thread.
      *
      * @param listener the listener to me notified on arrival of presence messages.
      * @param completionListener listener to be called on success/failure
+     * <p>
+     * These listeners are invoked on a background thread.
      * @throws AblyException
      */
     public void subscribe(PresenceListener listener, CompletionListener completionListener) throws AblyException {
@@ -115,6 +115,7 @@ public class Presence {
 
     /**
      * Same as above without completion listener
+     * @param listener the listener to me notified on arrival of presence messages.
      * <p>
      * This listener is invoked on a background thread.
      */
@@ -136,12 +137,12 @@ public class Presence {
     /**
      * Subscribe to presence events with a specific action on the associated Channel.
      * This implicitly attaches the Channel if it is not already attached.
-     * <p>
-     * These listeners are invoked on a background thread.
      *
      * @param action to be observed
      * @param listener
      * @param completionListener listener to be called on success/failure
+     * <p>
+     * These listeners are invoked on a background thread.
      * @throws AblyException
      */
     public void subscribe(PresenceMessage.Action action, PresenceListener listener, CompletionListener completionListener) throws AblyException {
@@ -404,12 +405,12 @@ public class Presence {
     /**
      * Enter this client into this channel. This client will be added to the presence set
      * and presence subscribers will see an enter message for this client.
-     * <p>
-     * This listener is invoked on a background thread.
      *
      * @param data optional data (eg a status message) for this member.
      * See {@link io.ably.types.Data} for the supported data types.
      * @param listener a listener to be notified on completion of the operation.
+     * <p>
+     * This listener is invoked on a background thread.
      * @throws AblyException
      */
     public void enter(Object data, CompletionListener listener) throws AblyException {
@@ -421,12 +422,12 @@ public class Presence {
      * Update the presence data for this client. If the client is not already a member of
      * the presence set it will be added, and presence subscribers will see an enter or
      * update message for this client.
-     * <p>
-     * This listener is invoked on a background thread.
      *
      * @param data optional data (eg a status message) for this member.
      * See {@link io.ably.types.Data} for the supported data types.
      * @param listener a listener to be notified on completion of the operation.
+     * <p>
+     * This listener is invoked on a background thread.
      * @throws AblyException
      */
     public void update(Object data, CompletionListener listener) throws AblyException {
@@ -437,12 +438,12 @@ public class Presence {
     /**
      * Leave this client from this channel. This client will be removed from the presence
      * set and presence subscribers will see a leave message for this client.
-     * <p>
-     * This listener is invoked on a background thread.
      *
      * @param data optional data (eg a status message) for this member.
      * See {@link io.ably.types.Data} for the supported data types.
      * @param listener a listener to be notified on completion of the operation.
+     * <p>
+     * This listener is invoked on a background thread.
      * @throws AblyException
      */
     public void leave(Object data, CompletionListener listener) throws AblyException {
@@ -453,10 +454,10 @@ public class Presence {
     /**
      * Leave this client from this channel. This client will be removed from the presence
      * set and presence subscribers will see a leave message for this client.
-     * <p>
-     * This listener is invoked on a background thread.
      *
      * @param listener a listener to be notified on completion of the operation.
+     * <p>
+     * This listener is invoked on a background thread.
      * @throws AblyException
      */
     public void leave(CompletionListener listener) throws AblyException {
@@ -499,12 +500,12 @@ public class Presence {
      * server instances) that act on behalf of multiple clientIds. In order to be able to
      * enter the channel with this method, the client library must have been instanced
      * either with a key, or with a token bound to the wildcard clientId.
-     * <p>
-     * This listener is invoked on a background thread.
      *
      * @param clientId the id of the client.
      * @param data optional data (eg a status message) for this member.
      * @param listener a listener to be notified on completion of the operation.
+     * <p>
+     * This listener is invoked on a background thread.
      * @throws AblyException
      */
     public void enterClient(String clientId, Object data, CompletionListener listener) throws AblyException {
@@ -553,12 +554,12 @@ public class Presence {
      * presence subscribers will see an enter or update message for this client.
      * As for #enterClient above, the connection must be authenticated in a way that
      * enables it to represent an arbitrary clientId.
-     * <p>
-     * This listener is invoked on a background thread.
      *
      * @param clientId the id of the client.
      * @param data optional data (eg a status message) for this member.
      * @param listener a listener to be notified on completion of the operation.
+     * <p>
+     * This listener is invoked on a background thread.
      * @throws AblyException
      */
     public void updateClient(String clientId, Object data, CompletionListener listener) throws AblyException {
@@ -599,12 +600,12 @@ public class Presence {
     /**
      * Leave a given client from this channel. This client will be removed from the
      * presence set and presence subscribers will see a leave message for this client.
-     * <p>
-     * This listener is invoked on a background thread.
      *
      * @param clientId the id of the client.
      * @param data optional data (eg a status message) for this member.
      * @param listener a listener to be notified on completion of the operation.
+     * <p>
+     * This listener is invoked on a background thread.
      * @throws AblyException
      */
     public void leaveClient(String clientId, Object data, CompletionListener listener) throws AblyException {
@@ -624,11 +625,11 @@ public class Presence {
      * Update the presence for this channel with a given PresenceMessage update.
      * The connection must be authenticated in a way that enables it to represent
      * the clientId in the message.
-     * <p>
-     * This listener is invoked on a background thread.
      *
      * @param msg the presence message
      * @param listener a listener to be notified on completion of the operation.
+     * <p>
+     * This listener is invoked on a background thread.
      * @throws AblyException
      */
     public void updatePresence(PresenceMessage msg, CompletionListener listener) throws AblyException {

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -55,6 +55,8 @@ public class Auth {
          * to obtain token requests or tokens from another entity,
          * so tokens can be renewed without the client requiring a
          * key
+         * <p>
+         * This callback is invoked on a background thread.
          */
         public TokenCallback authCallback;
 

--- a/lib/src/main/java/io/ably/lib/rest/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/rest/ChannelBase.java
@@ -55,9 +55,12 @@ public class ChannelBase {
      * Publish a message on this channel using the REST API.
      * Since the REST API is stateless, this request is made independently
      * of any other request on this or any other channel.
+     * <p>
+     * This listener is invoked on a background thread.
+     *
      * @param name the event name
      * @param data the message payload; see {@link io.ably.types.Data} for
-     * @param listener
+     * @param listener a listener to be notified of the outcome of this message.
      */
     public void publishAsync(String name, Object data, CompletionListener listener) {
         publishImpl(name, data).async(new CompletionListener.ToCallback(listener));
@@ -81,8 +84,11 @@ public class ChannelBase {
 
     /**
      * Asynchronously publish an array of messages on this channel
-     * @param messages
-     * @param listener
+     * <p>
+     * This listener is invoked on a background thread.
+     *
+     * @param messages the message
+     * @param listener a listener to be notified of the outcome of this message.
      */
     public void publishAsync(final Message[] messages, final CompletionListener listener) {
         publishImpl(messages).async(new CompletionListener.ToCallback(listener));
@@ -165,6 +171,9 @@ public class ChannelBase {
 
         /**
          * Asynchronously get the presence state for this Channel.
+         * <p>
+         * This listener is invoked on a background thread.
+         *
          * @param callback on success returns the currently present members.
          */
         public void getAsync(Param[] params, Callback<AsyncPaginatedResult<PresenceMessage>> callback) {
@@ -190,6 +199,9 @@ public class ChannelBase {
 
         /**
          * Asynchronously obtain recent history for this channel using the REST API.
+         * <p>
+         * This listener is invoked on a background thread.
+         *
          * @param params the request params. See the Ably REST API
          * @param callback
          * @return

--- a/lib/src/main/java/io/ably/lib/rest/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/rest/ChannelBase.java
@@ -55,12 +55,12 @@ public class ChannelBase {
      * Publish a message on this channel using the REST API.
      * Since the REST API is stateless, this request is made independently
      * of any other request on this or any other channel.
-     * <p>
-     * This listener is invoked on a background thread.
      *
      * @param name the event name
      * @param data the message payload; see {@link io.ably.types.Data} for
      * @param listener a listener to be notified of the outcome of this message.
+     * <p>
+     * This listener is invoked on a background thread.
      */
     public void publishAsync(String name, Object data, CompletionListener listener) {
         publishImpl(name, data).async(new CompletionListener.ToCallback(listener));
@@ -84,11 +84,11 @@ public class ChannelBase {
 
     /**
      * Asynchronously publish an array of messages on this channel
-     * <p>
-     * This listener is invoked on a background thread.
      *
      * @param messages the message
      * @param listener a listener to be notified of the outcome of this message.
+     * <p>
+     * This listener is invoked on a background thread.
      */
     public void publishAsync(final Message[] messages, final CompletionListener listener) {
         publishImpl(messages).async(new CompletionListener.ToCallback(listener));
@@ -171,10 +171,10 @@ public class ChannelBase {
 
         /**
          * Asynchronously get the presence state for this Channel.
-         * <p>
-         * This listener is invoked on a background thread.
          *
          * @param callback on success returns the currently present members.
+         * <p>
+         * This callback is invoked on a background thread.
          */
         public void getAsync(Param[] params, Callback<AsyncPaginatedResult<PresenceMessage>> callback) {
             getImpl(params).async(callback);
@@ -199,11 +199,11 @@ public class ChannelBase {
 
         /**
          * Asynchronously obtain recent history for this channel using the REST API.
-         * <p>
-         * This listener is invoked on a background thread.
          *
          * @param params the request params. See the Ably REST API
          * @param callback
+         * <p>
+         * This callback is invoked on a background thread.
          * @return
          */
         public void historyAsync(Param[] params, Callback<AsyncPaginatedResult<PresenceMessage>> callback) {

--- a/lib/src/main/java/io/ably/lib/util/EventEmitter.java
+++ b/lib/src/main/java/io/ably/lib/util/EventEmitter.java
@@ -25,9 +25,9 @@ public abstract class EventEmitter<Event, Listener> {
 
     /**
      * Register the given listener for all events
+     * @param listener
      * <p>
      * This listener is invoked on a background thread.
-     * @param listener
      */
     public synchronized void on(Listener listener) {
         if(!listeners.contains(listener))
@@ -36,9 +36,9 @@ public abstract class EventEmitter<Event, Listener> {
 
     /**
      * Register the given listener for a single occurrence of any event
+     * @param listener
      * <p>
      * This listener is invoked on a background thread.
-     * @param listener
      */
     public synchronized void once(Listener listener) {
         filters.put(listener, new Filter(null, listener, true));
@@ -55,9 +55,9 @@ public abstract class EventEmitter<Event, Listener> {
 
     /**
      * Register the given listener for a specific event
+     * @param listener
      * <p>
      * This listener is invoked on a background thread.
-     * @param listener
      */
     public synchronized void on(Event event, Listener listener) {
         filters.put(listener, new Filter(event, listener, false));
@@ -65,9 +65,9 @@ public abstract class EventEmitter<Event, Listener> {
 
     /**
      * Register the given listener for a single occurrence of a specific event
+     * @param listener
      * <p>
      * This listener is invoked on a background thread.
-     * @param listener
      */
     public synchronized void once(Event event, Listener listener) {
         filters.put(listener, new Filter(event, listener, true));

--- a/lib/src/main/java/io/ably/lib/util/EventEmitter.java
+++ b/lib/src/main/java/io/ably/lib/util/EventEmitter.java
@@ -25,6 +25,8 @@ public abstract class EventEmitter<Event, Listener> {
 
     /**
      * Register the given listener for all events
+     * <p>
+     * This listener is invoked on a background thread.
      * @param listener
      */
     public synchronized void on(Listener listener) {
@@ -34,6 +36,8 @@ public abstract class EventEmitter<Event, Listener> {
 
     /**
      * Register the given listener for a single occurrence of any event
+     * <p>
+     * This listener is invoked on a background thread.
      * @param listener
      */
     public synchronized void once(Listener listener) {
@@ -51,6 +55,8 @@ public abstract class EventEmitter<Event, Listener> {
 
     /**
      * Register the given listener for a specific event
+     * <p>
+     * This listener is invoked on a background thread.
      * @param listener
      */
     public synchronized void on(Event event, Listener listener) {
@@ -59,6 +65,8 @@ public abstract class EventEmitter<Event, Listener> {
 
     /**
      * Register the given listener for a single occurrence of a specific event
+     * <p>
+     * This listener is invoked on a background thread.
      * @param listener
      */
     public synchronized void once(Event event, Listener listener) {


### PR DESCRIPTION
As all of our callbacks are invoked on background threads. There was no documentation about which thread is used in Ably Java SDK and this can be a problem for android developers as UI updating needs to be done on the main thread.

I have updated JavaDoc and README of threading in Ably callbacks and their usage. 
I have also added JavaDoc to ChannelStateListener and ConnectionStateListener which were missing.

Please feel free to suggest improvements. 

Closes https://github.com/ably/ably-java/issues/800