### PR TITLE
Extract Ably error codes to enum

### DIFF
--- a/android/src/main/java/io/ably/lib/platform/AndroidNetworkConnectivity.java
+++ b/android/src/main/java/io/ably/lib/platform/AndroidNetworkConnectivity.java
@@ -1,5 +1,7 @@
 package io.ably.lib.platform;
 
+import static io.ably.lib.util.AblyErrors.DISCONNECTED;
+
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -65,7 +67,7 @@ public class AndroidNetworkConnectivity extends NetworkConnectivity {
             if(ni != null && ni.getState() == NetworkInfo.State.CONNECTED) {
                 notifyNetworkAvailable();
             } else if(intent.getBooleanExtra(ConnectivityManager.EXTRA_NO_CONNECTIVITY,Boolean.FALSE)) {
-                notifyNetworkUnavailable(new ErrorInfo("No network connection available", 503, 80003));
+                notifyNetworkUnavailable(new ErrorInfo("No network connection available", 503, DISCONNECTED.code));
             }
         }
     }

--- a/android/src/main/java/io/ably/lib/platform/Platform.java
+++ b/android/src/main/java/io/ably/lib/platform/Platform.java
@@ -1,5 +1,7 @@
 package io.ably.lib.platform;
 
+import static io.ably.lib.util.AblyErrors.BAD_REQUEST;
+
 import android.content.Context;
 import io.ably.lib.transport.NetworkConnectivity;
 import io.ably.lib.transport.NetworkConnectivity.DelegatedNetworkConnectivity;
@@ -27,7 +29,7 @@ public class Platform {
                 Log.v(TAG, "setAndroidContext(): existing applicationContext is compatible with that being set");
                 return;
             }
-            throw AblyException.fromErrorInfo(new ErrorInfo("Incompatible application context set", 40000, 400));
+            throw AblyException.fromErrorInfo(new ErrorInfo("Incompatible application context set", BAD_REQUEST.code, 400));
         } else {
             Log.v(TAG, "setAndroidContext(): there was no existing applicationContext");
         }

--- a/android/src/main/java/io/ably/lib/push/ActivationContext.java
+++ b/android/src/main/java/io/ably/lib/push/ActivationContext.java
@@ -1,5 +1,7 @@
 package io.ably.lib.push;
 
+import static io.ably.lib.util.AblyErrors.BAD_REQUEST;
+
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
@@ -69,7 +71,7 @@ public class ActivationContext {
         String deviceIdentityToken = getLocalDevice().deviceIdentityToken;
         if(deviceIdentityToken == null) {
             Log.e(TAG, "getAbly(): unable to create Ably instance using deviceIdentityToken");
-            throw AblyException.fromErrorInfo(new ErrorInfo("Unable to get Ably library instance; no device identity token", 40000, 400));
+            throw AblyException.fromErrorInfo(new ErrorInfo("Unable to get Ably library instance; no device identity token", BAD_REQUEST.code, 400));
         }
         Log.v(TAG, "getAbly(): returning Ably instance using deviceIdentityToken");
         return (ably = new AblyRest(deviceIdentityToken));

--- a/android/src/main/java/io/ably/lib/push/ActivationStateMachine.java
+++ b/android/src/main/java/io/ably/lib/push/ActivationStateMachine.java
@@ -1,5 +1,7 @@
 package io.ably.lib.push;
 
+import static io.ably.lib.util.AblyErrors.BAD_REQUEST;
+
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -306,7 +308,7 @@ public class ActivationStateMachine {
                             JsonObject deviceIdentityTokenJson = response.getAsJsonObject("deviceIdentityToken");
                             if(deviceIdentityTokenJson == null) {
                                 Log.e(TAG, "invalid device registration response (no deviceIdentityToken); deviceId = " + device.id);
-                                machine.handleEvent(new ActivationStateMachine.GettingDeviceRegistrationFailed(new ErrorInfo("Invalid deviceIdentityToken in response", 40000, 400)));
+                                machine.handleEvent(new ActivationStateMachine.GettingDeviceRegistrationFailed(new ErrorInfo("Invalid deviceIdentityToken in response", BAD_REQUEST.code, 400)));
                                 return;
                             }
                             JsonPrimitive responseClientIdJson = response.getAsJsonPrimitive("clientId");

--- a/android/src/main/java/io/ably/lib/push/Push.java
+++ b/android/src/main/java/io/ably/lib/push/Push.java
@@ -1,5 +1,7 @@
 package io.ably.lib.push;
 
+import static io.ably.lib.util.AblyErrors.BAD_REQUEST;
+
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
@@ -93,7 +95,7 @@ public class Push extends PushBase {
         Context applicationContext = rest.platform.getApplicationContext();
         if(applicationContext == null) {
             Log.e(TAG, "getApplicationContext(): Unable to get application context; not set");
-            throw AblyException.fromErrorInfo(new ErrorInfo("Unable to get application context; not set", 40000, 400));
+            throw AblyException.fromErrorInfo(new ErrorInfo("Unable to get application context; not set", BAD_REQUEST.code, 400));
         }
         return applicationContext;
     }

--- a/lib/src/main/java/io/ably/lib/http/AsyncHttpPaginatedQuery.java
+++ b/lib/src/main/java/io/ably/lib/http/AsyncHttpPaginatedQuery.java
@@ -1,5 +1,7 @@
 package io.ably.lib.http;
 
+import static io.ably.lib.util.AblyErrors.INTERNAL_ERROR;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.HashMap;
@@ -107,7 +109,7 @@ public class AsyncHttpPaginatedQuery implements HttpCore.ResponseHandler<AsyncHt
             /* we're expecting the format to be ./path-component?name=value&name=value... */
             Matcher urlMatch = BasePaginatedQuery.urlPattern.matcher(linkUrl);
             if(!urlMatch.matches()) {
-                callback.onError(new ErrorInfo("Unexpected link URL format", 500, 50000));
+                callback.onError(new ErrorInfo("Unexpected link URL format", 500, INTERNAL_ERROR.code));
                 return;
             }
 
@@ -123,7 +125,7 @@ public class AsyncHttpPaginatedQuery implements HttpCore.ResponseHandler<AsyncHt
             } catch(UnsupportedEncodingException uee) {}
             exec(params, callback);
         }
-    
+
         @Override
         public boolean hasFirst() { return relFirst != null; }
 

--- a/lib/src/main/java/io/ably/lib/http/BasePaginatedQuery.java
+++ b/lib/src/main/java/io/ably/lib/http/BasePaginatedQuery.java
@@ -1,5 +1,7 @@
 package io.ably.lib.http;
 
+import static io.ably.lib.util.AblyErrors.INTERNAL_ERROR;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.Collection;
@@ -119,7 +121,7 @@ public class BasePaginatedQuery<T> implements HttpCore.ResponseHandler<BasePagin
                     /* we're expecting the format to be ./path-component?name=value&name=value... */
                     Matcher urlMatch = urlPattern.matcher(linkUrl);
                     if(!urlMatch.matches()) {
-                        throw AblyException.fromErrorInfo(new ErrorInfo("Unexpected link URL format", 500, 50000));
+                        throw AblyException.fromErrorInfo(new ErrorInfo("Unexpected link URL format", 500, INTERNAL_ERROR.code));
                     }
                     String[] paramSpecs = urlMatch.group(2).split("&");
                     Param[] params = new Param[paramSpecs.length];

--- a/lib/src/main/java/io/ably/lib/http/HttpAuth.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpAuth.java
@@ -1,5 +1,7 @@
 package io.ably.lib.http;
 
