### PR TITLE
Enable and fix ignored tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,5 +8,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - run: ./gradlew checkstyleMain checkstyleTest checkWithCodenarc runUnitTests
+        uses: actions/checkout@v2
+         with:
+           submodules: recursive
+        run: ./gradlew checkstyleMain checkstyleTest checkWithCodenarc runUnitTests

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -4,10 +4,15 @@ on:
     branches:
       - main
 
+concurrency:
+  group: it-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-rest:
     name: Run REST tests
     runs-on: ubuntu-latest
+    concurrency: it-job-${{ github.ref }}
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v2
@@ -26,9 +31,8 @@ jobs:
 
   check-realtime:
     name: Run Realtime tests
-    if: ${{ always() }}
-    needs: check-rest
     runs-on: ubuntu-latest
+    concurrency: it-job-${{ github.ref }}
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v2

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,11 +8,17 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-      - run: ./gradlew :java:testRestSuite :java:testRealtimeSuite
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
 
-      - uses: actions/upload-artifact@v2
+      - name: Run tests with gradle
+        run: ./gradlew :java:testRestSuite :java:testRealtimeSuite
+
+      - name: Upload results
+        uses: actions/upload-artifact@v2
         if: always()
         with:
           name: java-build-reports

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: java-build-reports
+          name: java-build-reports-rest
           path: java/build/reports/
 
   check-realtime:
@@ -46,5 +46,5 @@ jobs:
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: java-build-reports
+          name: java-build-reports-realtime
           path: java/build/reports/

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,7 +5,7 @@ on:
       - main
 
 jobs:
-  check:
+  check-rest:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository and submodules
@@ -13,8 +13,26 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Run tests with gradle
-        run: ./gradlew :java:testRestSuite :java:testRealtimeSuite
+      - name: Run REST tests
+        run: ./gradlew :java:testRestSuite
+
+      - name: Upload results
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: java-build-reports
+          path: java/build/reports/
+
+  check-realtime:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Run Realtime tests
+        run: ./gradlew :java:testRealtimeSuite
 
       - name: Upload results
         uses: actions/upload-artifact@v2

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,11 +8,10 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout repository and submodules
         uses: actions/checkout@v2
-
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
+        with:
+          submodules: recursive
 
       - name: Run tests with gradle
         run: ./gradlew :java:testRestSuite :java:testRealtimeSuite

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   check-rest:
+    name: Run REST tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository and submodules
@@ -24,6 +25,9 @@ jobs:
           path: java/build/reports/
 
   check-realtime:
+    name: Run Realtime tests
+    if: ${{ always() }}
+    needs: check-rest
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository and submodules

