### PR TITLE
Ignore consistently failing test : auth_renewAuth_callback_invoked

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/Defaults.java
+++ b/lib/src/main/java/io/ably/lib/transport/Defaults.java
@@ -8,7 +8,7 @@ import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 
 public class Defaults {
-    public static final float ABLY_VERSION_NUMBER   = 1.0f;
+    public static final float ABLY_VERSION_NUMBER   = 1.2f;
 
     /**
      * The level of compatibility with the Ably service that this SDK supports, also referred to as the 'wire protocol version'.

--- a/lib/src/main/java/io/ably/lib/transport/Defaults.java
+++ b/lib/src/main/java/io/ably/lib/transport/Defaults.java
@@ -8,7 +8,7 @@ import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 
 public class Defaults {
-    public static final float ABLY_VERSION_NUMBER   = 1.2f;
+    public static final float ABLY_VERSION_NUMBER   = 1.0f;
 
     /**
      * The level of compatibility with the Ably service that this SDK supports, also referred to as the 'wire protocol version'.

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAuthTest.java
@@ -1052,6 +1052,7 @@ public class RealtimeAuthTest extends ParameterizedTest {
         }
     }
 
+    @Ignore("Fix flakey test")
     @Test
     public void auth_renewAuth_callback_invoked() throws InterruptedException {
         try {


### PR DESCRIPTION
This PR ignores a test that is mostly failing on CI : auth_renewAuth_callback_invoked

There is already an issue for this : https://github.com/ably/ably-java/issues/863 and we should be addressing fixing from that issue