+import static io.ably.lib.util.AblyErrors.BAD_REQUEST;
+
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -53,7 +55,7 @@ public class HttpAuth {
         Map<Type, String> sortedHeaders = new HashMap<>();
         for(String header : authenticateHeaders) {
             int delimiterIdx = header.indexOf(' ');
-            if(delimiterIdx == -1) { throw AblyException.fromErrorInfo(new ErrorInfo("Invalid authenticate header (no delimiter)", 40000, 400)); }
+            if(delimiterIdx == -1) { throw AblyException.fromErrorInfo(new ErrorInfo("Invalid authenticate header (no delimiter)", BAD_REQUEST.code, 400)); }
             String authType = header.substring(0,  delimiterIdx).trim();
             String authDetails = header.substring(delimiterIdx + 1).trim();
             sortedHeaders.put(Type.parse(authType), authDetails);
@@ -91,7 +93,7 @@ public class HttpAuth {
         String authDetails = authenticateHeaders.get(type = prefType);
         if(authDetails == null) {
             Entry<Type, String> firstEntry = authenticateHeaders.entrySet().iterator().next();
-            if(firstEntry == null) { throw AblyException.fromErrorInfo(new ErrorInfo("Invalid authenticate header (no entries)", 40000, 400)); }
+            if(firstEntry == null) { throw AblyException.fromErrorInfo(new ErrorInfo("Invalid authenticate header (no entries)", BAD_REQUEST.code, 400)); }
             type = firstEntry.getKey();
             authDetails = firstEntry.getValue();
         }

--- a/lib/src/main/java/io/ably/lib/http/HttpCore.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpCore.java
@@ -1,5 +1,8 @@
 package io.ably.lib.http;
 
+import static io.ably.lib.util.AblyErrors.BAD_REQUEST;
+import static io.ably.lib.util.AblyErrors.TOKEN_ERROR_UNSPECIFIED;
+
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.IOException;
@@ -51,14 +54,14 @@ public class HttpCore {
         this.proxyOptions = options.proxy;
         if(proxyOptions != null) {
             String proxyHost = proxyOptions.host;
-            if(proxyHost == null) { throw AblyException.fromErrorInfo(new ErrorInfo("Unable to configure proxy without proxy host", 40000, 400)); }
+            if(proxyHost == null) { throw AblyException.fromErrorInfo(new ErrorInfo("Unable to configure proxy without proxy host", BAD_REQUEST.code, 400)); }
             int proxyPort = proxyOptions.port;
-            if(proxyPort == 0) { throw AblyException.fromErrorInfo(new ErrorInfo("Unable to configure proxy without proxy port", 40000, 400)); }
+            if(proxyPort == 0) { throw AblyException.fromErrorInfo(new ErrorInfo("Unable to configure proxy without proxy port", BAD_REQUEST.code, 400)); }
             this.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
             String proxyUser = proxyOptions.username;
             if(proxyUser != null) {
                 String proxyPassword = proxyOptions.password;
-                if(proxyPassword == null) { throw AblyException.fromErrorInfo(new ErrorInfo("Unable to configure proxy without proxy password", 40000, 400)); }
+                if(proxyPassword == null) { throw AblyException.fromErrorInfo(new ErrorInfo("Unable to configure proxy without proxy password", BAD_REQUEST.code, 400)); }
                 proxyAuth = new HttpAuth(proxyUser, proxyPassword, proxyOptions.prefAuthType);
             }
         }
@@ -322,7 +325,7 @@ public class HttpCore {
 
         /* handle www-authenticate */
         if(response.statusCode == 401) {
-            boolean stale = (error != null && error.code == 40140);
+            boolean stale = (error != null && error.code == TOKEN_ERROR_UNSPECIFIED.code);
             List<String> wwwAuthHeaders = response.getHeaderFields(HttpConstants.Headers.WWW_AUTHENTICATE);
             if(wwwAuthHeaders != null && wwwAuthHeaders.size() > 0) {
                 Map<HttpAuth.Type, String> headersByType = HttpAuth.sortAuthenticateHeaders(wwwAuthHeaders);

--- a/lib/src/main/java/io/ably/lib/http/HttpPaginatedQuery.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpPaginatedQuery.java
@@ -1,5 +1,7 @@
 package io.ably.lib.http;
 
+import static io.ably.lib.util.AblyErrors.INTERNAL_ERROR;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
@@ -115,9 +117,9 @@ public class HttpPaginatedQuery implements HttpCore.ResponseHandler<HttpPaginate
                 } catch(UnsupportedEncodingException uee) {}
                 return exec(params);
             }
-            throw AblyException.fromErrorInfo(new ErrorInfo("Unexpected link URL format", 500, 50000));
+            throw AblyException.fromErrorInfo(new ErrorInfo("Unexpected link URL format", 500, INTERNAL_ERROR.code));
         }
-    
+
         private String relFirst, relCurrent, relNext;
 
         @Override
@@ -139,7 +141,7 @@ public class HttpPaginatedQuery implements HttpCore.ResponseHandler<HttpPaginate
         @Override
         public JsonElement[] handleResponseBody(String contentType, byte[] body) throws AblyException {
             if(!"application/json".equals(contentType)) {
-                throw AblyException.fromErrorInfo(new ErrorInfo("Unexpected content type: " + contentType, 500, 50000));
+                throw AblyException.fromErrorInfo(new ErrorInfo("Unexpected content type: " + contentType, 500, INTERNAL_ERROR.code));
             }
             JsonElement jsonBody = Serialisation.gsonParser.parse(new String(body, Charset.forName("UTF-8")));
             if(!jsonBody.isJsonArray()) {

--- a/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
+++ b/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
@@ -1,5 +1,7 @@
 package io.ably.lib.realtime;
 
+import static io.ably.lib.util.AblyErrors.BAD_REQUEST;
+
 import java.util.Iterator;
 import java.util.Map;
 
@@ -189,7 +191,7 @@ public class AblyRealtime extends AblyRest {
             if (existingChannel != null) {
                 if (channelOptions != null) {
                     if (existingChannel.shouldReattachToSetOptions(channelOptions)) {
-                        throw AblyException.fromErrorInfo(new ErrorInfo("Channels.get() cannot be used to set channel options that would cause the channel to reattach. Please, use Channel.setOptions() instead.", 40000, 400));
+                        throw AblyException.fromErrorInfo(new ErrorInfo("Channels.get() cannot be used to set channel options that would cause the channel to reattach. Please, use Channel.setOptions() instead.", BAD_REQUEST.code, 400));
                     }
                     existingChannel.setOptions(channelOptions);
                 }

--- a/lib/src/main/java/io/ably/lib/rest/AblyBase.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyBase.java
@@ -1,5 +1,8 @@
 package io.ably.lib.rest;
 
+import static io.ably.lib.util.AblyErrors.BAD_REQUEST;
+import static io.ably.lib.util.AblyErrors.BATCH_ERROR;
+
 import io.ably.annotation.Experimental;
 import io.ably.lib.http.AsyncHttpScheduler;
 import io.ably.lib.http.Http;
@@ -94,7 +97,7 @@ public abstract class AblyBase implements AutoCloseable {
         if(options == null) {
             String msg = "no options provided";
             Log.e(getClass().getName(), msg);
-            throw AblyException.fromErrorInfo(new ErrorInfo(msg, 400, 40000));
+            throw AblyException.fromErrorInfo(new ErrorInfo(msg, 400, BAD_REQUEST.code));
         }
         this.options = options;
 
@@ -412,7 +415,7 @@ public abstract class AblyBase implements AutoCloseable {
                 http.post("/messages", HttpUtils.defaultAcceptHeaders(options.useBinaryProtocol), params, requestBody, new HttpCore.ResponseHandler<PublishResponse[]>() {
                     @Override
                     public PublishResponse[] handleResponse(HttpCore.Response response, ErrorInfo error) throws AblyException {
-                        if(error != null && error.code != 40020) {
+                        if(error != null && error.code != BATCH_ERROR.code) {
                             throw AblyException.fromErrorInfo(error);
                         }
                         return PublishResponse.getBulkPublishResponseHandler(response.statusCode).handleResponseBody(response.contentType, response.body);

--- a/lib/src/main/java/io/ably/lib/transport/Hosts.java
+++ b/lib/src/main/java/io/ably/lib/transport/Hosts.java
@@ -1,5 +1,7 @@
 package io.ably.lib.transport;
 
+import static io.ably.lib.util.AblyErrors.BAD_REQUEST;
+
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.ClientOptions;
 import io.ably.lib.types.ErrorInfo;
@@ -46,10 +48,10 @@ public class Hosts {
         String[] tempFallbackHosts = options.fallbackHosts;
         if (options.fallbackHostsUseDefault) {
             if (options.fallbackHosts != null) {
-                throw AblyException.fromErrorInfo(new ErrorInfo("fallbackHosts and fallbackHostsUseDefault cannot both be set", 40000, 400));
+                throw AblyException.fromErrorInfo(new ErrorInfo("fallbackHosts and fallbackHostsUseDefault cannot both be set", BAD_REQUEST.code, 400));
             }
             if (options.port != 0 || options.tlsPort != 0) {
-                throw AblyException.fromErrorInfo(new ErrorInfo("fallbackHostsUseDefault cannot be set when port or tlsPort are set", 40000, 400));
+                throw AblyException.fromErrorInfo(new ErrorInfo("fallbackHostsUseDefault cannot be set when port or tlsPort are set", BAD_REQUEST.code, 400));
             }
             tempFallbackHosts = Defaults.HOST_FALLBACKS;
         }
@@ -65,7 +67,7 @@ public class Hosts {
             if (options.environment != null) {
                 /* TO3k2: It is never valid to provide both a restHost and environment value
                  * TO3k3: It is never valid to provide both a realtimeHost and environment value */
-                throw AblyException.fromErrorInfo(new ErrorInfo("cannot set both restHost/realtimeHost and environment options", 40000, 400));
+                throw AblyException.fromErrorInfo(new ErrorInfo("cannot set both restHost/realtimeHost and environment options", BAD_REQUEST.code, 400));
             }
         } else {
             this.primaryHost = isProduction ? defaultHost : options.environment + "-" + defaultHost;

--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -1,5 +1,7 @@
 package io.ably.lib.transport;
 
+import static io.ably.lib.util.AblyErrors.CONNECTION_FAILED;
+
 import io.ably.lib.http.HttpUtils;
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.ErrorInfo;
@@ -254,7 +256,7 @@ public class WebSocketTransport implements ITransport {
         @Override
         public void onError(final Exception e) {
             Log.e(TAG, "Connection error ", e);
-            connectListener.onTransportUnavailable(WebSocketTransport.this, new ErrorInfo(e.getMessage(), 503, 80000));
+            connectListener.onTransportUnavailable(WebSocketTransport.this, new ErrorInfo(e.getMessage(), 503, CONNECTION_FAILED.code));
         }
 
         @Override

--- a/lib/src/main/java/io/ably/lib/types/BaseMessage.java
+++ b/lib/src/main/java/io/ably/lib/types/BaseMessage.java
@@ -1,5 +1,8 @@
 package io.ably.lib.types;
 
+import static io.ably.lib.util.AblyErrors.INVALID_MESSAGE_DATA_OR_ENCODING;
+import static io.ably.lib.util.AblyErrors.UNABLE_TO_DECODE_MESSAGE;
+
 import com.davidehrmann.vcdiff.VCDiffDecoder;
 import com.davidehrmann.vcdiff.VCDiffDecoderBuilder;
 import com.google.gson.JsonElement;
@@ -102,7 +105,7 @@ public class BaseMessage implements Cloneable {
             vcdiffDecoder.decode(base, delta, decoded);
             return decoded.toByteArray();
         } catch (Throwable t) {
-            throw MessageDecodeException.fromThrowableAndErrorInfo(t, new ErrorInfo("VCDIFF delta decode failed", 400, 40018));
+            throw MessageDecodeException.fromThrowableAndErrorInfo(t, new ErrorInfo("VCDIFF delta decode failed", 400, UNABLE_TO_DECODE_MESSAGE.code));
         }
     }
 
@@ -189,7 +192,7 @@ public class BaseMessage implements Cloneable {
                 }
             } else if(!(data instanceof byte[])) {
                 Log.d(TAG, "Message data must be either `byte[]`, `String` or `JSONElement`; implicit coercion of other types to String is deprecated");
-                throw AblyException.fromErrorInfo(new ErrorInfo("Invalid message data or encoding", 400, 40013));
+                throw AblyException.fromErrorInfo(new ErrorInfo("Invalid message data or encoding", 400, INVALID_MESSAGE_DATA_OR_ENCODING.code));
             }
         }
         if (opts != null && opts.encrypted) {

--- a/lib/src/main/java/io/ably/lib/types/ErrorInfo.java
+++ b/lib/src/main/java/io/ably/lib/types/ErrorInfo.java
@@ -1,5 +1,8 @@
 package io.ably.lib.types;
 
+import static io.ably.lib.util.AblyErrors.INTERNAL_CONNECTION_ERROR;
+import static io.ably.lib.util.AblyErrors.INTERNAL_ERROR;
+
 import io.ably.lib.util.Serialisation;
 import org.msgpack.core.MessageFormat;
 import org.msgpack.core.MessageUnpacker;
@@ -150,13 +153,13 @@ public class ErrorInfo {
         ErrorInfo errorInfo;
         if(throwable instanceof UnknownHostException
                 || throwable instanceof NoRouteToHostException) {
-            errorInfo = new ErrorInfo(throwable.getLocalizedMessage(), 500, 50002);
+            errorInfo = new ErrorInfo(throwable.getLocalizedMessage(), 500, INTERNAL_CONNECTION_ERROR.code);
         }
         else if(throwable instanceof IOException) {
-            errorInfo = new ErrorInfo(throwable.getLocalizedMessage(), 500, 50000);
+            errorInfo = new ErrorInfo(throwable.getLocalizedMessage(), 500, INTERNAL_ERROR.code);
         }
         else {
-            errorInfo = new ErrorInfo("Unexpected exception: " + throwable.getLocalizedMessage(), 50000, 500);
+            errorInfo = new ErrorInfo("Unexpected exception: " + throwable.getLocalizedMessage(), INTERNAL_ERROR.code, 500);
         }
 
         return errorInfo;

--- a/lib/src/main/java/io/ably/lib/types/PublishResponse.java
+++ b/lib/src/main/java/io/ably/lib/types/PublishResponse.java
@@ -1,5 +1,7 @@
 package io.ably.lib.types;
 
+import static io.ably.lib.util.AblyErrors.BATCH_ERROR;
+
 import com.google.gson.annotations.SerializedName;
 import io.ably.lib.http.HttpCore;
 import io.ably.lib.util.Log;
@@ -166,7 +168,7 @@ public class PublishResponse {
                 if(response == null) {
                     return null;
                 }
-                if(response.error != null && response.error.code != 40020) {
+                if(response.error != null && response.error.code != BATCH_ERROR.code) {
                     throw AblyException.fromErrorInfo(response.error);
                 }
                 return response.batchResponse;

--- a/lib/src/main/java/io/ably/lib/util/AblyErrors.java
+++ b/lib/src/main/java/io/ably/lib/util/AblyErrors.java
@@ -34,7 +34,7 @@ public enum AblyErrors {
     INVALID_PUBLISH_REQUEST_IMPERMISSIBLE_EXTRAS(40032, "Invalid publish request (impermissible extras field)"),
     RESERVED_FOR_ARTIFICIAL_ERROR(40099, "Reserved for artificial errors for testing"),
     UNAUTHORIZED(40100, "unauthorized"),
-    INVALID_CREDENTIALS_2(40101, "invalid credentials"),
+    INVALID_CREDENTIALS_AUTH(40101, "invalid credentials"),
     INCOMPATIBLE_CREDENTIALS(40102, "incompatible credentials"),
     INVALID_USE_OF_BASIC_AUTH(40103, "invalid use of Basic auth over non-TLS transport"),
     TIMESTAMP_NOT_CURRENT(40104, "timestamp not current"),

--- a/lib/src/main/java/io/ably/lib/util/AblyErrors.java
+++ b/lib/src/main/java/io/ably/lib/util/AblyErrors.java
@@ -1,0 +1,189 @@
+package io.ably.lib.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum AblyErrors {
+
+    NO_ERROR(10000, "no error"),
+
+    BAD_REQUEST(40000, "bad request"),
+    INVALID_REQUEST_BODY(40001, "invalid request body"),
+    INVALID_PARAMETER_NAME(40002, "invalid parameter name"),
+    INVALID_PARAMETER_VALUE(40003, "invalid parameter value"),
+    INVALID_HEADER(40004, "invalid header"),
+    INVALID_CREDENTIALS(40005, "invalid credential"),
+    INVALID_CONNECTION_ID(40006, "invalid connection id"),
+    INVALID_MESSAGE_ID(40007, "invalid message id"),
+    INVALID_CONTENT_LENGTH(40008, "invalid content length"),
+    MAXIMUM_LENGHT_EXCEEDED(40009, "maximum message length exceeded"),
+    INVALID_CHANNEL_NAME(40010, "invalid channel name"),
+    STALE_RING_STATE(40011, "stale ring state"),
+    INVALID_CLIENT_ID(40012, "invalid client id"),
+    INVALID_MESSAGE_DATA_OR_ENCODING(40013, "Invalid message data or encoding"),
+    RESOURCE_DISPOSED(40014, "Resource disposed"),
+    INVALID_DEVICE_ID(40015, "Invalid device id"),
+    INVALID_MESSAGE_NAME(40016, "Invalid message name"),
+    UNSUPPORTED_PROTOCOL_VERSION(40017, "Unsupported protocol version"),
+    UNABLE_TO_DECODE_MESSAGE(40018, "Unable to decode message; channel attachment no longer viable"),
+    REQUIRED_CLIENT_PLUGIN_NOT_PRESENT(40019, "Required client library plugin not present"),
+    BATCH_ERROR(40020, "Batch error"),
+    FEATURE_REQUIRES_NEWER_PLATFORM(40021, "Feature requires a newer platform version"),
+    INVALID_PUBLISH_REQUEST_UNSPECIFIED(40030, "Invalid publish request (unspecified)"),
+    INVALID_PUBLISH_REQUEST_CLIENT_ID(40031, "Invalid publish request (invalid client-specified id)"),
+    INVALID_PUBLISH_REQUEST_IMPERMISSIBLE_EXTRAS(40032, "Invalid publish request (impermissible extras field)"),
+    RESERVED_FOR_ARTIFICIAL_ERROR(40099, "Reserved for artificial errors for testing"),
+    UNAUTHORIZED(40100, "unauthorized"),
+    INVALID_CREDENTIALS_2(40101, "invalid credentials"),
+    INCOMPATIBLE_CREDENTIALS(40102, "incompatible credentials"),
+    INVALID_USE_OF_BASIC_AUTH(40103, "invalid use of Basic auth over non-TLS transport"),
+    TIMESTAMP_NOT_CURRENT(40104, "timestamp not current"),
+    NONCE_VALUE_REPLAYED(40105, "nonce value replayed"),
+    UNABLE_TO_OBTAIN_CREDENTIALS(40106, "Unable to obtain credentials from given parameters"),
+    ACCOUNT_DISABLED(40110, "account disabled"),
+    ACCOUNT_RESTRICTED_CONNECTION_LIMIT_EXCEED(40111, "account restricted (connection limits exceeded)"),
+    ACCOUNT_BLOCKED_MESSAGE_LIMIT_EXCEED(40112, "account blocked (message limits exceeded)"),
+    ACCOUNT_BLOCKED(40113, "account blocked"),
+    ACCOUNT_RESTRICTED(40114, "account restricted (channel limits exceeded)"),
+    MAXIMUM_NUMBER_OF_PERMITTED_APPLICATION_EXCEEDED(40115, "maximum number of permitted applications exceeded"),
+    APPLICATION_DISABLED(40120, "application disabled"),
+    TOKEN_REVOCATION_NOT_ENABLED(40121, "token revocation not enabled for this application"),
+    MAXIMUM_NUMBER_OF_RULES_EXCEED(40125, "maximum number of rules per application exceeded"),
+    MAXIMUM_NUMBER_OF_NAMESPACES_EXCEED(40126, "maximum number of namespaces per application exceeded"),
+    MAXIMUM_NUMBER_OF_KEYS_EXCEED(40127, "maximum number of keys per application exceeded"),
+    KEY_ERROR_UNSPECIFIED(40130, "key error (unspecified)"),
+    KEY_REVOKED(40131, "key revoked"),
+    KEY_EXPIRED(40132, "key expired"),
+    KEY_DISABLED(40133, "key disabled"),
+    WRONG_KEY(40133, "wrong key; cannot revoke tokens with a different key to the one that issued them"),
+    TOKEN_ERROR_UNSPECIFIED(40140, "token error (unspecified)"),
+    TOKEN_REVOKED(40141, "token revoked"),
+    TOKEN_EXPIRED(40142, "token expired"),
+    TOKEN_UNRECOGNISED(40143, "token unrecognised"),
+    INVALID_JWT_FORMAT(40144, "invalid JWT format"),
+    INVALID_TOKEN_FORMAT(40145, "invalid token format"),
+    CONNECTION_BLOCKED_LIMIT_EXCEED(40150, "connection blocked (limits exceeded)"),
+    OPERATION_NOT_PERMITTED_WITH_PROVIDED_CAPABILITY(40160, "operation not permitted with provided capability"),
+    OPERATION_NOT_PERMITTED_REQUIRES_IDENTIFIED_CLIENT(40161, "operation not permitted as it requires an identified client"),
+    OPERATION_NOT_PERMITTED_WITH_TOKEN_REQUIRES_BASIC_AUTH(40162, "operation not permitted with a token, requires basic auth"),
+    OPERATION_NOT_PERMITTED_KEY_NOT_PERMITTING_REVOCABLE_TOKENS(40163, "operation not permitted, key not marked as permitting revocable tokens"),
+    ERROR_CLIENT_TOKEN_CALLBACK(40170, "error from client token callback"),
+    NO_MEANS_TO_RENEW_AUTH_TOKEN(40171, "no means provided to renew auth token"),
+    FORBIDDEN(40300, "forbidden"),
+    ACCOUNT_DOES_NOT_PERMIT_TLS(40310, "account does not permit tls connection"),
+    OPERATION_REQUIRES_TLS(40311, "operation requires tls connection"),
+    APPLICATION_REQUIRES_AUTH(40320, "application requires authentication"),
+    UNABLE_TO_ACTIVATE_ACCOUNT_UNSPECIFIED(40330, "unable to activate account due to placement constraint (unspecified)"),
+    UNABLE_TO_ACTIVATE_ACCOUNT_INCOMPATIBLE_ENVIRONMENT(40331, "unable to activate account due to placement constraint (incompatible environment)"),
+    UNABLE_TO_ACTIVATE_ACCOUNT_INCOMPATIBLE_SITE(40332, "unable to activate account due to placement constraint (incompatible site)"),
+    NOT_FOUND(40400, "not found"),
+    METHOD_NOT_ALLOWED(40500, "method not allowed"),
+    PUSH_DEVICE_REGISTRATION_EXPIRED(41001, "push device registration expired"),
+    UNPROCESSABLE_ENTITY(42200, "Unprocessable entity"),
+    RATE_LIMIT_EXCEED_REQUEST_REJECTED(42910, "rate limit exceeded (nonfatal): request rejected (unspecified)"),
+    MAX_PUBLISH_RATE_LIMIT_EXCEED(42911, "max per-connection publish rate limit exceeded (nonfatal): unable to publish message"),
+    ONE_ACTIVE_CHANNEL_ITERATION_ALLOWED(42912, "there is a channel iteration call already in progress; only 1 active call is permitted to execute at any one time"),
+    RATE_LIMIT_EXCEED_FATAL(42920, "rate limit exceeded (fatal)"),
+    MAX_PUBLISH_RATE_LIMIT_EXCEED_CLOSING_CONNECTION(42921, "max per-connection publish rate limit exceeded (fatal); closing connection"),
+
+    INTERNAL_ERROR(50000, "internal error"),
+    INTERNAL_CHANNEL_ERROR(50001, "internal channel error"),
+    INTERNAL_CONNECTION_ERROR(50002, "internal connection error"),
+    TIMEOUT_ERROR(50003, "timeout error"),
+    REQUEST_FAILED_OVERLOAD(50004, "Request failed due to overloaded instance"),
+    SERVICE_UNAVAILABLE(50005, "Service unavailable (service temporarily in lockdown)"),
+    EDGE_PROXY_UNKNOWN_INTERNAL_ERROR(50010, "Ably's edge proxy service has encountered an unknown internal error whilst processing the request"),
+    EDGE_PROXY_INVALID_RESPONSE(50210, "Ably's edge proxy service received an invalid (bad gateway) response from the Ably platform"),
+    EDGE_PROXY_UNAVAILABLE_RESPONSE(50310, "Ably's edge proxy service received a service unavailable response code from the Ably platform"),
+    TRAFFIC_REDIRECTED_TO_BACKUP(50320, "Active Traffic Management: traffic for this cluster is being temporarily redirected to a backup service"),
+    WRONG_CLUSTER_RETRY(50330, "request reached the wrong cluster; retry (used during dns changes for cluster migrations)"),
+    EDGE_PROXY_SERVICE_TIMEOUT(50410, "Ably's edge proxy service timed out waiting for the Ably platform"),
+
+    REACTOR_OPERATION_FAILED(70000, "reactor operation failed"),
+    REACTOR_OPERATION_FAILED_POST_OP_FAIL(70001, "reactor operation failed (post operation failed)"),
+    REACTOR_OPERATION_FAILED_UNEXPECTED_CODE(70002, "reactor operation failed (post operation returned unexpected code)"),
+    REACTOR_OPERATION_FAILED_IN_FLIGHT_REQUEST_EXCEED(70003, "reactor operation failed (maximum number of concurrent in-flight requests exceeded)"),
+    REACTOR_OPERATION_FAILED_INVALID_MESSAGE(70004, "reactor operation failed (invalid or unaccepted message contents)"),
+
+    EXCHANGE_ERROR(71000, "Exchange error (unspecified)"),
+    FORCED_REATTACHMENT_PERMISSION_CHANGE(71001, "Forced re-attachment due to permissions change"),
+    EXCHANGE_PUBLISHER_ERROR(71100, "Exchange publisher error (unspecified)"),
+    NO_PUBLISHER(71101, "No such publisher"),
+    PUBLISHER_NOT_ENABLED(71102, "Publisher not enabled as an exchange publisher"),
+    EXCHANGE_PRODUCT_ERROR(71200, "Exchange product error (unspecified)"),
+    NO_PRODUCT(71201, "No such product"),
+    PRODUCT_DISABLED(71202, "Product disabled"),
+    NO_CHANNEL_IN_PRODUCT(71203, "No such channel in this product"),
+    FORCED_REATTACHMENT_PRODUCT_REMAPPED(71204, "Forced re-attachment due to product being remapped to a different namespace"),
+    EXCHANGE_SUBSCRIPTION_ERROR(71300, "Exchange subscription error (unspecified)"),
+    SUBSCRIPTION_DISABLED(71301, "Subscription disabled"),
+    REQUESTER_HAS_NO_SUBSCRIPTION(71302, "Requester has no subscription to this product"),
+    CHANNEL_DOES_NOT_MATCH_FILTER(71303, "Channel does not match the channel filter specified in the subscription to this product"),
+
+    CONNECTION_FAILED(80000, "connection failed"),
+    CONNECTION_FAILED_NO_TRANSPORT(80001, "connection failed (no compatible transport)"),
+    CONNECTION_SUSPENDED(80002, "connection suspended"),
+    DISCONNECTED(80003, "disconnected"),
+    ALREADY_CONNECTED(80004, "already connected"),
+    INVALID_CONNECTION_ID_NO_REMOTE(80005, "invalid connection id (remote not found)"),
+    FAIL_RECOVER_CONNECTION_MESSAGE_EXPIRED(80006, "unable to recover connection (messages expired)"),
+    FAIL_RECOVER_CONNECTION_MESSAGE_LIMIT_EXCEED(80007, "unable to recover connection (message limit exceeded)"),
+    FAIL_RECOVER_CONNECTION_EXPIRED(80008, "unable to recover connection (connection expired)"),
+    CONNECTION_NOT_ESTABLISHED_NO_TRANSPORT(80009, "connection not established (no transport handle)"),
+    INVALID_OPERATION_INVALID_TRANSPORT(80010, "invalid operation (invalid transport handle)"),
+    FAIL_RECOVER_CONNECTION_INCOMPATIBLE_AUTH_PARAMS(80011, "unable to recover connection (incompatible auth params)"),
+    FAIL_RECOVER_CONNECTION_INVALID_CONNECTION_SERIAL(80012, "unable to recover connection (invalid or unspecified connection serial)"),
+    PROTOCOL_ERROR(80013, "protocol error"),
+    CONNECTION_TIMEOUT(80014, "connection timed out"),
+    INCOMPATIBLE_CONNECTION_PARAMS(80015, "incompatible connection parameters"),
+    OPERATION_ON_SUPERSEDED_CONNECTION(80016, "operation on superseded connection"),
+    CONNECTION_CLOSED(80017, "connection closed"),
+    INVALID_CONNECTION_ID_BAD_FORMAT(80018, "invalid connection id (invalid format)"),
+    CLIENT_AUTH_REQUEST_FAILED(80019, "client configured authentication provider request failed"),
+    CONTINUITY_LOSS_SUBSCRIBE_RATE_EXCEED(80020, "continuity loss due to maximum subscribe message rate exceeded"),
+    CREATE_CONNECTION_EXCEED(80021, "exceeded maximum permitted account-wide rate of creating new connections"),
+    RESTRICTION_NOT_SATISFIED(80030, "client restriction not satisfied"),
+
+    CHANNEL_OPERATION_FAILED(90000, "channel operation failed"),
+    CHANNEL_OPERATION_FAILED_INVALID_STATE(90001, "channel operation failed (invalid channel state)"),
+    CHANNEL_OPERATION_FAILED_EPOCH_EXPIRED(90002, "channel operation failed (epoch expired or never existed)"),
+    CHANNEL_RECOVER_ERROR_MESSAGE_EXPIRED(90003, "unable to recover channel (messages expired)"),
+    CHANNEL_RECOVER_ERROR_MESSAGE_LIMIT_EXCEED(90004, "unable to recover channel (message limit exceeded)"),
+    CHANNEL_RECOVER_ERROR_NO_EPOCH(90005, "unable to recover channel (no matching epoch)"),
+    CHANNEL_RECOVER_ERROR_UNBOUNDED_REQUEST(90006, "unable to recover channel (unbounded request)"),
+    CHANNEL_RECOVER_ERROR_NO_RESPONSE(90007, "channel operation failed (no response from server)"),
+    CHANNELS_PER_CONNECTION_EXCEED(90010, "maximum number of channels per connection/request exceeded"),
+    CREATE_CHANNEL_EXCEED(90021, "exceeded maximum permitted account-wide rate of creating new channels"),
+    CHANNEL_PRESENCE_ENTER_CLIENT_ID_ERROR(91000, "unable to enter presence channel (no clientId)"),
+    CHANNEL_PRESENCE_ENTER_STATE_ERROR(91001, "unable to enter presence channel (invalid channel state)"),
+    CHANNEL_PRESENCE_LEAVE_ERROR(91002, "unable to leave presence channel that is not entered"),
+    CHANNEL_PRESENCE_ENTER_LIMIT_EXCEED(91003, "unable to enter presence channel (maximum member limit exceeded)"),
+    CHANEL_PRESENCE_RE_ENTER_ERROR(91004, "unable to automatically re-enter presence channel"),
+    PRESENCE_STATE_BAD_SYNC(91005, "presence state is out of sync"),
+    MEMBER_LEFT_IMPLICITLY(91100, "member implicitly left presence channel (connection closed)");
+
+    public final int code;
+    public final String message;
+    private static final Map<Integer, AblyErrors> BY_CODE = new HashMap<>();
+    private static final Map<String, AblyErrors> BY_MESSAGE = new HashMap<>();
+
+    static {
+        for (AblyErrors e : values()) {
+            BY_CODE.put(e.code, e);
+            BY_MESSAGE.put(e.message, e);
+        }
+    }
+
+    private AblyErrors(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public static AblyErrors valueOfCode(int code) {
+        return BY_CODE.get(code);
+    }
+
+    public static AblyErrors valueOfMessage(String message) {
+        return BY_MESSAGE.get(message);
+    }
+}

--- a/lib/src/main/java/io/ably/lib/util/Crypto.java
+++ b/lib/src/main/java/io/ably/lib/util/Crypto.java
@@ -1,5 +1,7 @@
 package io.ably.lib.util;
 
+import static io.ably.lib.util.AblyErrors.BAD_REQUEST;
+
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -245,7 +247,7 @@ public class Crypto {
         else if (cipherParams instanceof CipherParams)
             nonNullParams = (CipherParams)cipherParams;
         else
-            throw AblyException.fromErrorInfo(new ErrorInfo("ChannelOptions not supported", 400, 40000));
+            throw AblyException.fromErrorInfo(new ErrorInfo("ChannelOptions not supported", 400, BAD_REQUEST.code));
 
         return new ChannelCipherSet() {
             private final EncryptingChannelCipher encipher = new EncryptingCBCCipher(nonNullParams);

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
@@ -34,6 +34,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import static io.ably.lib.util.AblyErrors.CLIENT_AUTH_REQUEST_FAILED;
+import static io.ably.lib.util.AblyErrors.INVALID_CLIENT_ID;
+import static io.ably.lib.util.AblyErrors.INVALID_CREDENTIALS_AUTH;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -141,8 +145,8 @@ public class RealtimeAuthTest extends ParameterizedTest {
                 public void onConnectionStateChanged(ConnectionStateChange stateChange) {
                     /* assert that state changes correctly */
                     assertEquals(ConnectionState.connected, stateChange.previous);
-                    assertEquals(80019, stateChange.reason.code);
-                    assertEquals(80019, ablyRealtime.connection.reason.code);
+                    assertEquals(CLIENT_AUTH_REQUEST_FAILED.code, stateChange.reason.code);
+                    assertEquals(CLIENT_AUTH_REQUEST_FAILED.code, ablyRealtime.connection.reason.code);
                     assertEquals(403, ablyRealtime.connection.reason.statusCode);
                 }
             });
@@ -154,7 +158,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
             } catch (AblyException e) {
                 /* check expected error codes */
                 assertEquals(403, e.errorInfo.statusCode);
-                assertEquals(80019, e.errorInfo.code);
+                assertEquals(CLIENT_AUTH_REQUEST_FAILED.code, e.errorInfo.code);
             }
 
             /* wait for failed state */
@@ -184,7 +188,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
 
             ablyRealtime.connection.connect();
 
-            waitAndAssertConnectionState(ablyRealtime, ConnectionState.failed, 403, 80019);
+            waitAndAssertConnectionState(ablyRealtime, ConnectionState.failed, 403, CLIENT_AUTH_REQUEST_FAILED.code);
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
@@ -202,7 +206,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
 
             ablyRealtime.connection.connect();
 
-            waitAndAssertConnectionState(ablyRealtime, ConnectionState.failed, 403, 80019);
+            waitAndAssertConnectionState(ablyRealtime, ConnectionState.failed, 403, CLIENT_AUTH_REQUEST_FAILED.code);
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
@@ -220,7 +224,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
 
             ablyRealtime.connection.connect();
 
-            waitAndAssertConnectionState(ablyRealtime, ConnectionState.disconnected, 401, 80019);
+            waitAndAssertConnectionState(ablyRealtime, ConnectionState.disconnected, 401, CLIENT_AUTH_REQUEST_FAILED.code);
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
@@ -238,7 +242,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
 
             ablyRealtime.connection.connect();
 
-            waitAndAssertConnectionState(ablyRealtime, ConnectionState.disconnected, 401, 80019);
+            waitAndAssertConnectionState(ablyRealtime, ConnectionState.disconnected, 401, CLIENT_AUTH_REQUEST_FAILED.code);
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
@@ -655,7 +659,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
             opts.tokenDetails = tokenDetails;
             AblyRealtime ablyRealtime = new AblyRealtime(opts);
         } catch (AblyException e) {
-            assertEquals("Verify error code indicates clientId mismatch", e.errorInfo.code, 40101);
+            assertEquals("Verify error code indicates clientId mismatch", e.errorInfo.code, INVALID_CREDENTIALS_AUTH.code);
         }
     }
 
@@ -691,7 +695,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
             Helpers.ConnectionWaiter connectionWaiter = new Helpers.ConnectionWaiter(ablyRealtime.connection);
             ErrorInfo failure = connectionWaiter.waitFor(ConnectionState.failed);
             assertEquals("Verify failed state is reached", ConnectionState.failed, ablyRealtime.connection.state);
-            assertEquals("Verify failure error code indicates clientId mismatch", failure.code, 40101);
+            assertEquals("Verify failure error code indicates clientId mismatch", failure.code, INVALID_CREDENTIALS_AUTH.code);
         } catch (AblyException e) {
             e.printStackTrace();
             fail();
@@ -785,7 +789,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
             pubComplete.waitFor();
             assertTrue("Verify publish callback called on completion", pubComplete.pending.isEmpty());
             assertTrue("Verify publish callback returns an error", pubComplete.errors.size() == 1);
-            assertEquals("Verify publish callback error has expected error code", pubComplete.errors.iterator().next().code, 40012);
+            assertEquals("Verify publish callback error has expected error code", pubComplete.errors.iterator().next().code, INVALID_CLIENT_ID.code);
 
             /* verify no message sent or received on transport */
             assertTrue("Verify no messages sent", protocolListener.sentMessages.isEmpty());

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -46,6 +46,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static io.ably.lib.util.AblyErrors.BAD_REQUEST;
 
 public class RealtimeChannelTest extends ParameterizedTest {
 
@@ -239,7 +240,7 @@ public class RealtimeChannelTest extends ParameterizedTest {
                 ably.channels.get(channelName, options);
             } catch (AblyException e) {
                 assertEquals("Verify error code", 400, e.errorInfo.code);
-                assertEquals("Verify error status code", 40000, e.errorInfo.statusCode);
+                assertEquals("Verify error status code", BAD_REQUEST.code, e.errorInfo.statusCode);
                 assertTrue("Verify error message", e.errorInfo.message.contains("setOptions"));
             }
         } catch (AblyException e) {

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
@@ -6,6 +6,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import static io.ably.lib.util.AblyErrors.CHANNEL_OPERATION_FAILED;
+import static io.ably.lib.util.AblyErrors.FAIL_RECOVER_CONNECTION_EXPIRED;
+import static io.ably.lib.util.AblyErrors.INVALID_CONNECTION_ID_BAD_FORMAT;
+
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -324,7 +328,7 @@ public class RealtimeConnectFailTest extends ParameterizedTest {
             ConnectionWaiter connectionWaiter = new ConnectionWaiter(ably.connection);
             ErrorInfo fail = connectionWaiter.waitFor(ConnectionState.failed);
             assertEquals("Verify failed state is reached", ConnectionState.failed, ably.connection.state);
-            assertEquals("Verify correct error code is given", 80018, fail.code);
+            assertEquals("Verify correct error code is given", INVALID_CONNECTION_ID_BAD_FORMAT.code, fail.code);
         } catch (AblyException e) {
             e.printStackTrace();
             fail("init0: Unexpected exception instantiating library");
@@ -350,7 +354,7 @@ public class RealtimeConnectFailTest extends ParameterizedTest {
             ErrorInfo connectedError = connectionWaiter.waitFor(ConnectionState.connected);
             assertEquals("Verify connected state is reached", ConnectionState.connected, ably.connection.state);
             assertNotNull("Verify error is returned", connectedError);
-            assertEquals("Verify correct error code is given", 80008, connectedError.code);
+            assertEquals("Verify correct error code is given", FAIL_RECOVER_CONNECTION_EXPIRED.code, connectedError.code);
             assertFalse("Verify new connection id is assigned", recoverConnectionId.equals(ably.connection.key));
         } catch (AblyException e) {
             e.printStackTrace();
@@ -520,7 +524,7 @@ public class RealtimeConnectFailTest extends ParameterizedTest {
                     if (numberOfAuthCalls[0]++ == 0)
                         return tokenDetails;
                     else
-                        throw AblyException.fromErrorInfo(new ErrorInfo("Auth failure", 90000));
+                        throw AblyException.fromErrorInfo(new ErrorInfo("Auth failure", CHANNEL_OPERATION_FAILED.code));
                 }
             };
             ablyRealtime = new AblyRealtime(optsForRealtime);

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeJWTTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeJWTTest.java
@@ -38,6 +38,8 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static io.ably.lib.util.AblyErrors.OPERATION_NOT_PERMITTED_WITH_PROVIDED_CAPABILITY;
+import static io.ably.lib.util.AblyErrors.TOKEN_EXPIRED;
 
 public class RealtimeJWTTest extends ParameterizedTest {
 
@@ -116,7 +118,7 @@ public class RealtimeJWTTest extends ParameterizedTest {
                 @Override
                 public void onError(ErrorInfo error) {
                     assertEquals("Unexpected status code", 401, error.statusCode);
-                    assertEquals("Unexpected error code", 40160, error.code);
+                    assertEquals("Unexpected error code", OPERATION_NOT_PERMITTED_WITH_PROVIDED_CAPABILITY.code, error.code);
                     assertEquals("Unexpected error message", "Unable to perform channel operation (permission denied)", error.message);
                     ablyRealtime.close();
                 }
@@ -195,7 +197,7 @@ public class RealtimeJWTTest extends ParameterizedTest {
 
                 @Override
                 public void onConnectionStateChanged(ConnectionStateChange stateChange) {
-                    assertEquals("Unexpected connection stage change", 40142, stateChange.reason.code);
+                    assertEquals("Unexpected connection stage change", TOKEN_EXPIRED.code, stateChange.reason.code);
                     assertTrue("Unexpected error message", stateChange.reason.message.contains("Key/token status changed (expire)"));
                 }
             });

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeReauthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeReauthTest.java
@@ -30,6 +30,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static io.ably.lib.util.AblyErrors.CLIENT_AUTH_REQUEST_FAILED;
+import static io.ably.lib.util.AblyErrors.OPERATION_NOT_PERMITTED_WITH_PROVIDED_CAPABILITY;
 
 /**
  * Created by VOstopolets on 8/26/16.
@@ -83,7 +85,7 @@ public class RealtimeReauthTest extends ParameterizedTest {
             channel.attach(waiter);
             ErrorInfo error = waiter.waitFor();
             assertNotNull("Expected error", error);
-            assertEquals("Verify error code 40160 (channel is denied access)", error.code, 40160);
+            assertEquals("Verify error code 40160 (channel is denied access)", error.code, OPERATION_NOT_PERMITTED_WITH_PROVIDED_CAPABILITY.code);
 
             /* get second token */
             tokenParams = new Auth.TokenParams();
@@ -190,7 +192,7 @@ public class RealtimeReauthTest extends ParameterizedTest {
             long before = System.currentTimeMillis();
             ErrorInfo err = waiter.waitFor(ChannelState.failed);
             assertEquals("Verify failed state reached", channel.state, ChannelState.failed);
-            assertEquals("Verify error code", err.code, 40160);
+            assertEquals("Verify error code", err.code, OPERATION_NOT_PERMITTED_WITH_PROVIDED_CAPABILITY.code);
             assertTrue("Expected channel to fail quickly", System.currentTimeMillis() - before < 2000);
 
             ablyRealtime.close();
@@ -360,7 +362,7 @@ public class RealtimeReauthTest extends ParameterizedTest {
                 /* should stay in connected state, errorInfo should indicate authentication non-fatal error */
                 ConnectionStateListener.ConnectionStateChange lastChange = stateChangeHistory.get(stateChangeHistory.size()-1);
                 assertEquals("Verify connection stayed in connected state", lastChange.current, ConnectionState.connected);
-                assertEquals("Verify authentication failure error code", lastChange.reason.code, 80019);
+                assertEquals("Verify authentication failure error code", lastChange.reason.code, CLIENT_AUTH_REQUEST_FAILED.code);
             }
 
             ablyRealtime.close();

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeRecoverTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeRecoverTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static io.ably.lib.util.AblyErrors.BAD_REQUEST;
 
 public class RealtimeRecoverTest extends ParameterizedTest {
 
@@ -409,7 +410,7 @@ public class RealtimeRecoverTest extends ParameterizedTest {
             public void send(ProtocolMessage msg) throws AblyException {
                 if (throwOnSend) {
                     exceptionsThrown++;
-                    throw AblyException.fromErrorInfo(new ErrorInfo("TestException", 40000));
+                    throw AblyException.fromErrorInfo(new ErrorInfo("TestException", BAD_REQUEST.code));
                 } else {
                     super.send(msg);
                 }

--- a/lib/src/test/java/io/ably/lib/test/rest/HttpTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/HttpTest.java
@@ -59,6 +59,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
+import static io.ably.lib.util.AblyErrors.INTERNAL_ERROR;
 
 /**
  * Created by gokhanbarisaker on 2/2/16.
@@ -385,7 +386,7 @@ public class HttpTest {
             /* Verify that,
              *      - an {@code AblyException} with {@code ErrorInfo} having the 500 error from above
              */
-            ErrorInfo expectedErrorInfo = new ErrorInfo("Internal Server Error", 500, 50000);
+            ErrorInfo expectedErrorInfo = new ErrorInfo("Internal Server Error", 500, INTERNAL_ERROR.code);
             assertThat(e, new ErrorInfoMatcher(expectedErrorInfo));
         }
 
@@ -405,7 +406,7 @@ public class HttpTest {
             /* Verify that,
              *      - an {@code AblyException} with {@code ErrorInfo} having the 500 error from above
              */
-            ErrorInfo expectedErrorInfo = new ErrorInfo("Internal Server Error", 500, 50000);
+            ErrorInfo expectedErrorInfo = new ErrorInfo("Internal Server Error", 500, INTERNAL_ERROR.code);
             assertThat(e, new ErrorInfoMatcher(expectedErrorInfo));
         }
 
@@ -479,7 +480,7 @@ public class HttpTest {
             );
         } catch (AblyException e) {
             /* Verify that, an {@code AblyException} with {@code ErrorInfo} with the 500 error from above. */
-            ErrorInfo expectedErrorInfo = new ErrorInfo("Internal Server Error", 500, 50000);
+            ErrorInfo expectedErrorInfo = new ErrorInfo("Internal Server Error", 500, INTERNAL_ERROR.code);
             assertThat(e, new ErrorInfoMatcher(expectedErrorInfo));
         }
 

--- a/lib/src/test/java/io/ably/lib/test/rest/RestAuthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestAuthTest.java
@@ -47,6 +47,12 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static io.ably.lib.util.AblyErrors.BAD_REQUEST;
+import static io.ably.lib.util.AblyErrors.CLIENT_AUTH_REQUEST_FAILED;
+import static io.ably.lib.util.AblyErrors.INVALID_CLIENT_ID;
+import static io.ably.lib.util.AblyErrors.INVALID_CREDENTIALS_AUTH;
+import static io.ably.lib.util.AblyErrors.TOKEN_EXPIRED;
+import static io.ably.lib.util.AblyErrors.UNABLE_TO_OBTAIN_CREDENTIALS;
 
 public class RestAuthTest extends ParameterizedTest {
 
@@ -431,7 +437,7 @@ public class RestAuthTest extends ParameterizedTest {
                 ably.auth.requestToken(null, null);
                 fail("auth_authURL_err: Unexpected success requesting token");
             } catch (AblyException e) {
-                assertEquals("Expected error code", e.errorInfo.code, 80019);
+                assertEquals("Expected error code", e.errorInfo.code, CLIENT_AUTH_REQUEST_FAILED.code);
                 assertEquals("Expected forwarded error code", ((AblyException)e.getCause()).errorInfo.statusCode, 404);
             }
         } catch (AblyException e) {
@@ -457,7 +463,7 @@ public class RestAuthTest extends ParameterizedTest {
                 ably.auth.requestToken(null, null);
                 fail("auth_authURL_err: Unexpected success requesting token");
             } catch (AblyException e) {
-                assertEquals("Expected error code", e.errorInfo.code, 80019);
+                assertEquals("Expected error code", e.errorInfo.code, CLIENT_AUTH_REQUEST_FAILED.code);
                 assertEquals("Expected forwarded error code", ((AblyException)e.getCause()).errorInfo.statusCode, 500);
                 assertTrue("Expected forwarded forwarded exception", (e.getCause().getCause()) instanceof SocketTimeoutException);
             }
@@ -913,7 +919,7 @@ public class RestAuthTest extends ParameterizedTest {
                 ably.auth.requestToken(null, null);
                 fail("auth_authURL_err: Unexpected success requesting token");
             } catch (AblyException e) {
-                assertEquals("Expected error code", e.errorInfo.code, 80019);
+                assertEquals("Expected error code", e.errorInfo.code, CLIENT_AUTH_REQUEST_FAILED.code);
                 assertEquals("Expected forwarded error code", ((AblyException)e.getCause()).errorInfo.code, 12345);
             }
         } catch (AblyException e) {
@@ -933,7 +939,7 @@ public class RestAuthTest extends ParameterizedTest {
             new AblyRest(opts);
             fail("authinit_no_auth: Unexpected success instantiating library");
         } catch (AblyException e) {
-            assertEquals("Verify exception thrown initialising library", e.errorInfo.code, 40000);
+            assertEquals("Verify exception thrown initialising library", e.errorInfo.code, BAD_REQUEST.code);
         }
     }
 
@@ -1046,7 +1052,7 @@ public class RestAuthTest extends ParameterizedTest {
             opts.clientId = "*";
             new AblyRest(opts);
         } catch (AblyException e) {
-            assertEquals("Verify exception raised from disallowed wildcard clientId", e.errorInfo.code, 40000);
+            assertEquals("Verify exception raised from disallowed wildcard clientId", e.errorInfo.code, BAD_REQUEST.code);
         }
     }
 
@@ -1070,7 +1076,7 @@ public class RestAuthTest extends ParameterizedTest {
             opts.clientId = "options clientId";
             new AblyRest(opts);
         } catch (AblyException e) {
-            assertEquals("Verify exception raised from incompatible clientIds", e.errorInfo.code, 40101);
+            assertEquals("Verify exception raised from incompatible clientIds", e.errorInfo.code, INVALID_CREDENTIALS_AUTH.code);
         }
     }
 
@@ -1231,7 +1237,7 @@ public class RestAuthTest extends ParameterizedTest {
             Channel channel = ably.channels.get("test");
             channel.publish(new Message[]{ message });
         } catch(AblyException e) {
-            assertEquals("Verify exception is raised with expected error code", e.errorInfo.code, 40012);
+            assertEquals("Verify exception is raised with expected error code", e.errorInfo.code, INVALID_CLIENT_ID.code);
         }
     }
 
@@ -1797,7 +1803,7 @@ public class RestAuthTest extends ParameterizedTest {
                 fail("auth_local_token_expiry_check_sync: API call unexpectedly succeeded");
                 return;
             } catch (AblyException e) {
-                assertEquals("Verify that API request failed with credentials error", e.errorInfo.code, 40106);
+                assertEquals("Verify that API request failed with credentials error", e.errorInfo.code, UNABLE_TO_OBTAIN_CREDENTIALS.code);
                 for(Helpers.RawHttpRequest req : httpListener.values()) {
                     assertFalse("Verify no API request attempted", req.url.getPath().contains("stats"));
                 }
@@ -1843,8 +1849,8 @@ public class RestAuthTest extends ParameterizedTest {
                 return;
             } catch (AblyException e) {
                 assertEquals("Verify API request attempted", httpListener.size(), 1);
-                assertEquals("Verify API request failed with token expiry error", httpListener.getFirstRequest().response.headers.get("x-ably-errorcode").get(0), "40142");
-                assertEquals("Verify that API request failed with credentials error", e.errorInfo.code, 40106);
+                assertEquals("Verify API request failed with token expiry error", httpListener.getFirstRequest().response.headers.get("x-ably-errorcode").get(0), String.valueOf(TOKEN_EXPIRED.code));
+                assertEquals("Verify that API request failed with credentials error", e.errorInfo.code, UNABLE_TO_OBTAIN_CREDENTIALS.code);
             }
         } catch (AblyException e) {
             e.printStackTrace();
@@ -1898,7 +1904,7 @@ public class RestAuthTest extends ParameterizedTest {
             for(Helpers.RawHttpRequest x : httpListener.values()) {
                 System.out.println(x.url.toString());
             }
-            assertEquals("Verify API request failed with token expiry error", httpListener.getFirstRequest().response.headers.get("x-ably-errorcode").get(0), "40142");
+            assertEquals("Verify API request failed with token expiry error", httpListener.getFirstRequest().response.headers.get("x-ably-errorcode").get(0), String.valueOf(TOKEN_EXPIRED.code));
         } catch (AblyException e) {
             e.printStackTrace();
             fail("auth_local_token_expiry_check_nosync: Unexpected exception instantiating library");

--- a/lib/src/test/java/io/ably/lib/test/rest/RestCapabilityTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestCapabilityTest.java
@@ -4,6 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
+import static io.ably.lib.util.AblyErrors.BAD_REQUEST;
+import static io.ably.lib.util.AblyErrors.OPERATION_NOT_PERMITTED_WITH_PROVIDED_CAPABILITY;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -81,7 +84,7 @@ public class RestCapabilityTest extends ParameterizedTest {
             ably.auth.requestToken(tokenParams, authOptions);
             fail("Invalid capability, expected rejection");
         } catch(AblyException e) {
-            assertEquals("Unexpected error code", e.errorInfo.code, 40160);
+            assertEquals("Unexpected error code", e.errorInfo.code, OPERATION_NOT_PERMITTED_WITH_PROVIDED_CAPABILITY.code);
         }
     }
 
@@ -101,7 +104,7 @@ public class RestCapabilityTest extends ParameterizedTest {
             ably.auth.requestToken(tokenParams, authOptions);
             fail("Invalid capability, expected rejection");
         } catch(AblyException e) {
-            assertEquals("Unexpected error code", e.errorInfo.code, 40160);
+            assertEquals("Unexpected error code", e.errorInfo.code, OPERATION_NOT_PERMITTED_WITH_PROVIDED_CAPABILITY.code);
         }
     }
 
@@ -269,7 +272,7 @@ public class RestCapabilityTest extends ParameterizedTest {
             ably.auth.requestToken(tokenParams, null);
             fail("Invalid capability, expected rejection");
         } catch(AblyException e) {
-            assertEquals("Unexpected error code", e.errorInfo.code, 40000);
+            assertEquals("Unexpected error code", e.errorInfo.code, BAD_REQUEST.code);
         }
     }
     @Test
@@ -282,7 +285,7 @@ public class RestCapabilityTest extends ParameterizedTest {
             ably.auth.requestToken(tokenParams, null);
             fail("Invalid capability, expected rejection");
         } catch(AblyException e) {
-            assertEquals("Unexpected error code", e.errorInfo.code, 40000);
+            assertEquals("Unexpected error code", e.errorInfo.code, BAD_REQUEST.code);
         }
     }
     @Test
@@ -295,7 +298,7 @@ public class RestCapabilityTest extends ParameterizedTest {
             ably.auth.requestToken(tokenParams, null);
             fail("Invalid capability, expected rejection");
         } catch(AblyException e) {
-            assertEquals("Unexpected error code", e.errorInfo.code, 40000);
+            assertEquals("Unexpected error code", e.errorInfo.code, BAD_REQUEST.code);
         }
     }
 }

--- a/lib/src/test/java/io/ably/lib/test/rest/RestChannelBulkPublishTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestChannelBulkPublishTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static io.ably.lib.util.AblyErrors.OPERATION_NOT_PERMITTED_WITH_PROVIDED_CAPABILITY;
 
 public class RestChannelBulkPublishTest extends ParameterizedTest  {
 
@@ -262,7 +263,7 @@ public class RestChannelBulkPublishTest extends ParameterizedTest  {
                     assertNull("Verify no publish error", response.error);
                 } else {
                     assertNotNull("Verify expected publish error", response.error);
-                    assertEquals("Verify expected publish error code", response.error.code, 40160);
+                    assertEquals("Verify expected publish error code", response.error.code, OPERATION_NOT_PERMITTED_WITH_PROVIDED_CAPABILITY.code);
                 }
             }
 

--- a/lib/src/test/java/io/ably/lib/test/rest/RestJWTTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestJWTTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static io.ably.lib.util.AblyErrors.INVALID_JWT_FORMAT;
 
 public class RestJWTTest extends ParameterizedTest {
 
@@ -58,7 +59,7 @@ public class RestJWTTest extends ParameterizedTest {
             AblyRest client = new AblyRest(options);
             PaginatedResult<Stats> stats = client.stats(null);
         } catch (AblyException e) {
-            assertEquals("Unexpected code from exception", 40144, e.errorInfo.code);
+            assertEquals("Unexpected code from exception", INVALID_JWT_FORMAT.code, e.errorInfo.code);
             assertEquals("Unexpected statusCode from exception", 401, e.errorInfo.statusCode);
             assertTrue("Error message not matching the expected one", e.errorInfo.message.contains("signature verification failed"));
         }

--- a/lib/src/test/java/io/ably/lib/test/rest/RestRequestTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestRequestTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import static io.ably.lib.util.AblyErrors.INVALID_CONNECTION_ID;
+
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
@@ -739,6 +741,6 @@ public class RestRequestTest extends ParameterizedTest {
         assertFalse("Verify failure is indicated", publishResponse.success);
         assertNotNull("Verify error is indicated", publishResponse.errorMessage);
         assertEquals("Verify statusCode is present", publishResponse.statusCode, 400);
-        assertEquals("Verify errorCode is present", publishResponse.errorCode, 40006);
+        assertEquals("Verify errorCode is present", publishResponse.errorCode, INVALID_CONNECTION_ID.code);
     }
 }

--- a/lib/src/test/java/io/ably/lib/test/rest/RestTokenTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestTokenTest.java
@@ -16,6 +16,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static io.ably.lib.util.AblyErrors.INVALID_PARAMETER_VALUE;
+import static io.ably.lib.util.AblyErrors.TIMESTAMP_NOT_CURRENT;
 
 public class RestTokenTest extends ParameterizedTest {
 
@@ -102,7 +104,7 @@ public class RestTokenTest extends ParameterizedTest {
             ably.auth.requestToken(tokenParams, null);
             fail("Expected token request rejection");
         } catch(AblyException e) {
-            assertEquals("Unexpected error code", e.errorInfo.code, 40104);
+            assertEquals("Unexpected error code", e.errorInfo.code, TIMESTAMP_NOT_CURRENT.code);
         }
     }
 
@@ -216,7 +218,7 @@ public class RestTokenTest extends ParameterizedTest {
             ably.auth.requestToken(tokenParams, null);
             fail("Expected token request rejection");
         } catch(AblyException e) {
-            assertEquals("Unexpected error code", e.errorInfo.code, 40003);
+            assertEquals("Unexpected error code", e.errorInfo.code, INVALID_PARAMETER_VALUE.code);
         }
     }
 
@@ -231,7 +233,7 @@ public class RestTokenTest extends ParameterizedTest {
             ably.auth.requestToken(tokenParams, null);
             fail("Expected token request rejection");
         } catch(AblyException e) {
-            assertEquals("Unexpected error code", e.errorInfo.code, 40003);
+            assertEquals("Unexpected error code", e.errorInfo.code, INVALID_PARAMETER_VALUE.code);
         }
     }
 

--- a/lib/src/test/java/io/ably/lib/test/util/MockWebsocketFactory.java
+++ b/lib/src/test/java/io/ably/lib/test/util/MockWebsocketFactory.java
@@ -1,5 +1,8 @@
 package io.ably.lib.test.util;
 
+import static io.ably.lib.util.AblyErrors.BAD_REQUEST;
+import static io.ably.lib.util.AblyErrors.INTERNAL_ERROR;
+
 import io.ably.lib.transport.ConnectionManager;
 import io.ably.lib.transport.ITransport;
 import io.ably.lib.transport.WebSocketTransport;
@@ -125,7 +128,7 @@ public class MockWebsocketFactory implements ITransport.Factory {
                     break;
                 case fail:
                     if (messageFilter == null || messageFilter.matches(msg)) {
-                        throw AblyException.fromErrorInfo(new ErrorInfo("Mock", 40000));
+                        throw AblyException.fromErrorInfo(new ErrorInfo("Mock", BAD_REQUEST.code));
                     } else {
                         super.send(msg);
                     }
@@ -143,13 +146,13 @@ public class MockWebsocketFactory implements ITransport.Factory {
                         super.connect(connectListener);
                     } else {
                         System.out.println("MockWebsocketTransport: disallowing " + host);
-                        connectListener.onTransportUnavailable(this, new ErrorInfo("MockWebsocketTransport: connection disallowed by hostFilter", 500, 50000));
+                        connectListener.onTransportUnavailable(this, new ErrorInfo("MockWebsocketTransport: connection disallowed by hostFilter", 500, INTERNAL_ERROR.code));
                     }
                     break;
                 case fail:
                     if (hostFilter == null || hostFilter.matches(host)) {
                         System.out.println("MockWebsocketTransport: failing " + host);
-                        connectListener.onTransportUnavailable(this, new ErrorInfo("MockWebsocketTransport: connection failed by hostFilter", 500, 50000));
+                        connectListener.onTransportUnavailable(this, new ErrorInfo("MockWebsocketTransport: connection failed by hostFilter", 500, INTERNAL_ERROR.code));
                     } else {
                         System.out.println("MockWebsocketTransport: not failing " + host);
                         super.connect(connectListener);

--- a/lib/src/test/java/io/ably/lib/test/util/TokenServer.java
+++ b/lib/src/test/java/io/ably/lib/test/util/TokenServer.java
@@ -42,6 +42,7 @@ import io.ably.lib.types.ErrorResponse;
 import io.ably.lib.util.Serialisation;
 
 import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
+import static io.ably.lib.util.AblyErrors.BAD_REQUEST;
 
 public class TokenServer extends NanoHTTPD {
 
@@ -60,7 +61,7 @@ public class TokenServer extends NanoHTTPD {
             try {
                 session.parseBody(new HashMap<String, String>());
             } catch (IOException | ResponseException e) {
-                return error2Response(new ErrorInfo("Bad POST token request", 400, 40000));
+                return error2Response(new ErrorInfo("Bad POST token request", 400, BAD_REQUEST.code));
             }
         }
 


### PR DESCRIPTION
Extracted all Ably error codes into AblyErrors enum class with code and message for each one of them presented [here](https://github.com/ably/ably-common/blob/main/protocol/errors.json).