### PR TITLE
Increase minSdkVersion to 21 (lollipop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ Visit https://www.ably.com/docs for a complete API reference and more examples.
 
 For Java, JRE 7 or later is required. Note that the [Java Unlimited JCE extensions](http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html) must be installed in the Java runtime environment.
 
-For Android, 4.4 (API level 19) or later is required.
+For Android, 5.0 (API level 21) or later is required.
 
 ## Support, feedback and troubleshooting
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ android {
     compileSdkVersion 30
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 24
         versionCode 1
         versionName version


### PR DESCRIPTION
Increasing the minimum API level to 21 will support 98.6% or more devices while keeping the complexity of the old APIs at a minimum.