### PR TITLE
Skip checking WS hostname when not using SSL

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -150,7 +150,7 @@ public class WebSocketTransport implements ITransport {
         @Override
         public void onOpen(ServerHandshake handshakedata) {
             Log.d(TAG, "onOpen()");
-            if (shouldExplicitlyVerifyHostname && !isHostnameVerified(params.host)) {
+            if (params.options.tls && shouldExplicitlyVerifyHostname && !isHostnameVerified(params.host)) {
                 close();
             } else {
                 connectListener.onTransportAvailable(WebSocketTransport.this);


### PR DESCRIPTION
otherwise an exception is raised as there is no SSL session to check