### PR TITLE
Fix attach/detach race condition

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -198,8 +198,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
                         on(new ChannelStateCompletionListener(listener, ChannelState.attached, ChannelState.failed));
                     }
                     return;
-                case detaching:
-                    //add to pending attach after detach has succeeded
+                case detaching: //RTL4h
                     pendingAttachRequest = new AttachRequest(forceReattach,listener);
                     return;
                 case attached:
@@ -286,7 +285,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
                     on(new ChannelStateCompletionListener(listener, ChannelState.detached, ChannelState.failed));
                 }
                 return;
-            case attaching:
+            case attaching: //RTL5i
                 pendingDetachRequest = new DetachRequest(listener);
                 return;
             default:

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -139,7 +139,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
                 detach(pendingDetachRequest.completionListener);
                 pendingDetachRequest = null;
             } catch (AblyException e) {
-                Log.e(TAG,"Channel ailed to detach after attach:"+name,e);
+                Log.e(TAG,"Channel failed to detach after attach:"+name,e);
             }
         }
     }

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -1104,7 +1104,6 @@ public class RealtimeChannelTest extends ParameterizedTest {
 
             //now wait for detach to complete
             (new ChannelWaiter(channel)).waitFor(ChannelState.detached);
-            /* detach */
             detachCompletionWaiter.waitFor();
 
             assertThat(detachCompletionWaiter.success,is(true));

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -1103,7 +1103,7 @@ public class RealtimeChannelTest extends ParameterizedTest {
             assertEquals("Verify attached state reached", ChannelState.attached, channel.state);
 
             //now wait for detach to complete
-            new ChannelWaiter(channel).waitFor(ChannelState.detached);
+            (new ChannelWaiter(channel)).waitFor(ChannelState.detached);
             /* detach */
             detachCompletionWaiter.waitFor();
 

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -1039,19 +1039,19 @@ public class RealtimeChannelTest extends ParameterizedTest {
 
             /* wait until connected */
             (new ConnectionWaiter(ably.connection)).waitFor(ConnectionState.connected);
-            assertEquals("Verify connected state reached", ably.connection.state, ConnectionState.connected);
+            assertEquals("Verify connected state reached", ConnectionState.connected, ably.connection.state);
 
             /* create a channel and attach */
             final String channelName = "attach_channel";
             final Channel channel = ably.channels.get(channelName);
             channel.attach();
             new ChannelWaiter(channel).waitFor(ChannelState.attached);
-            assertEquals("Verify attached state reached", channel.state, ChannelState.attached);
+            assertEquals("Verify attached state reached", ChannelState.attached, channel.state);
 
             /* detach */
             final Helpers.CompletionWaiter detachCompletionWaiter = new Helpers.CompletionWaiter();
             channel.detach(detachCompletionWaiter);
-            assertEquals("Verify detaching state reached", channel.state, ChannelState.detaching);
+            assertEquals("Verify detaching state reached", ChannelState.detaching, channel.state);
             final Helpers.CompletionWaiter attachCompletionWaiter = new Helpers.CompletionWaiter();
             //attempt to attach while detaching
             channel.attach(attachCompletionWaiter);
@@ -1087,20 +1087,20 @@ public class RealtimeChannelTest extends ParameterizedTest {
 
             /* wait until connected */
             (new ConnectionWaiter(ably.connection)).waitFor(ConnectionState.connected);
-            assertEquals("Verify connected state reached", ably.connection.state, ConnectionState.connected);
+            assertEquals("Verify connected state reached", ConnectionState.connected, ably.connection.state);
 
             /* create a channel and attach */
             final String channelName = "attach_channel";
             final Channel channel = ably.channels.get(channelName);
             final Helpers.CompletionWaiter attachCompletionWaiter = new Helpers.CompletionWaiter();
             channel.attach(attachCompletionWaiter);
-            assertEquals("Verify detaching state reached", channel.state, ChannelState.attaching);
+            assertEquals("Verify detaching state reached", ChannelState.attaching, channel.state);
             //immediately start detach operation
             final Helpers.CompletionWaiter detachCompletionWaiter = new Helpers.CompletionWaiter();
             channel.detach(detachCompletionWaiter);
 
             new ChannelWaiter(channel).waitFor(ChannelState.attached);
-            assertEquals("Verify attached state reached", channel.state, ChannelState.attached);
+            assertEquals("Verify attached state reached", ChannelState.attached, channel.state);
 
             //now wait for detach to complete
             new ChannelWaiter(channel).waitFor(ChannelState.detached);

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -1049,20 +1049,21 @@ public class RealtimeChannelTest extends ParameterizedTest {
             assertEquals("Verify attached state reached", channel.state, ChannelState.attached);
 
             /* detach */
-            channel.detach();
-            assertEquals("Verify detaching state reached", channel.state, ChannelState.detaching);
-            final Helpers.CompletionWaiter attachCompletionWaiter = new Helpers.CompletionWaiter();
-            channel.attach();
-
             final Helpers.CompletionWaiter detachCompletionWaiter = new Helpers.CompletionWaiter();
             channel.detach(detachCompletionWaiter);
+            assertEquals("Verify detaching state reached", channel.state, ChannelState.detaching);
+            final Helpers.CompletionWaiter attachCompletionWaiter = new Helpers.CompletionWaiter();
+            //attempt to attach while detaching
+            channel.attach(attachCompletionWaiter);
 
             /* Verify onSuccess callback gets called */
             detachCompletionWaiter.waitFor();
             assertThat(detachCompletionWaiter.success, is(true));
+            assertThat(channel.state, is(ChannelState.detached));
             //verify reattach - after detach
             attachCompletionWaiter.waitFor();
             assertThat(attachCompletionWaiter.success,is(true));
+            assertThat(channel.state, is(ChannelState.attached));
         } finally {
             if(ably != null)
                 ably.close();


### PR DESCRIPTION
This PR improves spec conformance for [RTL4h](https://sdk.ably.com/builds/ably/specification/main/features/#RTL4h) and [RTL5i](https://sdk.ably.com/builds/ably/specification/main/features/#RTL5i)
However I think the spec might be a bit misleading (Please correct me if I'm wrong)
In RTL4h, it writes

> If the channel is in a pending state DETACHING or ATTACHING, do the attach operation after the completion of the pending request

I'm not sure if the attach operation should be done after an attach already happened (no need for adding a pending attach). Currently it just register a completion listener if provided and then returns which I think is the correct behaviour. I changed the behaviour when the channel was in DETACHING state so it wouldn't send an attach right away and add a pending attach request to be sent after completion of detach.

The same applies for RTL5i, but in reverse order 

Closes https://github.com/ably/ably-java/issues/885
