### PR TITLE
Provide a path for user when transport is null

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -947,7 +947,6 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
         ConnectionManager.State connectionState = connectionManager.getConnectionState();
         boolean queueMessages = ably.options.queueMessages;
         if(!connectionManager.isActive() || (connectionState.queueEvents && !queueMessages)) {
-            listener.onError(connectionState.defaultErrorInfo);
             throw AblyException.fromErrorInfo(connectionState.defaultErrorInfo);
         }
         boolean connected = (connectionState.sendEvents);

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -947,6 +947,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
         ConnectionManager.State connectionState = connectionManager.getConnectionState();
         boolean queueMessages = ably.options.queueMessages;
         if(!connectionManager.isActive() || (connectionState.queueEvents && !queueMessages)) {
+            listener.onError(connectionState.defaultErrorInfo);
             throw AblyException.fromErrorInfo(connectionState.defaultErrorInfo);
         }
         boolean connected = (connectionState.sendEvents);

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1544,6 +1544,7 @@ public class ConnectionManager implements ConnectListener {
     private void sendImpl(ProtocolMessage message, CompletionListener listener) throws AblyException {
         if(transport == null) {
             Log.v(TAG, "sendImpl(): Discarding message; transport unavailable");
+            listener.onError(new ErrorInfo("Unable to send message; transport unavailable", 500, 50000));
             return;
         }
         if(ProtocolMessage.ackRequired(message)) {

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1543,13 +1543,9 @@ public class ConnectionManager implements ConnectListener {
 
     private void sendImpl(ProtocolMessage message, CompletionListener listener) throws AblyException {
         if(transport == null) {
-            Log.v(TAG, "sendImpl(): Discarding message; transport unavailable");
-            if (listener != null){
-                listener.onError(new ErrorInfo("Unable to send message; transport unavailable", 80009, 80009));
-            }
-
-            return;
+            throw AblyException.fromErrorInfo(new ErrorInfo("Unable to send message; transport unavailable", 80009, 80009));
         }
+
         if(ProtocolMessage.ackRequired(message)) {
             message.msgSerial = msgSerial++;
             pendingMessages.push(new QueuedMessage(message, listener));

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1544,7 +1544,10 @@ public class ConnectionManager implements ConnectListener {
     private void sendImpl(ProtocolMessage message, CompletionListener listener) throws AblyException {
         if(transport == null) {
             Log.v(TAG, "sendImpl(): Discarding message; transport unavailable");
-            listener.onError(new ErrorInfo("Unable to send message; transport unavailable", 500, 50000));
+            if (listener != null){
+                listener.onError(new ErrorInfo("Unable to send message; transport unavailable", 500, 50000));
+            }
+
             return;
         }
         if(ProtocolMessage.ackRequired(message)) {

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1545,7 +1545,7 @@ public class ConnectionManager implements ConnectListener {
         if(transport == null) {
             Log.v(TAG, "sendImpl(): Discarding message; transport unavailable");
             if (listener != null){
-                listener.onError(new ErrorInfo("Unable to send message; transport unavailable", 500, 50000));
+                listener.onError(new ErrorInfo("Unable to send message; transport unavailable", 80009, 80009));
             }
 
             return;


### PR DESCRIPTION
This change provides a path where `sendImpl` function returns without a callback or through throwing an exception. This PR addresses that without changing synchronization policy of the `ConnectionManager`
