### PR TITLE
Stop hiding flakey test failures

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'de.fuerstenau.buildconfig' version '1.1.8'
     id 'checkstyle'
-    id 'org.gradle.test-retry' version '1.2.0'
 }
 
 apply plugin: 'java'
@@ -80,10 +79,6 @@ task testRealtimeSuite(type: Test) {
     }
     outputs.upToDateWhen { false }
     testLogging.exceptionFormat = 'full'
-    retry {
-        maxRetries = 3
-        maxFailures = 4
-    }
 }
 
 task testRestSuite(type: Test) {
@@ -95,10 +90,6 @@ task testRestSuite(type: Test) {
     }
     outputs.upToDateWhen { false }
     testLogging.exceptionFormat = 'full'
-    retry {
-        maxRetries = 3
-        maxFailures = 4
-    }
 }
 
 /*


### PR DESCRIPTION
We had our reasons for https://github.com/ably/ably-java/pull/642 at the time, but we need to stop hiding under the blanket of comfort offered by artificially induced green CI. We need to know when tests are failing so we can fix them.