### PR TITLE
added null check to prevent NullPointerExceptions

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/Presence.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Presence.java
@@ -1176,9 +1176,13 @@ public class Presence {
                 /* any members that were present at the start of the sync,
                  * and have not been seen in sync, can be removed */
                 for(String itemKey: residualMembers) {
-                    /* clone presence message as it still can be in the internal presence map */
-                    removedEntries.add((PresenceMessage)members.get(itemKey).clone());
-                    members.remove(itemKey);
+                    PresenceMessage removedMember = members.remove(itemKey);
+                    /* This null check is added as a potential fix for an issue that
+                     * could not be reproduced, reported here https://github.com/ably/ably-java/issues/853 */
+                    if(removedMember != null) {
+                        /* clone presence message as it still can be in the internal presence map */
+                        removedEntries.add((PresenceMessage) removedMember.clone());
+                    }
                 }
                 residualMembers = null;
 


### PR DESCRIPTION
 I failed to reproduce NullPointerException reported by an Android AAT customer (corresponding AAT issue [here](https://github.com/ably/ably-asset-tracking-android/issues/809)). Based on code investigation, this is the only place this exception could occur. 

I see two downsides to this fix:
- this is a bandaid fix. No root cause/reproduction scenario was found. The underlying issue might still cause problems
- if this issue would be about to occur, listeners won't be notified about a member leaving the channel presence

Given the excessive time spent looking into this, I think it is worth merging this in its current state

Fixes #853