### PR TITLE
Connection resumption improvements

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
+++ b/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
@@ -231,6 +231,20 @@ public class AblyRealtime extends AblyRest {
             }
         }
 
+        /**
+         * By spec RTN15c3
+         */
+        @Override
+        public void reattachOnResumeFailure() {
+            for (Map.Entry<String, Channel> channelEntry : map.entrySet()) {
+                Channel channel = channelEntry.getValue();
+                if (channel.state == ChannelState.attaching || channel.state == ChannelState.attached || channel.state == ChannelState.suspended) {
+                    Log.d(TAG, "reAttach(); channel = " + channel.name);
+                    channel.attach(true, null);
+                }
+            }
+        }
+
         private void clear() {
             map.clear();
         }

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -181,7 +181,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
         this.attach(false, listener);
     }
 
-    private void attach(boolean forceReattach, CompletionListener listener) {
+    void attach(boolean forceReattach, CompletionListener listener) {
         clearAttachTimers();
         attachWithTimeout(forceReattach, listener);
     }

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1249,28 +1249,20 @@ public class ConnectionManager implements ConnectListener {
      * on pending queue, for example when a connection resume failed
      */
     private void addPendingMessagesToQueuedMessages(boolean resetMessageSerial) {
+        // Add messages from pending messages to front of queuedMessages in order to retry them
+        queuedMessages.addAll(0, pendingMessages.queue);
+        //rewind start serial back to the first serial since we are clearing the queue
+        if (!pendingMessages.queue.isEmpty()){
+            //Reset current serial to the first pending message on previous queue as we are going to clear the queue now
+            msgSerial =  pendingMessages.queue.get(0).msg.msgSerial;
+            pendingMessages.resetStartSerial((int) (msgSerial));
+            pendingMessages.clearQueue();
+        }
+
         //RTN19a
         if (resetMessageSerial){
             pendingMessages.resetStartSerial(0);
             msgSerial = 0; //msgSerial will increase in sendImpl when messages are sent
-        }
-        //put messages from pending messages to front of queuedMessages, the ones with the message serials will already
-        //have been assigned new message serial to them at this point
-        final int pendingMessageCount = pendingMessages.queue.size();
-        queuedMessages.addAll(0, pendingMessages.queue);
-        //Clear the pendingQueue now, because we do not want the retried messages to accumulate on it.
-        pendingMessages.clearQueue();
-
-
-        // reassign new serials for remaining queued messages if reset was required
-        if (resetMessageSerial) {
-            int startIndex = pendingMessageCount != 0 ? pendingMessageCount - 1 : 0;
-            for (int i = startIndex; i < queuedMessages.size(); i++) {
-                //if index is 0, it means there wasn't any previous pending messages so we use newly reset msgSerial as
-                //starting serial
-                final long previousMessageSerial = i == 0 ? msgSerial : queuedMessages.get(i - 1).msg.msgSerial;
-                queuedMessages.get(i).msg.msgSerial = previousMessageSerial + 1;
-            }
         }
     }
 

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1188,6 +1188,7 @@ public class ConnectionManager implements ConnectListener {
         final ErrorInfo error = message.error;
         connection.reason = error;
         if (connection.id != null) { // there was a previous connection, so this is a resume and RTN15c applies
+            Log.d(TAG, "There was a connection resume");
             if(message.connectionId.equals(connection.id)) {
                 // resume succeeded
                 if(message.error == null) {
@@ -1266,6 +1267,9 @@ public class ConnectionManager implements ConnectListener {
         }
     }
 
+    public List<QueuedMessage> getPendingMessages() {
+        return pendingMessages.queue;
+    }
 
     private synchronized void onDisconnected(ProtocolMessage message) {
         ErrorInfo reason = message.error;

--- a/lib/src/main/java/io/ably/lib/transport/ITransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/ITransport.java
@@ -122,6 +122,8 @@ public interface ITransport {
      */
     void send(ProtocolMessage msg) throws AblyException;
 
+    void receive(ProtocolMessage msg) throws AblyException;
+
     /**
      * Get connection URL
      * @return


### PR DESCRIPTION
This PR introduces some fixes to connection resumption issues by implementing spec RTN15c1, RTN15c2 and RTN15c3. To summarize the rule of implementation.

* If connection resume is successful, current serial is set to the first serial of pending queue, queue is cleared and previously sent pending messages are added in front of queued messages. 
* If connection resume is failed the message serial is reset to 0 and all pending messages are added the queue to be sent with the newly assigned serials

Previously when there was a new connection established, channels were suspended and pending messages were reset. This should not be happening anymore

Also I have made some changes to general interface of `WebSocketTransport` to be able to mock blocking receives 
* There is a new `receive` method that uses a single method interface to delegate handling of sending messages to connectionManager. There are also some changes with MockWebSocketTransport that allows blocking incoming acks/nacks. This class is also now exposed so that we can read sent published messages directly. Please note that changes done here for these classes only serve the particular case of publishing. I think it can be improved to contain other protocol actions too.

Some changes are inspired and taken from https://github.com/ably/ably-java/pull/842

Closes https://github.com/ably/ably-java/issues/474