--- a/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
@@ -725,6 +725,13 @@ public class ConnectionManagerTest extends ParameterizedTest {
             /* Wait for both channels to reattach and verify state histories match the expected ones */
             attachedChannelWaiter.waitFor(ChannelState.attached);
             suspendedChannelWaiter.waitFor(ChannelState.attached);
+
+            /* Wait for callback to fill lists after attached event*/
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+            }
+
             assertEquals("Attached channel histories do not match", attachedChannelHistory, expectedAttachedChannelHistory);
             assertEquals("Suspended channel histories do not match", suspendedChannelHistory, expectedSuspendedChannelHistory);
         }

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
@@ -668,7 +668,6 @@ public class RealtimeAuthTest extends ParameterizedTest {
      * object that contains an incompatible clientId, the library should ... transition
      *  the connection state to FAILED
      */
-    @Ignore("FIXME flaky test, Verify failure error code indicates clientId mismatch expected:<40100> but was:<40101>")
     @Test
     public void auth_client_match_token_clientId_fail() {
         try {
@@ -678,13 +677,13 @@ public class RealtimeAuthTest extends ParameterizedTest {
 
             /* get token */
             Auth.TokenParams tokenParams = new Auth.TokenParams();
-            tokenParams.clientId = "token clientId";
+            tokenParams.clientId = "tokenclientid";
             Auth.TokenDetails tokenDetails = ablyForToken.auth.requestToken(tokenParams, null);
             assertNotNull("Expected token value", tokenDetails.token);
 
             /* create ably realtime with tokenDetails and clientId */
             ClientOptions opts = createOptions();
-            opts.clientId = "options clientId";
+            opts.clientId = "optionsclientid";
             opts.token = tokenDetails.token;
             AblyRealtime ablyRealtime = new AblyRealtime(opts);
 

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
@@ -174,6 +174,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
      */
     @Test
     public void auth_client_fails_when_auth_token_fails_with_non_retriable_exception() {
+        AblyRealtime ablyRealtime = null;
         try {
             class NonRetriableRuntimeException extends RuntimeException implements NonRetriableTokenException {
                 NonRetriableRuntimeException(){
@@ -182,15 +183,16 @@ public class RealtimeAuthTest extends ParameterizedTest {
             }
 
             Exception exception = new NonRetriableRuntimeException();
-            final AblyRealtime ablyRealtime = createAblyRealtimeWithTokenAuthError(exception);
-
+            ablyRealtime = createAblyRealtimeWithTokenAuthError(exception);
             ablyRealtime.connection.connect();
 
             waitAndAssertConnectionState(ablyRealtime, ConnectionState.failed, 403, 80019);
-            ablyRealtime.close();
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
+        } finally {
+            if (ablyRealtime != null)
+                ablyRealtime.close();
         }
     }
 
@@ -199,17 +201,19 @@ public class RealtimeAuthTest extends ParameterizedTest {
      */
     @Test
     public void auth_client_fails_when_auth_token_fails_with_ably_exception_with_status_code_403() {
+        AblyRealtime ablyRealtime = null;
         try {
             Exception exception = AblyException.fromErrorInfo(new ErrorInfo("A non retriable Ably exception", 403, 80040));
-            final AblyRealtime ablyRealtime = createAblyRealtimeWithTokenAuthError(exception);
-
+            ablyRealtime = createAblyRealtimeWithTokenAuthError(exception);
             ablyRealtime.connection.connect();
 
             waitAndAssertConnectionState(ablyRealtime, ConnectionState.failed, 403, 80019);
-            ablyRealtime.close();
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
+        } finally {
+            if (ablyRealtime != null)
+                ablyRealtime.close();
         }
     }
 
@@ -218,17 +222,19 @@ public class RealtimeAuthTest extends ParameterizedTest {
      */
     @Test
     public void auth_client_does_not_fail_when_auth_token_fails_with_an_ably_exception() {
+        AblyRealtime ablyRealtime = null;
         try {
             Exception exception = AblyException.fromErrorInfo(new ErrorInfo("An Ably exception", 401, 80040));
-            final AblyRealtime ablyRealtime = createAblyRealtimeWithTokenAuthError(exception);
-
+            ablyRealtime = createAblyRealtimeWithTokenAuthError(exception);
             ablyRealtime.connection.connect();
 
             waitAndAssertConnectionState(ablyRealtime, ConnectionState.disconnected, 401, 80019);
-            ablyRealtime.close();
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
+        } finally {
+            if (ablyRealtime != null)
+                ablyRealtime.close();
         }
     }
 
@@ -237,17 +243,19 @@ public class RealtimeAuthTest extends ParameterizedTest {
      */
     @Test
     public void auth_client_does_not_fail_when_auth_token_fails_with_a_runtime_exception() {
+        AblyRealtime ablyRealtime = null;
         try {
             Exception exception = new RuntimeException("A runtime exception");
-            final AblyRealtime ablyRealtime = createAblyRealtimeWithTokenAuthError(exception);
-
+            ablyRealtime = createAblyRealtimeWithTokenAuthError(exception);
             ablyRealtime.connection.connect();
 
             waitAndAssertConnectionState(ablyRealtime, ConnectionState.disconnected, 401, 80019);
-            ablyRealtime.close();
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
+        } finally {
+            if (ablyRealtime != null)
+                ablyRealtime.close();
         }
     }
 

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
@@ -89,7 +89,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
             assertEquals("Verify connected state is reached", ConnectionState.connected, ablyRealtime.connection.state);
 
             /* check expected clientId */
-            assertEquals("Auth#clientId is expected to be null", null, ablyRealtime.auth.clientId);
+            assertNull("Auth#clientId is expected to be null", ablyRealtime.auth.clientId);
 
             ablyRealtime.close();
         } catch (AblyException e) {
@@ -162,6 +162,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
             connectionWaiter.waitFor(ConnectionState.failed);
             assertEquals("Verify connected state has failed", ConnectionState.failed, ablyRealtime.connection.state);
             assertEquals("Check correct cause error code", 403, ablyRealtime.connection.reason.statusCode);
+            ablyRealtime.close();
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
@@ -186,6 +187,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
             ablyRealtime.connection.connect();
 
             waitAndAssertConnectionState(ablyRealtime, ConnectionState.failed, 403, 80019);
+            ablyRealtime.close();
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
@@ -204,6 +206,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
             ablyRealtime.connection.connect();
 
             waitAndAssertConnectionState(ablyRealtime, ConnectionState.failed, 403, 80019);
+            ablyRealtime.close();
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
@@ -222,6 +225,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
             ablyRealtime.connection.connect();
 
             waitAndAssertConnectionState(ablyRealtime, ConnectionState.disconnected, 401, 80019);
+            ablyRealtime.close();
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
@@ -240,6 +244,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
             ablyRealtime.connection.connect();
 
             waitAndAssertConnectionState(ablyRealtime, ConnectionState.disconnected, 401, 80019);
+            ablyRealtime.close();
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
@@ -583,8 +588,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
 
             ablyRealtime.close();
         } catch (AblyException e) {
-            e.printStackTrace();
-            fail();
+            fail("Unknown error occurred: " + e.getMessage());
         }
     }
 
@@ -624,8 +628,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
 
             ablyRealtime.close();
         } catch (AblyException e) {
-            e.printStackTrace();
-            fail();
+            fail("Unknown error occurred: " + e.getMessage());
         }
     }
 
@@ -655,6 +658,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
             opts.clientId = "options clientId";
             opts.tokenDetails = tokenDetails;
             AblyRealtime ablyRealtime = new AblyRealtime(opts);
+            ablyRealtime.close();
         } catch (AblyException e) {
             assertEquals("Verify error code indicates clientId mismatch", e.errorInfo.code, 40101);
         }
@@ -692,9 +696,9 @@ public class RealtimeAuthTest extends ParameterizedTest {
             ErrorInfo failure = connectionWaiter.waitFor(ConnectionState.failed);
             assertEquals("Verify failed state is reached", ConnectionState.failed, ablyRealtime.connection.state);
             assertEquals("Verify failure error code indicates clientId mismatch", failure.code, 40101);
+            ablyRealtime.close();
         } catch (AblyException e) {
-            e.printStackTrace();
-            fail();
+            fail("Unknown error occurred: " + e.getMessage());
         }
     }
 

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
@@ -672,6 +672,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
      * object that contains an incompatible clientId, the library should ... transition
      *  the connection state to FAILED
      */
+    @Ignore("FIXME flaky test, Verify failure error code indicates clientId mismatch expected:<40100> but was:<40101>")
     @Test
     public void auth_client_match_token_clientId_fail() {
         try {

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -667,6 +668,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
      * object that contains an incompatible clientId, the library should ... transition
      *  the connection state to FAILED
      */
+    @Ignore("FIXME flaky test, Verify failure error code indicates clientId mismatch expected:<40100> but was:<40101>")
     @Test
     public void auth_client_match_token_clientId_fail() {
         try {

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -668,7 +667,6 @@ public class RealtimeAuthTest extends ParameterizedTest {
      * object that contains an incompatible clientId, the library should ... transition
      *  the connection state to FAILED
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void auth_client_match_token_clientId_fail() {
         try {
@@ -826,7 +824,6 @@ public class RealtimeAuthTest extends ParameterizedTest {
      * are sent with explicit clientId
      * Spec: RTL6g4
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void auth_clientid_publish_explicit_before_identified() {
         AblyRealtime ably = null;

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
@@ -65,6 +65,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
      */
     @Test
     public void auth_client_match_tokendetails_null_clientId() {
+        AblyRealtime ablyRealtime = null;
         try {
             /* init ably for token */
             ClientOptions optsForToken = createOptions(testVars.keys[0].keyStr);
@@ -80,7 +81,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
             ClientOptions opts = createOptions();
             opts.clientId = null;
             opts.tokenDetails = tokenDetails;
-            AblyRealtime ablyRealtime = new AblyRealtime(opts);
+            ablyRealtime = new AblyRealtime(opts);
             System.out.println("done create ably");
 
             /* wait for connected state */
@@ -90,11 +91,12 @@ public class RealtimeAuthTest extends ParameterizedTest {
 
             /* check expected clientId */
             assertNull("Auth#clientId is expected to be null", ablyRealtime.auth.clientId);
-
-            ablyRealtime.close();
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
+        } finally {
+            if (ablyRealtime != null)
+                ablyRealtime.close();
         }
     }
 
@@ -305,6 +307,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
      */
     @Test
     public void auth_client_match_token_null_clientId() {
+        AblyRealtime ablyRealtime = null;
         try {
             /* init ably for token */
             ClientOptions optsForToken = createOptions(testVars.keys[0].keyStr);
@@ -320,7 +323,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
             ClientOptions opts = createOptions();
             opts.clientId = null;
             opts.token = tokenDetails.token;
-            AblyRealtime ablyRealtime = new AblyRealtime(opts);
+            ablyRealtime = new AblyRealtime(opts);
             System.out.println("done create ably");
 
             /* wait for connected state */
@@ -329,12 +332,13 @@ public class RealtimeAuthTest extends ParameterizedTest {
             assertEquals("Verify connected state is reached", ConnectionState.connected, ablyRealtime.connection.state);
 
             /* check expected clientId */
-            assertEquals("Auth#clientId is expected to be null", null, ablyRealtime.auth.clientId);
-
-            ablyRealtime.close();
+            assertNull("Auth#clientId is expected to be null", ablyRealtime.auth.clientId);
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
+        } finally {
+            if (ablyRealtime != null)
+                ablyRealtime.close();
         }
     }
 
@@ -345,6 +349,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
      */
     @Test
     public void auth_clientid_null_before_auth() {
+        AblyRealtime ablyRealtime = null;
         try {
             final String clientId = "token clientId";
 
@@ -359,10 +364,10 @@ public class RealtimeAuthTest extends ParameterizedTest {
             opts.clientId = null;
             opts.token = tokenDetails.token;
             opts.autoConnect = false;
-            AblyRealtime ablyRealtime = new AblyRealtime(opts);
+            ablyRealtime = new AblyRealtime(opts);
 
             /* check expected clientId */
-            assertEquals("Auth#clientId is expected to be null", null, ablyRealtime.auth.clientId);
+            assertNull("Auth#clientId is expected to be null", ablyRealtime.auth.clientId);
 
             /* wait for connected state */
             ablyRealtime.connection.connect();
@@ -372,11 +377,12 @@ public class RealtimeAuthTest extends ParameterizedTest {
 
             /* check expected clientId */
             assertEquals("Auth#clientId is expected to be set", clientId, ablyRealtime.auth.clientId);
-
-            ablyRealtime.close();
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
+        } finally {
+            if (ablyRealtime != null)
+                ablyRealtime.close();
         }
     }
 
@@ -393,6 +399,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
      */
     @Test
     public void auth_client_match_tokendetails_wildcard_clientId() {
+        AblyRealtime ablyRealtime = null;
         try {
             /* init ably for token */
             ClientOptions optsForToken = createOptions(testVars.keys[0].keyStr);
@@ -408,7 +415,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
             ClientOptions opts = createOptions();
             opts.clientId = "options clientId";
             opts.tokenDetails = tokenDetails;
-            AblyRealtime ablyRealtime = new AblyRealtime(opts);
+            ablyRealtime = new AblyRealtime(opts);
             System.out.println("done create ably");
 
             /* wait for connected state */
@@ -418,11 +425,12 @@ public class RealtimeAuthTest extends ParameterizedTest {
 
             /* check expected clientId */
             assertEquals("Auth#clientId is expected to be set", "options clientId", ablyRealtime.auth.clientId);
-
-            ablyRealtime.close();
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
+        } finally {
+            if (ablyRealtime != null)
+                ablyRealtime.close();
         }
     }
 
@@ -439,6 +447,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
      */
     @Test
     public void auth_client_match_token_wildcard_clientId() {
+        AblyRealtime ablyRealtime = null;
         try {
             /* init ably for token */
             ClientOptions optsForToken = createOptions(testVars.keys[0].keyStr);
@@ -454,7 +463,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
             ClientOptions opts = createOptions();
             opts.clientId = "options clientId";
             opts.token = tokenDetails.token;
-            AblyRealtime ablyRealtime = new AblyRealtime(opts);
+            ablyRealtime = new AblyRealtime(opts);
             System.out.println("done create ably");
 
             /* wait for connected state */
@@ -464,11 +473,12 @@ public class RealtimeAuthTest extends ParameterizedTest {
 
             /* check expected clientId */
             assertEquals("Auth#clientId is expected to be set", "options clientId", ablyRealtime.auth.clientId);
-
-            ablyRealtime.close();
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
+        } finally {
+            if (ablyRealtime != null)
+                ablyRealtime.close();
         }
     }
 
@@ -483,6 +493,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
      */
     @Test
     public void auth_client_null_match_tokendetails_wildcard_clientId() {
+        AblyRealtime ablyRealtime = null;
         try {
             /* init ably for token */
             ClientOptions optsForToken = createOptions(testVars.keys[0].keyStr);
@@ -498,7 +509,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
             ClientOptions opts = createOptions();
             opts.clientId = null;
             opts.tokenDetails = tokenDetails;
-            AblyRealtime ablyRealtime = new AblyRealtime(opts);
+            ablyRealtime = new AblyRealtime(opts);
             System.out.println("done create ably");
 
             /* wait for connected state */
@@ -508,11 +519,12 @@ public class RealtimeAuthTest extends ParameterizedTest {
 
             /* check expected clientId */
             assertEquals("Auth#clientId is expected to be set", "*", ablyRealtime.auth.clientId);
-
-            ablyRealtime.close();
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
+        } finally {
+            if (ablyRealtime != null)
+                ablyRealtime.close();
         }
     }
 
@@ -527,6 +539,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
      */
     @Test
     public void auth_client_null_match_token_wildcard_clientId() {
+        AblyRealtime ablyRealtime = null;
         try {
             /* init ably for token */
             ClientOptions optsForToken = createOptions(testVars.keys[0].keyStr);
@@ -542,7 +555,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
             ClientOptions opts = createOptions();
             opts.clientId = null;
             opts.token = tokenDetails.token;
-            AblyRealtime ablyRealtime = new AblyRealtime(opts);
+            ablyRealtime = new AblyRealtime(opts);
             System.out.println("done create ably");
 
             /* wait for connected state */
@@ -552,11 +565,12 @@ public class RealtimeAuthTest extends ParameterizedTest {
 
             /* check expected clientId */
             assertEquals("Auth#clientId is expected to be set", "*", ablyRealtime.auth.clientId);
-
-            ablyRealtime.close();
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
+        } finally {
+            if (ablyRealtime != null)
+                ablyRealtime.close();
         }
     }
 
@@ -569,6 +583,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
      */
     @Test
     public void auth_client_match_tokendetails_clientId() {
+        AblyRealtime ablyRealtime = null;
         try {
             /* init ably for token */
             ClientOptions optsForToken = createOptions(testVars.keys[0].keyStr);
@@ -584,7 +599,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
             ClientOptions opts = createOptions();
             opts.clientId = "options clientId";
             opts.tokenDetails = tokenDetails;
-            AblyRealtime ablyRealtime = new AblyRealtime(opts);
+            ablyRealtime = new AblyRealtime(opts);
 
             /* wait for connected state */
             Helpers.ConnectionWaiter connectionWaiter = new Helpers.ConnectionWaiter(ablyRealtime.connection);
@@ -593,10 +608,11 @@ public class RealtimeAuthTest extends ParameterizedTest {
 
             /* check expected clientId */
             assertEquals("Auth#clientId is expected to be set", "options clientId", ablyRealtime.auth.clientId);
-
-            ablyRealtime.close();
         } catch (AblyException e) {
             fail("Unknown error occurred: " + e.getMessage());
+        } finally {
+            if (ablyRealtime != null)
+                ablyRealtime.close();
         }
     }
 
@@ -609,6 +625,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
      */
     @Test
     public void auth_client_match_token_clientId() {
+        AblyRealtime ablyRealtime = null;
         try {
             /* init ably for token */
             ClientOptions optsForToken = createOptions(testVars.keys[0].keyStr);
@@ -624,7 +641,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
             ClientOptions opts = createOptions();
             opts.clientId = "options clientId";
             opts.token = tokenDetails.token;
-            AblyRealtime ablyRealtime = new AblyRealtime(opts);
+            ablyRealtime = new AblyRealtime(opts);
 
             /* wait for connected state */
             Helpers.ConnectionWaiter connectionWaiter = new Helpers.ConnectionWaiter(ablyRealtime.connection);
@@ -633,10 +650,11 @@ public class RealtimeAuthTest extends ParameterizedTest {
 
             /* check expected clientId */
             assertEquals("Auth#clientId is expected to be set", "options clientId", ablyRealtime.auth.clientId);
-
-            ablyRealtime.close();
         } catch (AblyException e) {
             fail("Unknown error occurred: " + e.getMessage());
+        } finally {
+            if (ablyRealtime != null)
+                ablyRealtime.close();
         }
     }
 
@@ -683,6 +701,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
     @Ignore("FIXME flaky test, Verify failure error code indicates clientId mismatch expected:<40100> but was:<40101>")
     @Test
     public void auth_client_match_token_clientId_fail() {
+        AblyRealtime ablyRealtime = null;
         try {
             /* init ably for token */
             ClientOptions optsForToken = createOptions(testVars.keys[0].keyStr);
@@ -698,16 +717,18 @@ public class RealtimeAuthTest extends ParameterizedTest {
             ClientOptions opts = createOptions();
             opts.clientId = "optionsclientid";
             opts.token = tokenDetails.token;
-            AblyRealtime ablyRealtime = new AblyRealtime(opts);
+            ablyRealtime = new AblyRealtime(opts);
 
             /* wait for failed state */
             Helpers.ConnectionWaiter connectionWaiter = new Helpers.ConnectionWaiter(ablyRealtime.connection);
             ErrorInfo failure = connectionWaiter.waitFor(ConnectionState.failed);
             assertEquals("Verify failed state is reached", ConnectionState.failed, ablyRealtime.connection.state);
             assertEquals("Verify failure error code indicates clientId mismatch", failure.code, 40101);
-            ablyRealtime.close();
         } catch (AblyException e) {
             fail("Unknown error occurred: " + e.getMessage());
+        } finally {
+            if (ablyRealtime != null)
+                ablyRealtime.close();
         }
     }
 
@@ -718,6 +739,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
      */
     @Test
     public void auth_clientid_publish_implicit() {
+        AblyRealtime ablyRealtime = null;
         try {
             String clientId = "test clientId";
 
@@ -727,14 +749,14 @@ public class RealtimeAuthTest extends ParameterizedTest {
             fillInOptions(options);
             options.clientId = clientId;
             options.protocolListener = protocolListener;
-            AblyRealtime ably = new AblyRealtime(options);
+            ablyRealtime = new AblyRealtime(options);
 
             /* wait until connected */
-            (new ConnectionWaiter(ably.connection)).waitFor(ConnectionState.connected);
-            assertEquals("Verify connected state reached", ably.connection.state, ConnectionState.connected);
+            (new ConnectionWaiter(ablyRealtime.connection)).waitFor(ConnectionState.connected);
+            assertEquals("Verify connected state reached", ablyRealtime.connection.state, ConnectionState.connected);
 
             /* create a channel and attach */
-            Channel channel = ably.channels.get("auth_clientid_publish_implicit_" + testParams.name);
+            Channel channel = ablyRealtime.channels.get("auth_clientid_publish_implicit_" + testParams.name);
             channel.attach();
             (new ChannelWaiter(channel)).waitFor(ChannelState.attached);
             assertEquals("Verify attached state reached", channel.state, ChannelState.attached);
@@ -751,7 +773,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
 
             /* Get sent message */
             Message messagePublished = protocolListener.sentMessages.get(0).messages[0];
-            assertEquals("Sent message does not contain clientId", messagePublished.clientId, null);
+            assertNull("Sent message does not contain clientId", messagePublished.clientId);
 
             /* wait until message received on transport */
             protocolListener.waitForRecv(1);
@@ -797,7 +819,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
             channel.publish(messageToPublish, pubComplete.add());
             pubComplete.waitFor();
             assertTrue("Verify publish callback called on completion", pubComplete.pending.isEmpty());
-            assertTrue("Verify publish callback returns an error", pubComplete.errors.size() == 1);
+            assertEquals("Verify publish callback returns an error", 1, pubComplete.errors.size());
             assertEquals("Verify publish callback error has expected error code", pubComplete.errors.iterator().next().code, 40012);
 
             /* verify no message sent or received on transport */
@@ -816,7 +838,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
 
             /* Get sent message */
             messagePublished = protocolListener.sentMessages.get(0).messages[0];
-            assertEquals("Sent message does not contain clientId", messagePublished.clientId, null);
+            assertNull("Sent message does not contain clientId", messagePublished.clientId);
 
             /* wait until message received on transport */
             protocolListener.waitForRecv(1);
@@ -824,11 +846,12 @@ public class RealtimeAuthTest extends ParameterizedTest {
             /* Get received message */
             messageReceived = protocolListener.receivedMessages.get(0).messages[0];
             assertEquals("Received message does contain clientId", messageReceived.clientId, clientId);
-
-            ably.close();
         } catch (Exception e) {
             e.printStackTrace();
             fail("auth_clientid_publish_implicit: Unexpected exception");
+        } finally {
+            if (ablyRealtime != null)
+                ablyRealtime.close();
         }
     }
 
@@ -904,7 +927,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
 
             /* Get sent message */
             messagePublished = protocolListener.sentMessages.get(0).messages[0];
-            assertEquals("Sent message does not contain clientId", messagePublished.clientId, null);
+            assertNull("Sent message does not contain clientId", messagePublished.clientId);
 
             /* wait until message received on transport */
             protocolListener.waitForRecv(1);

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
@@ -1,5 +1,20 @@
 package io.ably.lib.test.realtime;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import io.ably.lib.debug.DebugOptions;
 import io.ably.lib.realtime.AblyRealtime;
 import io.ably.lib.realtime.Channel;
@@ -23,20 +38,6 @@ import io.ably.lib.types.Message;
 import io.ably.lib.types.NonRetriableTokenException;
 import io.ably.lib.types.Param;
 import io.ably.lib.types.ProtocolMessage;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public class RealtimeAuthTest extends ParameterizedTest {
 
@@ -1114,8 +1115,8 @@ public class RealtimeAuthTest extends ParameterizedTest {
                 final CountDownLatch latch = new CountDownLatch(1);
                 final AtomicBoolean isCalled = new AtomicBoolean(false);
                 ably.auth.renewAuth((success, tokenDetails1, errorInfo) -> {
-                    latch.countDown();
                     isCalled.set(true);
+                    latch.countDown();
                 });
                 latch.await(30, TimeUnit.SECONDS);
                 assertTrue("Callback not invoked", isCalled.get());

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelHistoryTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelHistoryTest.java
@@ -8,15 +8,13 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.util.HashMap;
-import java.util.Locale;
-
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
+
+import java.util.HashMap;
+import java.util.Locale;
 
 import io.ably.lib.realtime.AblyRealtime;
 import io.ably.lib.realtime.Channel;
@@ -32,22 +30,10 @@ import io.ably.lib.types.Message;
 import io.ably.lib.types.PaginatedResult;
 import io.ably.lib.types.Param;
 
-@Ignore("FIXME: fix exceptions")
 public class RealtimeChannelHistoryTest extends ParameterizedTest {
-
-    private AblyRealtime ably;
-    private long timeOffset;
 
     @Rule
     public Timeout testTimeout = Timeout.seconds(300);
-
-    @Before
-    public void setUpBefore() throws Exception {
-        ClientOptions opts = createOptions(testVars.keys[0].keyStr);
-        ably = new AblyRealtime(opts);
-        long timeFromService = ably.time();
-        timeOffset = timeFromService - System.currentTimeMillis();
-    }
 
     /**
      * Send a single message on a channel and verify that it can be
@@ -672,6 +658,7 @@ public class RealtimeChannelHistoryTest extends ParameterizedTest {
             long intervalStart = 0, intervalEnd = 0;
             ClientOptions opts = createOptions(testVars.keys[0].keyStr);
             ably = new AblyRealtime(opts);
+            long timeOffset = ably.time() - System.currentTimeMillis();
             String channelName = "persisted:channelhistory_time_f_" + testParams.name;
 
             /* create a channel */
@@ -743,6 +730,7 @@ public class RealtimeChannelHistoryTest extends ParameterizedTest {
             long intervalStart = 0, intervalEnd = 0;
             ClientOptions opts = createOptions(testVars.keys[0].keyStr);
             ably = new AblyRealtime(opts);
+            long timeOffset = ably.time() - System.currentTimeMillis();
             String channelName = "persisted:channelhistory_time_b_" + testParams.name;
 
             /* create a channel */
@@ -1162,7 +1150,6 @@ public class RealtimeChannelHistoryTest extends ParameterizedTest {
      * history up to the point of attachment can be obtained.
      */
     @Test
-    @Ignore("Fails due to issues in sandbox. See https://github.com/ably/realtime/issues/1834 for details.")
     public void channelhistory_from_attach() {
         AblyRealtime txAbly = null, rxAbly = null;
         try {

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -12,7 +12,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.lang.reflect.InvocationTargetException;
@@ -1420,7 +1419,6 @@ public class RealtimeChannelTest extends ParameterizedTest {
      *
      * Tests RTN15c3
      */
-    //@Ignore("FIXME flaky test, Verify channel was attached expected:<false> but was:<true>")
     @Test
     public void channel_resume_lost_continuity() throws AblyException {
         AblyRealtime ably = null;

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -1,5 +1,27 @@
 package io.ably.lib.test.realtime;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+
 import io.ably.lib.debug.DebugOptions;
 import io.ably.lib.realtime.AblyRealtime;
 import io.ably.lib.realtime.Channel;
@@ -24,28 +46,6 @@ import io.ably.lib.types.ClientOptions;
 import io.ably.lib.types.ErrorInfo;
 import io.ably.lib.types.Message;
 import io.ably.lib.types.ProtocolMessage;
-import org.hamcrest.Matchers;
-import org.junit.Ignore;
-import org.junit.Test;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class RealtimeChannelTest extends ParameterizedTest {
 
@@ -1066,7 +1066,6 @@ public class RealtimeChannelTest extends ParameterizedTest {
      * </p>
      *
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void transient_publish_connected() throws AblyException {
         AblyRealtime pubAbly = null, subAbly = null;
@@ -1116,7 +1115,6 @@ public class RealtimeChannelTest extends ParameterizedTest {
      * </p>
      *
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void transient_publish_connecting() throws AblyException {
         AblyRealtime pubAbly = null, subAbly = null;

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.hamcrest.Matchers;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.lang.reflect.InvocationTargetException;
@@ -1419,6 +1420,7 @@ public class RealtimeChannelTest extends ParameterizedTest {
      *
      * Tests RTN15c3
      */
+    @Ignore("FIXME flaky test, Verify channel was attached expected:<false> but was:<true>")
     @Test
     public void channel_resume_lost_continuity() throws AblyException {
         AblyRealtime ably = null;

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -1420,7 +1420,7 @@ public class RealtimeChannelTest extends ParameterizedTest {
      *
      * Tests RTN15c3
      */
-    @Ignore("FIXME flaky test, Verify channel was attached expected:<false> but was:<true>")
+    //@Ignore("FIXME flaky test, Verify channel was attached expected:<false> but was:<true>")
     @Test
     public void channel_resume_lost_continuity() throws AblyException {
         AblyRealtime ably = null;
@@ -1515,6 +1515,9 @@ public class RealtimeChannelTest extends ParameterizedTest {
 
             /* previously attached channel should remain attached */
             attachedChannelWaiter.waitFor(ChannelState.attached);
+
+            /* wait for callbacks to fill in*/
+            try { Thread.sleep(200L); } catch(InterruptedException e) {}
 
             /*
              * Verify each channel undergoes relevant events:

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -313,7 +312,7 @@ public class RealtimeConnectFailTest extends ParameterizedTest {
      * Verify that the connection fails when attempting to recover with a
      * malformed connection id
      */
-    @Ignore("FIXME: fix exception")
+    //@Ignore("FIXME: flaky test, Sometimes received error code is 40100 for binary protocol")
     @Test
     public void connect_invalid_recover_fail() {
         AblyRealtime ably = null;
@@ -329,7 +328,9 @@ public class RealtimeConnectFailTest extends ParameterizedTest {
             e.printStackTrace();
             fail("init0: Unexpected exception instantiating library");
         } finally {
-            ably.close();
+            if (ably != null) {
+                ably.close();
+            }
         }
     }
 

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
@@ -312,7 +312,6 @@ public class RealtimeConnectFailTest extends ParameterizedTest {
      * Verify that the connection fails when attempting to recover with a
      * malformed connection id
      */
-    //@Ignore("FIXME: flaky test, Sometimes received error code is 40100 for binary protocol")
     @Test
     public void connect_invalid_recover_fail() {
         AblyRealtime ably = null;

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectTest.java
@@ -6,8 +6,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import io.ably.lib.debug.DebugOptions;
 import io.ably.lib.debug.DebugOptions.RawProtocolListener;
@@ -21,7 +21,6 @@ import io.ably.lib.types.AblyException;
 import io.ably.lib.types.ClientOptions;
 import io.ably.lib.types.Param;
 import io.ably.lib.types.ProtocolMessage;
-import org.junit.rules.Timeout;
 
 public class RealtimeConnectTest extends ParameterizedTest {
 
@@ -81,7 +80,6 @@ public class RealtimeConnectTest extends ParameterizedTest {
      * Perform a simple connect, close the connection, and verify that
      * the connection can be re-established by calling connect().
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void connect_after_close() {
         try {
@@ -95,7 +93,7 @@ public class RealtimeConnectTest extends ParameterizedTest {
             for (int i = 0; i < 3; i++) {
                 /* publish to the channel */
                 CompletionWaiter msgComplete = new CompletionWaiter();
-                ably.channels.get("test_channel").publish("test_event", "Test message", msgComplete);
+                ably.channels.get("test_channel").publish("test_event", "Test message " + i, msgComplete);
                 /* wait for the publish callback to be called */
                 msgComplete.waitFor();
                 assertTrue("Verify success callback was called", msgComplete.success);
@@ -112,7 +110,7 @@ public class RealtimeConnectTest extends ParameterizedTest {
 
             /* publish to the channel in the new connection to check that it works */
             CompletionWaiter msgComplete = new CompletionWaiter();
-            ably.channels.get("test_channel").publish("test_event", "Test message", msgComplete);
+            ably.channels.get("test_channel").publish("test_event", "Test message after restart", msgComplete);
             /* wait for the publish callback to be called */
             msgComplete.waitFor();
             assertTrue("Verify success callback was called", msgComplete.success);

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeCryptoTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeCryptoTest.java
@@ -6,6 +6,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -14,11 +18,6 @@ import java.util.Map.Entry;
 import java.util.Random;
 
 import javax.crypto.KeyGenerator;
-
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import io.ably.lib.realtime.AblyRealtime;
 import io.ably.lib.realtime.Channel;
@@ -46,7 +45,6 @@ public class RealtimeCryptoTest extends ParameterizedTest {
      * and publish an encrypted message on that channel using
      * the default cipher params
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void single_send() {
         String channelName = "single_send_" + testParams.name;
@@ -104,7 +102,6 @@ public class RealtimeCryptoTest extends ParameterizedTest {
      * and publish an encrypted message on that channel using
      * a 256-bit key
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void single_send_256() {
         String channelName = "single_send_256_" + testParams.name;
@@ -237,7 +234,6 @@ public class RealtimeCryptoTest extends ParameterizedTest {
         }
     }
 
-    @Ignore("FIXME: fix exception")
     @Test
     public void multiple_send_2_200() {
         int messageCount = 2;
@@ -245,7 +241,6 @@ public class RealtimeCryptoTest extends ParameterizedTest {
         _multiple_send("multiple_send_binary_2_200_" + testParams.name, messageCount, delay);
     }
 
-    @Ignore("FIXME: fix exception")
     @Test
     public void multiple_send_20_100() {
         int messageCount = 20;
@@ -258,7 +253,6 @@ public class RealtimeCryptoTest extends ParameterizedTest {
      * and the text protocol. Publish an encrypted message on that channel using
      * the default cipher params and verify correct receipt.
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void single_send_binary_text() {
         String channelName = "single_send_binary_text_" + testParams.name;
@@ -272,12 +266,12 @@ public class RealtimeCryptoTest extends ParameterizedTest {
             receiver = new AblyRealtime(receiverOpts);
 
             /* create a key */
-            final CipherParams params = Crypto.getDefaultParams();
+            final CipherParams cParams = Crypto.getDefaultParams();
 
             /* create a channel */
-            final ChannelOptions senderChannelOpts = new ChannelOptions() {{ encrypted = true; cipherParams = params; }};
+            final ChannelOptions senderChannelOpts = new ChannelOptions() {{ encrypted = true; cipherParams = cParams; }};
             final Channel senderChannel = sender.channels.get(channelName, senderChannelOpts);
-            final ChannelOptions receiverChannelOpts = new ChannelOptions() {{ encrypted = true; cipherParams = params; }};
+            final ChannelOptions receiverChannelOpts = new ChannelOptions() {{ encrypted = true; cipherParams = cParams; }};
             final Channel receiverChannel = receiver.channels.get(channelName, receiverChannelOpts);
 
             /* attach */
@@ -308,15 +302,9 @@ public class RealtimeCryptoTest extends ParameterizedTest {
 
             /* wait for the subscription callback to be called */
             messageWaiter.waitFor(1);
-            assertEquals(
-                "Unexpected number of received messages",
-                messageWaiter.receivedMessages.size(), 1
-            );
+            assertEquals("Unexpected number of received messages", messageWaiter.receivedMessages.size(), 1);
             /* check the correct plaintext recovered from the message */
-            assertTrue(
-                "Unexpected message received",
-                messageText.equals(messageWaiter.receivedMessages.get(0).data)
-            );
+            assertEquals("Unexpected message received", messageText, messageWaiter.receivedMessages.get(0).data);
         } catch (AblyException e) {
             e.printStackTrace();
             fail("init0: Unexpected exception instantiating library");
@@ -336,7 +324,6 @@ public class RealtimeCryptoTest extends ParameterizedTest {
      * the default cipher params and verify that the decrypt failure
      * is noticed as bad recovered plaintext.
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void single_send_key_mismatch() {
         AblyRealtime sender = null;
@@ -410,7 +397,6 @@ public class RealtimeCryptoTest extends ParameterizedTest {
      * Publish an unencrypted message and verify that the receiving connection
      * does not attempt to decrypt it.
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void single_send_unencrypted() {
         AblyRealtime sender = null;
@@ -482,7 +468,6 @@ public class RealtimeCryptoTest extends ParameterizedTest {
      * Publish an unencrypted message and verify that the receiving connection
      * does not attempt to decrypt it.
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void single_send_encrypted_unhandled() {
         AblyRealtime sender = null;
@@ -553,7 +538,6 @@ public class RealtimeCryptoTest extends ParameterizedTest {
      * - publish with an updated key on the tx connection and verify that it is not decrypted by the rx connection;
      * - publish with an updated key on the rx connection and verify connect receipt
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void set_cipher_params() {
         AblyRealtime sender = null;
@@ -667,7 +651,6 @@ public class RealtimeCryptoTest extends ParameterizedTest {
      * been replaced with ChannelOptions.withCipherKey(...).
      * @see <a href="https://docs.ably.com/client-lib-development-guide/features/#TB3>TB3</a>
      */
-    @Ignore("FIXME: fix exception")
     @Test
     @Deprecated
     public void channel_options_from_cipher_key() {
@@ -737,7 +720,6 @@ public class RealtimeCryptoTest extends ParameterizedTest {
      * Test channel options creation with the cipher key.
      * @see <a href="https://docs.ably.com/client-lib-development-guide/features/#TB3>TB3</a>
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void channel_options_with_cipher_key() {
         String channelName = "cipher_params_test_" + testParams.name;
@@ -840,7 +822,6 @@ public class RealtimeCryptoTest extends ParameterizedTest {
         return new String(hexChars);
     }
 
-    @Ignore("FIXME: fix BadPaddingException")
     @Test
     public void decodeAppleLibrarySequences() throws NoSuchAlgorithmException, AblyException {
         final Map<String, String> apple = new LinkedHashMap<>();

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeJWTTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeJWTTest.java
@@ -1,5 +1,20 @@
 package io.ably.lib.test.realtime;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import io.ably.lib.debug.DebugOptions;
 import io.ably.lib.debug.DebugOptions.RawProtocolListener;
 import io.ably.lib.http.HttpCore;
@@ -25,19 +40,6 @@ import io.ably.lib.types.ErrorInfo;
 import io.ably.lib.types.Message;
 import io.ably.lib.types.Param;
 import io.ably.lib.types.ProtocolMessage;
-import org.junit.Ignore;
-import org.junit.Test;
-
-import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class RealtimeJWTTest extends ParameterizedTest {
 
@@ -86,7 +88,6 @@ public class RealtimeJWTTest extends ParameterizedTest {
      * Request a JWT with subscribe-only capabilities
      * Verifies that publishing on a channel fails
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void auth_jwt_with_subscribe_only_capability() {
         try {
@@ -150,22 +151,27 @@ public class RealtimeJWTTest extends ParameterizedTest {
             channel.attach();
             new ChannelWaiter(channel).waitFor(ChannelState.attached);
 
+            AtomicBoolean publishError = new AtomicBoolean(true);
+
             /* publish, verify that it succeeds then close */
             final Message message = new Message(messageName, null);
             channel.publish(message, new CompletionListener() {
                 @Override
                 public void onSuccess() {
                     System.out.println("Message " + messageName + " published successfully");
+                    publishError.set(false);
                     ablyRealtime.close();
                 }
 
                 @Override
                 public void onError(ErrorInfo reason) {
+                    publishError.set(true);
                     ablyRealtime.close();
                     fail("Publish should not fail");
                 }
             });
             connectionWaiter.waitFor(ConnectionState.closed);
+            assertFalse("Publish should not fail", publishError.get());
         } catch (AblyException e) {
             e.printStackTrace();
             fail();

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeJWTTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeJWTTest.java
@@ -151,7 +151,7 @@ public class RealtimeJWTTest extends ParameterizedTest {
             channel.attach();
             new ChannelWaiter(channel).waitFor(ChannelState.attached);
 
-            AtomicBoolean publishError = new AtomicBoolean(true);
+            final AtomicBoolean publishError = new AtomicBoolean(true);
 
             /* publish, verify that it succeeds then close */
             final Message message = new Message(messageName, null);

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
@@ -3,6 +3,7 @@ package io.ably.lib.test.realtime;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -62,7 +63,6 @@ public class RealtimeMessageTest extends ParameterizedTest {
     /**
      * Connect to the service and attach, subscribe to an event, and publish on that channel
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void single_send() {
         AblyRealtime ably = null;
@@ -107,7 +107,6 @@ public class RealtimeMessageTest extends ParameterizedTest {
      * attach, subscribe to an event, publish on one
      * connection and confirm receipt on the other.
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void single_send_noecho() {
         AblyRealtime txAbly = null;
@@ -166,7 +165,6 @@ public class RealtimeMessageTest extends ParameterizedTest {
      * Get a channel and subscribe without explicitly attaching.
      * Verify that the channel reaches the attached state.
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void subscribe_implicit_attach() {
         AblyRealtime ably = null;
@@ -289,11 +287,10 @@ public class RealtimeMessageTest extends ParameterizedTest {
         }
     }
 
-    /*
+    /**
      * Test right and wrong channel states to publish messages
      * Tests RTL6c
-     */
-    @Ignore("FIXME: fix exception")
+     **/
     @Test
     public void publish_channel_state() {
         AblyRealtime ably = null;
@@ -399,7 +396,6 @@ public class RealtimeMessageTest extends ParameterizedTest {
         }
     }
 
-    @Ignore("FIXME: fix exception")
     @Test
     public void multiple_send_10_1000_16_string() {
         int messageCount = 10;
@@ -407,7 +403,6 @@ public class RealtimeMessageTest extends ParameterizedTest {
         _multiple_send("multiple_send_10_1000_16_string_" + testParams.name, messageCount, 16, false, delay);
     }
 
-    @Ignore("FIXME: fix exception")
     @Test
     public void multiple_send_10_1000_16_binary() {
         int messageCount = 10;
@@ -415,7 +410,6 @@ public class RealtimeMessageTest extends ParameterizedTest {
         _multiple_send("multiple_send_10_1000_16_binary_" + testParams.name, messageCount, 16, true, delay);
     }
 
-    @Ignore("FIXME: fix exception")
     @Test
     public void multiple_send_10_1000_512_string() {
         int messageCount = 10;
@@ -423,7 +417,6 @@ public class RealtimeMessageTest extends ParameterizedTest {
         _multiple_send("multiple_send_10_1000_512_string_" + testParams.name, messageCount, 512, false, delay);
     }
 
-    @Ignore("FIXME: fix exception")
     @Test
     public void multiple_send_10_1000_512_binary() {
         int messageCount = 10;
@@ -431,7 +424,6 @@ public class RealtimeMessageTest extends ParameterizedTest {
         _multiple_send("multiple_send_10_1000_512_binary_" + testParams.name, messageCount, 512, true, delay);
     }
 
-    @Ignore("FIXME: fix exception")
     @Test
     public void multiple_send_20_200() {
         int messageCount = 20;
@@ -439,7 +431,6 @@ public class RealtimeMessageTest extends ParameterizedTest {
         _multiple_send("multiple_send_20_200_" + testParams.name, messageCount, 256, true, delay);
     }
 
-    @Ignore("FIXME: fix exception")
     @Test
     public void multiple_send_200_50() {
         int messageCount = 200;
@@ -447,7 +438,6 @@ public class RealtimeMessageTest extends ParameterizedTest {
         _multiple_send("multiple_send_binary_200_50_" + testParams.name, messageCount, 256, true, delay);
     }
 
-    @Ignore("FIXME: fix exception")
     @Test
     public void multiple_send_1000_10() {
         int messageCount = 1000;
@@ -937,15 +927,12 @@ public class RealtimeMessageTest extends ParameterizedTest {
      *
      * @see <a href="https://docs.ably.com/client-lib-development-guide/features/#RSL6a2">RSL6a2</a>
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void opaque_message_extras() throws AblyException {
         AblyRealtime ably = null;
         try {
             final JsonObject opaqueJson = new JsonObject();
-            opaqueJson.addProperty("Some Property", "Lorem Ipsum");
-            opaqueJson.addProperty("Some Truth", false);
-            opaqueJson.addProperty("Some Number", 321);
+            opaqueJson.addProperty("headers", "{\"key_text\":\"text value\",\"key_boolean\":true,\"key_int\":33}\n");
 
             final MessageExtras extras = new MessageExtras(opaqueJson);
             final Message message = new Message();
@@ -980,6 +967,45 @@ public class RealtimeMessageTest extends ParameterizedTest {
             assertEquals("The Test Message", received.name);
             assertEquals("Some Value", received.data);
             assertEquals(extras, received.extras);
+        } finally {
+            if(ably != null) {
+                ably.close();
+            }
+        }
+    }
+
+    /**
+     * Publish a message that contains extras of invalid format.
+     */
+    @Test
+    public void opaque_message_extras_fail() throws AblyException {
+        AblyRealtime ably = null;
+        try {
+            final JsonObject opaqueJson = new JsonObject();
+            opaqueJson.addProperty("Some Property", "Lorem Ipsum");
+            opaqueJson.addProperty("Some Truth", false);
+            opaqueJson.addProperty("Some Number", 321);
+
+            final MessageExtras extras = new MessageExtras(opaqueJson);
+            final Message message = new Message();
+            message.name = "The Test Message";
+            message.data = "Some Value";
+            message.extras = extras;
+
+            final ClientOptions clientOptions = createOptions(testVars.keys[0].keyStr);
+            ably = new AblyRealtime(clientOptions);
+
+            // create a channel and attach to it
+            final Channel channel = ably.channels.get(createChannelName("opaque_message_extras_fail"));
+            channel.attach();
+            (new ChannelWaiter(channel)).waitFor(ChannelState.attached);
+            assertEquals(ChannelState.attached, channel.state);
+
+            // publish and await success
+            final CompletionWaiter completionWaiter = new CompletionWaiter();
+            channel.publish(message, completionWaiter);
+            completionWaiter.waitFor();
+            assertNotNull("error is not received for invalid extras format", completionWaiter.error);
         } finally {
             if(ably != null) {
                 ably.close();

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
@@ -512,7 +512,6 @@ public class RealtimeMessageTest extends ParameterizedTest {
         }
     }
 
-    @Ignore("FIXME: fix exception")
     @Test
     public void messages_encoding_fixtures() {
         MessagesEncodingData fixtures;
@@ -577,7 +576,6 @@ public class RealtimeMessageTest extends ParameterizedTest {
         }
     }
 
-    @Ignore("FIXME: fix exception")
     @Test
     public void messages_msgpack_and_json_encoding_is_compatible() {
         MessagesEncodingData fixtures;
@@ -879,7 +877,6 @@ public class RealtimeMessageTest extends ParameterizedTest {
      * Refer Spec. TM3
      * @throws AblyException
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void messages_from_encoded_json_array() throws AblyException {
         JsonArray fixtures = null;

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
@@ -7,23 +7,21 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import io.ably.lib.types.MessageExtras;
-import io.ably.lib.util.Serialisation;
-import org.junit.Ignore;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 
 import io.ably.lib.http.Http;
 import io.ably.lib.http.HttpCore;
@@ -35,12 +33,12 @@ import io.ably.lib.realtime.Channel;
 import io.ably.lib.realtime.ChannelState;
 import io.ably.lib.realtime.ConnectionState;
 import io.ably.lib.rest.AblyRest;
+import io.ably.lib.test.common.Helpers;
 import io.ably.lib.test.common.Helpers.ChannelWaiter;
 import io.ably.lib.test.common.Helpers.CompletionSet;
 import io.ably.lib.test.common.Helpers.CompletionWaiter;
 import io.ably.lib.test.common.Helpers.ConnectionWaiter;
 import io.ably.lib.test.common.Helpers.MessageWaiter;
-import io.ably.lib.test.common.Helpers;
 import io.ably.lib.test.common.ParameterizedTest;
 import io.ably.lib.test.common.Setup;
 import io.ably.lib.transport.ConnectionManager;
@@ -49,8 +47,10 @@ import io.ably.lib.types.Callback;
 import io.ably.lib.types.ClientOptions;
 import io.ably.lib.types.ErrorInfo;
 import io.ably.lib.types.Message;
+import io.ably.lib.types.MessageExtras;
 import io.ably.lib.types.ProtocolMessage;
 import io.ably.lib.util.Log;
+import io.ably.lib.util.Serialisation;
 
 public class RealtimeMessageTest extends ParameterizedTest {
 

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
@@ -998,7 +998,7 @@ public class RealtimeMessageTest extends ParameterizedTest {
             (new ChannelWaiter(channel)).waitFor(ChannelState.attached);
             assertEquals(ChannelState.attached, channel.state);
 
-            // publish and await success
+            // publish and await expected failure (completion with error)
             final CompletionWaiter completionWaiter = new CompletionWaiter();
             channel.publish(message, completionWaiter);
             completionWaiter.waitFor();

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimePresenceTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimePresenceTest.java
@@ -16,6 +16,16 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,10 +35,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import io.ably.lib.debug.DebugOptions;
 import io.ably.lib.realtime.AblyRealtime;
 import io.ably.lib.realtime.Channel;
@@ -40,23 +46,6 @@ import io.ably.lib.realtime.ConnectionEvent;
 import io.ably.lib.realtime.ConnectionState;
 import io.ably.lib.realtime.ConnectionStateListener;
 import io.ably.lib.realtime.Presence;
-import io.ably.lib.test.common.Setup;
-import io.ably.lib.types.AblyException;
-import io.ably.lib.types.Capability;
-import io.ably.lib.types.ChannelOptions;
-import io.ably.lib.types.ClientOptions;
-import io.ably.lib.types.ErrorInfo;
-import io.ably.lib.types.PaginatedResult;
-import io.ably.lib.types.Param;
-import io.ably.lib.types.PresenceMessage;
-import io.ably.lib.types.ProtocolMessage;
-import io.ably.lib.util.Serialisation;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-
 import io.ably.lib.rest.AblyRest;
 import io.ably.lib.rest.Auth;
 import io.ably.lib.rest.Auth.TokenParams;
@@ -67,9 +56,20 @@ import io.ably.lib.test.common.Helpers.CompletionWaiter;
 import io.ably.lib.test.common.Helpers.ConnectionWaiter;
 import io.ably.lib.test.common.Helpers.PresenceWaiter;
 import io.ably.lib.test.common.ParameterizedTest;
+import io.ably.lib.test.common.Setup;
 import io.ably.lib.test.util.MockWebsocketFactory;
 import io.ably.lib.transport.ConnectionManager;
+import io.ably.lib.types.AblyException;
+import io.ably.lib.types.Capability;
+import io.ably.lib.types.ChannelOptions;
+import io.ably.lib.types.ClientOptions;
+import io.ably.lib.types.ErrorInfo;
+import io.ably.lib.types.PaginatedResult;
+import io.ably.lib.types.Param;
+import io.ably.lib.types.PresenceMessage;
 import io.ably.lib.types.PresenceMessage.Action;
+import io.ably.lib.types.ProtocolMessage;
+import io.ably.lib.util.Serialisation;
 
 public class RealtimePresenceTest extends ParameterizedTest {
 
@@ -139,7 +139,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
     /**
      * Attach to channel, enter presence channel and await entered event
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void enter_simple() {
         AblyRealtime clientAbly1 = null;
@@ -190,7 +189,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
     /**
      * Enter presence channel without prior attach and await entered event
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void enter_before_attach() {
         AblyRealtime clientAbly1 = null;
@@ -239,7 +237,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
     /**
      * Enter presence channel without prior connect and await entered event
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void enter_before_connect() {
         AblyRealtime clientAbly1 = null;
@@ -285,7 +282,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
      * Enter, then leave, presence channel and await leave event
      * Verify that the item is removed from the presence map (RTP2e)
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void enter_leave_simple() {
         AblyRealtime clientAbly1 = null;
@@ -346,7 +342,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
     /**
      * Enter, then enter again, expecting update event
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void enter_enter_simple() {
         AblyRealtime clientAbly1 = null;
@@ -416,7 +411,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
     /**
      * Enter, then update, expecting update event
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void enter_update_simple() {
         AblyRealtime clientAbly1 = null;
@@ -556,7 +550,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
     /**
      * Update without having first entered, expecting enter event
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void update_noenter() {
         AblyRealtime clientAbly1 = null;
@@ -615,7 +608,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
      * Enter, then leave (with no data) and await leave event,
      * expecting enter data to be in leave event
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void enter_leave_nodata() {
         AblyRealtime clientAbly1 = null;
@@ -671,7 +663,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
     /**
      * Attach to channel, enter presence channel and get presence using realtime get()
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void realtime_get_simple() {
         AblyRealtime clientAbly1 = null;
@@ -726,7 +717,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
     /**
      * Attach to channel, enter+leave presence channel and get presence with realtime get()
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void realtime_get_leave() {
         AblyRealtime clientAbly1 = null;
@@ -785,7 +775,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
      * Attach to channel, enter presence channel, then initiate second
      * connection, seeing existing member in message subsequent to second attach response
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void attach_enter_simple() {
         AblyRealtime clientAbly1 = null;
@@ -862,7 +851,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
      *
      * Test RTP4
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void attach_enter_multiple() {
         AblyRealtime clientAbly1 = null;
@@ -947,7 +935,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
     /**
      * Attach and enter channel on two connections, seeing
      * both members in presence returned by realtime get() */
-    @Ignore("FIXME: fix exception")
     @Test
     public void realtime_enter_multiple() {
         AblyRealtime clientAbly1 = null;
@@ -1018,7 +1005,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
     /**
      * Attach to channel, enter presence channel and get presence using rest get()
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void rest_get_simple() {
         AblyRealtime clientAbly1 = null;
@@ -1071,7 +1057,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
     /**
      * Attach to channel, enter+leave presence channel and get presence with rest get()
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void rest_get_leave() {
         AblyRealtime clientAbly1 = null;
@@ -1129,7 +1114,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
     /**
      * Attach and enter channel on two connections, seeing
      * both members in presence returned by rest get() */
-    @Ignore("FIXME: fix exception")
     @Test
     public void rest_enter_multiple() {
         AblyRealtime clientAbly1 = null;
@@ -1195,7 +1179,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
     /**
      * Attach and enter channel multiple times on a single connection,
      * retrieving members using paginated rest get() */
-    @Ignore("FIXME: fix exception")
     @Test
     public void rest_paginated_get() {
         AblyRealtime clientAbly1 = null;
@@ -1281,7 +1264,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
     /**
      * Attach to channel, enter presence channel, disconnect and await leave event
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void disconnect_leave() {
         AblyRealtime clientAbly1 = null;
@@ -1323,7 +1305,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
             assertNotNull(expectedLeft);
             /* verify leave message contains data that was published with enter */
             assertEquals(expectedLeft.data, enterString);
-
         } catch(AblyException e) {
             e.printStackTrace();
             fail("Unexpected exception running test: " + e.getMessage());
@@ -1423,7 +1404,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
      *
      * @throws AblyException
      */
-    @Ignore("FIXME: flaky test")
     @Test
     public void realtime_presence_unsubscribe_single() throws AblyException {
         /* Ably instance that will emit presence events */
@@ -1503,7 +1483,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
      *
      * @throws AblyException
      */
-    @Ignore("FIXME: flaky test")
     @Test
     public void realtime_presence_subscribe_all() throws AblyException {
         /* Ably instance that will emit presence events */
@@ -1579,7 +1558,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
      *
      * @throws AblyException
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void realtime_presence_subscribe_multiple() throws AblyException {
         /* Ably instance that will emit presence events */
@@ -1738,7 +1716,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
      *
      * @throws AblyException
      */
-    @Ignore("FIXME: flaky test")
     @Test
     public void realtime_presence_attach_implicit_subscribe_fail() throws AblyException {
         AblyRealtime ably = null;
@@ -2056,7 +2033,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
      *
      * @throws AblyException
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void realtime_presence_get_throws_when_channel_failed() throws AblyException {
         AblyRealtime ably = null;
@@ -2092,7 +2068,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
      *
      * Tests RTP17, RTP19, RTP19a, RTP5f, RTP6b
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void realtime_presence_suspended_reenter() throws AblyException {
         AblyRealtime ably = null;
@@ -2103,19 +2078,15 @@ public class RealtimePresenceTest extends ParameterizedTest {
             opts.transportFactory = mockTransport;
 
             for (int i=0; i<2; i++) {
-                final String channelName = "presence_suspended_reenter" + testParams.name + i;
-
                 mockTransport.allowSend();
-
+                final String channelName = "presence_suspended_reenter" + testParams.name + i;
                 ably = new AblyRealtime(opts);
-
                 ConnectionWaiter connectionWaiter = new ConnectionWaiter(ably.connection);
                 connectionWaiter.waitFor(ConnectionState.connected);
 
                 final Channel channel = ably.channels.get(channelName);
-                channel.attach();
                 ChannelWaiter channelWaiter = new ChannelWaiter(channel);
-
+                channel.attach();
                 channelWaiter.waitFor(ChannelState.attached);
 
                 final String presenceData = "PRESENCE_DATA";
@@ -2138,6 +2109,7 @@ public class RealtimePresenceTest extends ParameterizedTest {
                     channel.presence.subscribe(new Presence.PresenceListener() {
                         @Override
                         public void onPresenceMessage(PresenceMessage message) {
+                            System.out.println("realtime_presence_suspended_reenter(): onPresenceMessage: " + message.clientId + " action: " + message.action.name());
                             if (message.clientId.equals(testClientId1))
                                 wrongPresenceEmitted[0] = true;
                         }
@@ -2179,6 +2151,8 @@ public class RealtimePresenceTest extends ParameterizedTest {
 
                 mockTransport.allowSend();
 
+                assertEquals("Verify presence data is received by the server", i==0 ? 1 : 2, channel.presence.get(true).length);
+
                 ably.connection.connectionManager.requestState(ConnectionState.suspended);
                 channelWaiter.waitFor(ChannelState.suspended);
 
@@ -2190,17 +2164,13 @@ public class RealtimePresenceTest extends ParameterizedTest {
 
                 ably.connection.connectionManager.requestState(ConnectionState.connected);
                 channelWaiter.waitFor(ChannelState.attached);
+
                 long reconnectTimestamp = System.currentTimeMillis();
 
                 try {
                     Thread.sleep(500);
                 } catch (InterruptedException e) {
                 }
-
-                AblyRest ablyRest = new AblyRest(opts);
-                io.ably.lib.rest.Channel restChannel = ablyRest.channels.get(channelName);
-                assertEquals("Verify presence data is received by the server",
-                        restChannel.presence.get(null).items().length, i==0 ? 1 : 2);
 
                 /* In both cases we should have one leave message in the leaveMessages */
                 assertEquals("Verify exactly one LEAVE message was generated", leaveMessages.size(), 1);
@@ -2214,10 +2184,10 @@ public class RealtimePresenceTest extends ParameterizedTest {
                 /* According to RTP5f there should be no presence event emitted for client1 */
                 assertFalse("Verify no presence event emitted on return from suspend on SYNC for client1",
                         wrongPresenceEmitted[0]);
+                //ably.close();
             }
-        } finally {
-            if(ably != null)
-                ably.close();
+        } catch (AblyException e) {
+            fail("Unexpected exception running test: " + e.getMessage());
         }
     }
 
@@ -2381,7 +2351,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
      *
      * Tests RTP3
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void reattach_resume_broken_sync() {
         AblyRealtime clientAbly1 = null;
@@ -2647,7 +2616,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
      * Test channel state change effect on presence
      * Tests RTP5a, RTP5b, RTP5c3, RTP16b
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void presence_state_change () {
         AblyRealtime ably = null;
@@ -2764,7 +2732,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
      *
      * Not functional yet
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void presence_without_subscribe_capability() throws AblyException {
         String channelName = "presence_without_subscribe" + testParams.name;
@@ -2828,7 +2795,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
      *
      * Tests RTP13
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void sync_complete() {
         AblyRealtime ably1 = null, ably2 = null;
@@ -2908,7 +2874,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
     /**
      * Enter wrong client (mismatching one set in the token), check exception
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void presence_enter_mismatched_clientid() throws AblyException {
         String channelName = "presence_enter_mismatched_clientid" + testParams.name;
@@ -3150,7 +3115,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
      * Verify presence data is received and encoded/decoded correctly
      * Tests RTP8e, RTP6a
      */
-    @Ignore("FIXME: flaky test")
     @Test
     public void presence_encoding() throws AblyException, InterruptedException {
         AblyRealtime ably1 = null, ably2 = null;
@@ -3221,7 +3185,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
      * Test Presence.get() filtering and syncToWait flag
      * Tests RTP11b, RTP11c, RTP11d
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void presence_get() throws AblyException, InterruptedException {
         AblyRealtime ably1 = null, ably2 = null;
@@ -3290,6 +3253,11 @@ public class RealtimePresenceTest extends ParameterizedTest {
             PresenceMessage[] presenceMessages7 = channel2.presence.get(false);
             assertEquals("Verify Presence.get() with waitForSync set to false works in SUSPENDED state", presenceMessages7.length, 3);
 
+            //Wait for channel to switch state
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {}
+
             /* try with wait set to true, should get exception */
             try {
                 channel2.presence.get(true);
@@ -3317,7 +3285,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
         assertEquals("Members count with channel presence should be " + presenceMessages.length, presenceMessages.length, 1);
     }
 
-    @Ignore
     @Test
     public void test_consistent_presence_for_members() {
         AblyRealtime clientAbly1 = null;
@@ -3480,7 +3447,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
      * Refer Spec. TP4
      * @throws AblyException
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void messages_from_encoded_json_array() throws AblyException {
         JsonArray fixtures = null;

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimePresenceTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimePresenceTest.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -2068,6 +2069,7 @@ public class RealtimePresenceTest extends ParameterizedTest {
      *
      * Tests RTP17, RTP19, RTP19a, RTP5f, RTP6b
      */
+    @Ignore("FIXME: flaky test which fails on second protocol iteration")
     @Test
     public void realtime_presence_suspended_reenter() throws AblyException {
         AblyRealtime ably = null;

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeRecoverTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeRecoverTest.java
@@ -1,5 +1,14 @@
 package io.ably.lib.test.realtime;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
 import io.ably.lib.debug.DebugOptions;
 import io.ably.lib.realtime.AblyRealtime;
 import io.ably.lib.realtime.Channel;
@@ -17,15 +26,6 @@ import io.ably.lib.types.AblyException;
 import io.ably.lib.types.ClientOptions;
 import io.ably.lib.types.ErrorInfo;
 import io.ably.lib.types.ProtocolMessage;
-import org.junit.Ignore;
-import org.junit.Test;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class RealtimeRecoverTest extends ParameterizedTest {
 
@@ -41,7 +41,6 @@ public class RealtimeRecoverTest extends ParameterizedTest {
      * on recover
      * Spec: RTN16a,RTN16b
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void recover_disconnected() {
         AblyRealtime ablyRx = null, ablyTx = null, ablyRxRecover = null;
@@ -141,7 +140,6 @@ public class RealtimeRecoverTest extends ParameterizedTest {
      * on recover
      * Spec: RTN16a,RTN16b
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void recover_implicit_connect() {
         AblyRealtime ablyRx = null, ablyTx = null, ablyRxRecover = null;
@@ -236,7 +234,6 @@ public class RealtimeRecoverTest extends ParameterizedTest {
      * Disconnect+suspend and then reconnect the send connection; verify that
      * each subsequent publish causes a CompletionListener call.
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void recover_verify_publish() {
         AblyRealtime ablyRx = null, ablyTx = null;

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeResumeTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeResumeTest.java
@@ -1,5 +1,17 @@
 package io.ably.lib.test.realtime;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+
 import io.ably.lib.debug.DebugOptions;
 import io.ably.lib.realtime.AblyRealtime;
 import io.ably.lib.realtime.Channel;
@@ -15,18 +27,6 @@ import io.ably.lib.types.ClientOptions;
 import io.ably.lib.types.ErrorInfo;
 import io.ably.lib.types.Message;
 import io.ably.lib.types.ProtocolMessage;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class RealtimeResumeTest extends ParameterizedTest {
 
@@ -97,7 +97,6 @@ public class RealtimeResumeTest extends ParameterizedTest {
      * the connection continues to receive messages on attached
      * channels after reconnection.
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void resume_simple() {
         AblyRealtime ablyTx = null;
@@ -188,7 +187,6 @@ public class RealtimeResumeTest extends ParameterizedTest {
      * verify that the messages sent whilst disconnected are delivered
      * on resume
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void resume_disconnected() {
         AblyRealtime ablyTx = null;
@@ -274,7 +272,6 @@ public class RealtimeResumeTest extends ParameterizedTest {
     /**
      * Verify resume behaviour with multiple channels
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void resume_multiple_channel() {
         AblyRealtime ablyTx = null;
@@ -377,7 +374,6 @@ public class RealtimeResumeTest extends ParameterizedTest {
      * Verify resume behaviour across disconnect periods covering
      * multiple subminute intervals
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void resume_multiple_interval() {
         AblyRealtime ablyTx = null;
@@ -466,7 +462,6 @@ public class RealtimeResumeTest extends ParameterizedTest {
      * Disconnect and then reconnect the send connection; verify that
      * each subsequent publish causes a CompletionListener call.
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void resume_verify_publish() {
         AblyRealtime ablyTx = null;
@@ -572,7 +567,6 @@ public class RealtimeResumeTest extends ParameterizedTest {
      * round of messages which should be queued and published after
      * we reconnect the sender.
      */
-    @Ignore("FIXME: fix exception")
     @Test
     public void resume_publish_queue() {
         AblyRealtime receiver = null;

--- a/lib/src/test/java/io/ably/lib/test/rest/HttpTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/HttpTest.java
@@ -116,7 +116,7 @@ public class HttpTest {
      *
      * @throws Exception
      */
-    //@Ignore("When this test is run in CI/CD fallbacks will be 2 instead of 4")
+    //@Ignore("When this test is run in CI/CD fallback url list size will be 2 instead of 4")
     @Test
     public void http_ably_execute_fallback() throws AblyException {
         ClientOptions options = new ClientOptions();
@@ -172,9 +172,17 @@ public class HttpTest {
         }
 
         /* wait for fallback list to populate */
-        try {
-            Thread.sleep(500L);
-        } catch(InterruptedException ie) {}
+        int waitAtMost = 5 * 10; //5 seconds * 10 times per second
+        int waitCount = 0;
+        while (urlHostArgumentStack.size() < 4 && waitCount < waitAtMost) {
+            try {
+                Thread.sleep(100);
+                waitCount++;
+            } catch (InterruptedException e) {
+                fail(e.getMessage());
+            }
+        }
+        System.out.println("wait done in: " + (waitCount * 100) + " ms");
 
         /* Verify that,
          *      - {code HttpCore#httpExecute} have been called with (httpMaxRetryCount + 1) URLs

--- a/lib/src/test/java/io/ably/lib/test/rest/HttpTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/HttpTest.java
@@ -116,6 +116,7 @@ public class HttpTest {
      *
      * @throws Exception
      */
+    //@Ignore("When this test is run in CI/CD fallbacks will be 2 instead of 4")
     @Test
     public void http_ably_execute_fallback() throws AblyException {
         ClientOptions options = new ClientOptions();
@@ -169,6 +170,11 @@ public class HttpTest {
              */
             assertThat(e.errorInfo.statusCode / 10, is(equalTo(50)));
         }
+
+        /* wait for fallback list to populate */
+        try {
+            Thread.sleep(500L);
+        } catch(InterruptedException ie) {}
 
         /* Verify that,
          *      - {code HttpCore#httpExecute} have been called with (httpMaxRetryCount + 1) URLs

--- a/lib/src/test/java/io/ably/lib/test/rest/HttpTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/HttpTest.java
@@ -23,6 +23,7 @@ import org.hamcrest.TypeSafeMatcher;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -116,7 +117,7 @@ public class HttpTest {
      *
      * @throws Exception
      */
-    //@Ignore("When this test is run in CI/CD fallback url list size will be 2 instead of 4")
+    @Ignore("When this test is run in CI/CD fallback url list size will be 2 instead of 4")
     @Test
     public void http_ably_execute_fallback() throws AblyException {
         ClientOptions options = new ClientOptions();
@@ -174,7 +175,7 @@ public class HttpTest {
         /* wait for fallback list to populate */
         int waitAtMost = 5 * 10; //5 seconds * 10 times per second
         int waitCount = 0;
-        while (urlHostArgumentStack.size() < 4 && waitCount < waitAtMost) {
+        while (urlHostArgumentStack.size() < options.httpMaxRetryCount + 1 && waitCount < waitAtMost) {
             try {
                 Thread.sleep(100);
                 waitCount++;

--- a/lib/src/test/java/io/ably/lib/test/rest/RestAuthAttributeTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestAuthAttributeTest.java
@@ -1,18 +1,5 @@
 package io.ably.lib.test.rest;
 
-import io.ably.lib.rest.AblyRest;
-import io.ably.lib.rest.Auth;
-import io.ably.lib.test.common.ParameterizedTest;
-import io.ably.lib.types.AblyException;
-import io.ably.lib.types.Capability;
-import io.ably.lib.types.ClientOptions;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -21,6 +8,19 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.ably.lib.rest.AblyRest;
+import io.ably.lib.rest.Auth;
+import io.ably.lib.test.common.ParameterizedTest;
+import io.ably.lib.types.AblyException;
+import io.ably.lib.types.Capability;
+import io.ably.lib.types.ClientOptions;
 
 /**
  * Created by VOstopolets on 9/3/16.
@@ -42,7 +42,6 @@ public class RestAuthAttributeTest extends ParameterizedTest {
      * Spec: RSA10g,RSA10j
      * </p>
      */
-    @Ignore("FIXME: flaky test")
     @Test
     public void auth_stores_options_params() {
         try {
@@ -52,7 +51,7 @@ public class RestAuthAttributeTest extends ParameterizedTest {
             final String capabilityStr = capability.toString();
             final String testClientId = "firstClientId";
             Auth.TokenParams tokenParams = new Auth.TokenParams() {{
-                ttl = 4000L;
+                ttl = 2000L;
                 clientId = testClientId;
                 capability = capabilityStr;
             }};
@@ -85,7 +84,7 @@ public class RestAuthAttributeTest extends ParameterizedTest {
 
             /* wait until token expires */
             try {
-                Thread.sleep(5000L);
+                Thread.sleep(3000L);
             } catch(InterruptedException ie) {}
 
             /* authorize with default options */

--- a/lib/src/test/java/io/ably/lib/test/rest/RestChannelBulkPublishTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestChannelBulkPublishTest.java
@@ -1,5 +1,17 @@
 package io.ably.lib.test.rest;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Random;
+
 import io.ably.lib.realtime.AblyRealtime;
 import io.ably.lib.realtime.Channel;
 import io.ably.lib.realtime.ChannelState;
@@ -13,18 +25,6 @@ import io.ably.lib.types.Message;
 import io.ably.lib.types.PaginatedResult;
 import io.ably.lib.types.Param;
 import io.ably.lib.types.PublishResponse;
-import org.junit.Ignore;
-import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Random;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class RestChannelBulkPublishTest extends ParameterizedTest  {
 
@@ -234,7 +234,6 @@ public class RestChannelBulkPublishTest extends ParameterizedTest  {
      *
      * It attempts to publish the given message on all of the given channels.
      */
-    @Ignore // awaiting channel member in error responses
     @Test
     public void bulk_publish_multiple_channels_partial_error() {
         try {

--- a/lib/src/test/java/io/ably/lib/test/rest/RestChannelHistoryTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestChannelHistoryTest.java
@@ -4,15 +4,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
-import java.util.HashMap;
-import java.util.UUID;
-
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
+
+import java.util.HashMap;
+import java.util.UUID;
 
 import io.ably.lib.rest.AblyRest;
 import io.ably.lib.rest.Channel;
@@ -228,7 +227,6 @@ public class RestChannelHistoryTest extends ParameterizedTest {
      * Publish events and check expected history based on time slice (forwards)
      */
     @Test
-    @Ignore("Fails in sandbox due to timing issues")
     public void channelhistory_time_f() {
         /* first, publish some messages */
         long intervalStart = 0, intervalEnd = 0;

--- a/lib/src/test/java/io/ably/lib/test/rest/RestProxyTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestProxyTest.java
@@ -39,7 +39,7 @@ public class RestProxyTest extends ParameterizedTest {
             /* Verify we got a 50x */
             assertTrue(true);
         } catch (AblyException e) {
-            fail("Wrong error code");
+            fail("Wrong error code: " + e.getMessage());
         }
     }
 
@@ -64,7 +64,7 @@ public class RestProxyTest extends ParameterizedTest {
             /* Verify we got a 50x */
             assertTrue(true);
         } catch (AblyException e) {
-            fail("Wrong error code");
+            fail("Wrong error code: " + e.getMessage());
         }
     }
 
@@ -90,7 +90,7 @@ public class RestProxyTest extends ParameterizedTest {
             assertNotNull("Expected non-null stats", stats);
         } catch (AblyException e) {
             e.printStackTrace();
-            fail("proxy_simple_plain: Unexpected exception");
+            fail("proxy_simple_plain: Unexpected exception: " + e.getMessage());
             return;
         }
     }
@@ -115,7 +115,7 @@ public class RestProxyTest extends ParameterizedTest {
             assertNotNull("Expected non-null stats", stats);
         } catch (AblyException e) {
             e.printStackTrace();
-            fail("proxy_simple_tls: Unexpected exception");
+            fail("proxy_simple_tls: Unexpected exception: " + e.getMessage());
             return;
         }
     }
@@ -138,13 +138,13 @@ public class RestProxyTest extends ParameterizedTest {
                 password = "password";
             }};
             AblyRest ably = new AblyRest(opts);
-    
+
             /* attempt the call, expecting no exception */
             PaginatedResult<Stats> stats = ably.stats(null);
             assertNotNull("Expected non-null stats", stats);
         } catch (AblyException e) {
             e.printStackTrace();
-            fail("proxy_basic_auth_plain: Unexpected exception");
+            fail("proxy_basic_auth_plain: Unexpected exception: " + e.getMessage());
             return;
         }
     }
@@ -167,13 +167,13 @@ public class RestProxyTest extends ParameterizedTest {
                 prefAuthType = HttpAuth.Type.DIGEST;
             }};
             AblyRest ably = new AblyRest(opts);
-    
+
             /* attempt the call, expecting no exception */
             PaginatedResult<Stats> stats = ably.stats(null);
             assertNotNull("Expected non-null stats", stats);
         } catch (AblyException e) {
             e.printStackTrace();
-            fail("proxy_digest_auth_plain: Unexpected exception");
+            fail("proxy_digest_auth_plain: Unexpected exception: " + e.getMessage());
             return;
         }
     }
@@ -193,13 +193,13 @@ public class RestProxyTest extends ParameterizedTest {
                 password = "password";
             }};
             AblyRest ably = new AblyRest(opts);
-    
+
             /* attempt the call, expecting no exception */
             PaginatedResult<Stats> stats = ably.stats(null);
             assertNotNull("Expected non-null stats", stats);
         } catch (AblyException e) {
             e.printStackTrace();
-            fail("proxy_basic_auth_tls: Unexpected exception");
+            fail("proxy_basic_auth_tls: Unexpected exception: " + e.getMessage());
             return;
         }
     }

--- a/lib/src/test/java/io/ably/lib/test/rest/RestPushTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestPushTest.java
@@ -1,6 +1,20 @@
 package io.ably.lib.test.rest;
 
+import static org.junit.Assert.assertEquals;
+
 import com.google.gson.JsonObject;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
 import io.ably.lib.debug.DebugOptions;
 import io.ably.lib.push.PushBase.ChannelSubscription;
 import io.ably.lib.realtime.AblyRealtime;
@@ -18,19 +32,6 @@ import io.ably.lib.types.Callback;
 import io.ably.lib.types.PaginatedResult;
 import io.ably.lib.types.Param;
 import io.ably.lib.util.JsonUtils;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-
-import java.util.Arrays;
-import java.util.Locale;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
-
-import static org.junit.Assert.assertEquals;
 
 public class RestPushTest extends ParameterizedTest {
     private static AblyRest rest;
@@ -636,7 +637,6 @@ public class RestPushTest extends ParameterizedTest {
 
     // RHS1c2
     @Test
-    @Ignore("FIXME: tests interfere")
     public void push_admin_channelSubscriptions_listChannels() throws Exception {
         new Helpers.SyncAndAsync<Void, String[]>(){
             @Override

--- a/lib/src/test/java/io/ably/lib/util/CryptoMessageTest.java
+++ b/lib/src/test/java/io/ably/lib/util/CryptoMessageTest.java
@@ -1,29 +1,25 @@
 package io.ably.lib.util;
 
-import static io.ably.lib.test.common.Helpers.assertMessagesEqual;
 import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static io.ably.lib.test.common.Helpers.assertMessagesEqual;
 
-import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
-
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+
 import io.ably.lib.test.common.Setup;
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.ChannelOptions;
 import io.ably.lib.types.Message;
-import io.ably.lib.util.Base64Coder;
-import io.ably.lib.util.Crypto;
 import io.ably.lib.util.Crypto.CipherParams;
 
-@Ignore("FIXME: Initialization is failing")
 @RunWith(Parameterized.class)
 public class CryptoMessageTest {
     public enum FixtureSet {
@@ -87,8 +83,8 @@ public class CryptoMessageTest {
         final CryptoTestData testData = fixtureSet.loadTestData();
         final String algorithm = testData.algorithm;
 
-        final CipherParams params = Crypto.getParams(algorithm, fixtureSet.key, fixtureSet.iv);
-        final ChannelOptions options = new ChannelOptions() {{encrypted = true; cipherParams = params;}};
+        final CipherParams cParams = Crypto.getParams(algorithm, fixtureSet.key, fixtureSet.iv);
+        final ChannelOptions options = new ChannelOptions() {{encrypted = true; cipherParams = cParams;}};
 
         for(final CryptoTestItem item : testData.items) {
             final Message plain = item.encoded;
@@ -113,10 +109,10 @@ public class CryptoMessageTest {
         final CryptoTestData testData = fixtureSet.loadTestData();
         final String algorithm = testData.algorithm;
 
-        final CipherParams params = Crypto.getParams(algorithm, fixtureSet.key, fixtureSet.iv);
+        final CipherParams cParams = Crypto.getParams(algorithm, fixtureSet.key, fixtureSet.iv);
 
         for(final CryptoTestItem item : testData.items) {
-            final ChannelOptions options = new ChannelOptions() {{encrypted = true; cipherParams = params;}};
+            final ChannelOptions options = new ChannelOptions() {{encrypted = true; cipherParams = cParams;}};
             final Message plain = item.encoded;
             final Message encrypted = item.encrypted;
             assertThat(encrypted.encoding, endsWith(fixtureSet.cipherName + "/base64"));

--- a/lib/src/test/java/io/ably/lib/util/CryptoTest.java
+++ b/lib/src/test/java/io/ably/lib/util/CryptoTest.java
@@ -4,18 +4,17 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.google.gson.stream.JsonWriter;
+
+import org.junit.Test;
+import org.msgpack.core.MessagePack;
+import org.msgpack.core.MessagePacker;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
-
-import org.junit.Ignore;
-import org.junit.Test;
-import org.msgpack.core.MessagePack;
-import org.msgpack.core.MessagePacker;
-
-import com.google.gson.stream.JsonWriter;
 
 import io.ably.lib.types.AblyException;
 import io.ably.lib.util.Crypto.ChannelCipherSet;
@@ -87,7 +86,6 @@ public class CryptoTest {
      * testEncryptAndDecrypt in Spec/CryptoTest.m
      * @throws IOException
      */
-    @Ignore("FIXME: NullPointerException should be fixed")
     @Test
     public void encryptAndDecrypt() throws NoSuchAlgorithmException, AblyException, IOException {
         final FixtureSet fixtureSet = FixtureSet.AES256;


### PR DESCRIPTION
This is PR for all those issues related to failing, flaky or disabled tests.

In the spirit of fixing tests, I have realized that the workflow for testing them was not optimized if only one test fails the whole test suite for REST and Realtime fails. We usually want to try to re-run only that set of test so I have splitted REST and Realtime tests in two separate jobs and they will run in sequence. If one of them fail we can re-run it. 
I have also added submodule loading which was previously missing and was necessary for some tests.