### PR TITLE
Fail Ably connection if auth callback throws specific errors

### DIFF
--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -616,7 +616,7 @@ public class Auth {
                     signedTokenRequest = (TokenRequest)authCallbackResponse;
                 else
                     throw AblyException.fromErrorInfo(new ErrorInfo("Invalid authCallback response", 400, 40000));
-            } catch(AblyException e) {
+            } catch (Exception e) {
                 throw AblyException.fromErrorInfo(e, new ErrorInfo("authCallback failed with an exception", 401, 80019));
             }
         } else if(tokenOptions.authUrl != null) {

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -617,11 +617,11 @@ public class Auth {
                     signedTokenRequest = (TokenRequest)authCallbackResponse;
                 else
                     throw AblyException.fromErrorInfo(new ErrorInfo("Invalid authCallback response", 400, 40000));
-            } catch (Exception e) {
-                boolean isTokenExceptionNonRetriable = e instanceof NonRetriableTokenException;
-                boolean isAblyExceptionNonRetriable = e instanceof AblyException && ((AblyException) e).errorInfo.statusCode == 403;
-                boolean shouldNotRetryAuthOperation = isTokenExceptionNonRetriable || isAblyExceptionNonRetriable;
-                int statusCode = shouldNotRetryAuthOperation ? 403 : 401; // RSA4c & RSA4d
+            } catch (final Exception e) {
+                final boolean isTokenExceptionNonRetriable = e instanceof NonRetriableTokenException;
+                final boolean isAblyExceptionNonRetriable = e instanceof AblyException && ((AblyException) e).errorInfo.statusCode == 403;
+                final boolean shouldNotRetryAuthOperation = isTokenExceptionNonRetriable || isAblyExceptionNonRetriable;
+                final int statusCode = shouldNotRetryAuthOperation ? 403 : 401; // RSA4c & RSA4d
                 throw AblyException.fromErrorInfo(e, new ErrorInfo("authCallback failed with an exception", statusCode, 80019));
             }
         } else if(tokenOptions.authUrl != null) {

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -618,8 +618,10 @@ public class Auth {
                 else
                     throw AblyException.fromErrorInfo(new ErrorInfo("Invalid authCallback response", 400, 40000));
             } catch (Exception e) {
+                boolean isTokenExceptionNonRetriable = e instanceof NonRetriableTokenException;
                 boolean isAblyExceptionNonRetriable = e instanceof AblyException && ((AblyException) e).errorInfo.statusCode == 403;
-                int statusCode = isAblyExceptionNonRetriable ? 403 : 401; // RSA4c & RSA4d
+                boolean shouldNotRetryAuthOperation = isTokenExceptionNonRetriable || isAblyExceptionNonRetriable;
+                int statusCode = shouldNotRetryAuthOperation ? 403 : 401; // RSA4c & RSA4d
                 throw AblyException.fromErrorInfo(e, new ErrorInfo("authCallback failed with an exception", statusCode, 80019));
             }
         } else if(tokenOptions.authUrl != null) {

--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -23,6 +23,7 @@ import io.ably.lib.types.BaseMessage;
 import io.ably.lib.types.Capability;
 import io.ably.lib.types.ClientOptions;
 import io.ably.lib.types.ErrorInfo;
+import io.ably.lib.types.NonRetriableTokenException;
 import io.ably.lib.types.Param;
 import io.ably.lib.util.Base64Coder;
 import io.ably.lib.util.Log;
@@ -617,7 +618,9 @@ public class Auth {
                 else
                     throw AblyException.fromErrorInfo(new ErrorInfo("Invalid authCallback response", 400, 40000));
             } catch (Exception e) {
-                throw AblyException.fromErrorInfo(e, new ErrorInfo("authCallback failed with an exception", 401, 80019));
+                boolean isAblyExceptionNonRetriable = e instanceof AblyException && ((AblyException) e).errorInfo.statusCode == 403;
+                int statusCode = isAblyExceptionNonRetriable ? 403 : 401; // RSA4c & RSA4d
+                throw AblyException.fromErrorInfo(e, new ErrorInfo("authCallback failed with an exception", statusCode, 80019));
             }
         } else if(tokenOptions.authUrl != null) {
             Log.i("Auth.requestToken()", "using token auth with auth_url");
@@ -1005,8 +1008,26 @@ public class Auth {
             }
         }
         Log.i("Auth.assertValidToken()", "requesting new token");
-        setTokenDetails(requestToken(params, options));
+        TokenDetails newTokenDetails;
+        try {
+            newTokenDetails = requestToken(params, options);
+        } catch (AblyException ablyException) {
+            if (shouldFailConnectionDueToAuthError(ablyException.errorInfo)) {
+                ably.onAuthError(ablyException.errorInfo); // RSA4d
+            }
+            throw ablyException;
+        }
+        setTokenDetails(newTokenDetails);
         return tokenDetails;
+    }
+
+    /**
+     * RSA4d
+     * [...] the client library should transition to the FAILED state, with an ErrorInfo
+     * (with code 80019, statusCode 403, and cause set to the underlying cause) [...]
+     */
+    private boolean shouldFailConnectionDueToAuthError(ErrorInfo errorInfo) {
+        return errorInfo.statusCode == 403 && errorInfo.code == 80019;
     }
 
     private boolean tokenValid(TokenDetails tokenDetails) {

--- a/lib/src/main/java/io/ably/lib/types/NonRetriableTokenException.java
+++ b/lib/src/main/java/io/ably/lib/types/NonRetriableTokenException.java
@@ -1,7 +1,7 @@
 package io.ably.lib.types;
 
 /**
- * Implement this interface in your exception class if the token auth operation should not be retried.
+ * Implement this marker interface in your exception class if the token auth operation should not be retried.
  */
 public interface NonRetriableTokenException {
 

--- a/lib/src/main/java/io/ably/lib/types/NonRetriableTokenException.java
+++ b/lib/src/main/java/io/ably/lib/types/NonRetriableTokenException.java
@@ -1,0 +1,8 @@
+package io.ably.lib.types;
+
+/**
+ * Implement this interface in your exception class if the token auth operation should not be retried.
+ */
+public interface NonRetriableTokenException {
+
+}


### PR DESCRIPTION
The [RSA4d](https://docs.ably.com/client-lib-development-guide/features/#RSA4d) was not implemented properly as it only applied when you called `ably.auth.authorize()`. Now it applies whenever the token auth is being used.

When an exception is thrown from the token auth callback that has the `statusCode` set to 403 it should fail the connection https://github.com/ably/ably-java/pull/834/commits/aa1415904032391f3fa50aa908ede91bc8fedbf1.
Additionally, after [a discussion](https://github.com/ably/ably-asset-tracking-android/pull/745#issuecomment-1228170544) we've decided that we should not force SDK users to throw an `AblyException`. They should be able to throw any exception and it should be propagated and handled correctly https://github.com/ably/ably-java/pull/834/commits/92c260f3d7c0c8ee503a24b7cca51ad1e88db7d4. 
Furthermore, a new exception interface is added and when an exception implements it, we treat it as if it was an Ably exception with status code 403 https://github.com/ably/ably-java/pull/834/commits/5a23d44937600499d271d4166da0106492b9d869.

According to [RSA4d1](https://docs.ably.com/client-lib-development-guide/features/#RSA4d1) this behaviour could not happen in the `requestToken()` method but luckily the method is only used in the `assertValidToken()` method. Therefore, I've put the logic responsible for failing the connection there.

I wonder if we should also update some docs that would let users know about the new behaviour, WDYT?