### PR TITLE
Revert to protocol 1.1

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/Defaults.java
+++ b/lib/src/main/java/io/ably/lib/transport/Defaults.java
@@ -9,7 +9,7 @@ import java.util.Locale;
 
 public class Defaults {
     /* versions */
-    public static final float ABLY_VERSION_NUMBER   = 1.2f;
+    public static final float ABLY_VERSION_NUMBER   = 1.1f;
     public static final String ABLY_VERSION         = new DecimalFormat("0.0", new DecimalFormatSymbols(Locale.ENGLISH)).format(ABLY_VERSION_NUMBER);
     public static final String ABLY_AGENT_VERSION   = String.format("%s/%s", "ably-java", BuildConfig.VERSION);
 

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeHttpHeaderTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeHttpHeaderTest.java
@@ -81,7 +81,7 @@ public class RealtimeHttpHeaderTest extends ParameterizedTest {
              * Defaults.ABLY_VERSION_PARAM, as ultimately the request param has been derived from those values.
              */
             assertEquals("Verify correct version", requestParameters.get("v"),
-                    Collections.singletonList("1.2"));
+                    Collections.singletonList("1.1"));
 
             /* Spec RSC7d3
              * This test should not directly validate version against Defaults.ABLY_AGENT_VERSION, nor

--- a/lib/src/test/java/io/ably/lib/test/rest/HttpHeaderTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/HttpHeaderTest.java
@@ -84,7 +84,7 @@ public class HttpHeaderTest extends ParameterizedTest {
              * from those values.
              */
             Assert.assertNotNull("Expected headers", headers);
-            Assert.assertEquals(headers.get("x-ably-version"), "1.2");
+            Assert.assertEquals(headers.get("x-ably-version"), "1.1");
             Assert.assertEquals(headers.get("ably-agent"), expectedAblyAgentHeader);
         } catch (AblyException e) {
             e.printStackTrace();

--- a/lib/src/test/java/io/ably/lib/transport/DefaultsTest.java
+++ b/lib/src/test/java/io/ably/lib/transport/DefaultsTest.java
@@ -9,7 +9,7 @@ public class DefaultsTest {
 
     @Test
     public void versions() {
-        assertThat(Defaults.ABLY_VERSION, is("1.2"));
+        assertThat(Defaults.ABLY_VERSION, is("1.1"));
     }
 
     @Test


### PR DESCRIPTION
We will be reverting to protocol 1.1 in order to quick-fix an urgent issue with automatic presence re-enter. The protocol will be bumped to 1.2 again once the presence issue is fixed on the client side.

This PR aims to revert the work done in https://github.com/ably/ably-java/pull/591