### PR TITLE
Improve after resume failure logic

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
+++ b/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
@@ -256,9 +256,9 @@ public class AblyRealtime extends AblyRest {
                     Log.d(TAG, "reAttach(); channel = " + channel.name);
 
                     if (channelQueueMap.containsKey(channel.name)){
-                        channel.transferQueuedMessages(channelQueueMap.get(channel.name));
+                        channel.transferQueuedPresenceMessages(channelQueueMap.get(channel.name));
                     }else {
-                        channel.transferQueuedMessages(null);
+                        channel.transferQueuedPresenceMessages(null);
                     }
                 }
             }

--- a/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
+++ b/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
@@ -257,6 +257,8 @@ public class AblyRealtime extends AblyRest {
 
                     if (channelQueueMap.containsKey(channel.name)){
                         channel.reattach(channelQueueMap.get(channel.name));
+                    }else {
+                        channel.reattach(null);
                     }
                 }
             }

--- a/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
+++ b/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
@@ -1,6 +1,9 @@
 package io.ably.lib.realtime;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import io.ably.lib.rest.AblyRest;
@@ -233,14 +236,28 @@ public class AblyRealtime extends AblyRest {
 
         /**
          * By spec RTN15c3
+         * Move queued messages from connection manager to their respective channel and reattach
+         * @param queuedMessages Queued messages transferred from connection
          */
         @Override
-        public void reattachOnResumeFailure() {
+        public void reattach(List<ConnectionManager.QueuedMessage> queuedMessages) {
+            final Map<String, List<ConnectionManager.QueuedMessage>> channelQueueMap  = new HashMap<>();
+            for (ConnectionManager.QueuedMessage queuedMessage : queuedMessages) {
+                final String channelName = queuedMessage.msg.channel;
+                if (!channelQueueMap.containsKey(channelName)){
+                    channelQueueMap.put(channelName, new ArrayList<>());
+                }
+                channelQueueMap.get(channelName).add(queuedMessage);
+            }
+
             for (Map.Entry<String, Channel> channelEntry : map.entrySet()) {
                 Channel channel = channelEntry.getValue();
                 if (channel.state == ChannelState.attaching || channel.state == ChannelState.attached || channel.state == ChannelState.suspended) {
                     Log.d(TAG, "reAttach(); channel = " + channel.name);
-                    channel.attach(true, null);
+
+                    if (channelQueueMap.containsKey(channel.name)){
+                        channel.reattach(channelQueueMap.get(channel.name));
+                    }
                 }
             }
         }

--- a/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
+++ b/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
@@ -236,11 +236,11 @@ public class AblyRealtime extends AblyRest {
 
         /**
          * By spec RTN15c3
-         * Move queued messages from connection manager to their respective channel and reattach
-         * @param queuedMessages Queued messages transferred from connection
+         * Move queued messages from connection manager to their respective channel for them to be sent after reattach
+         * @param queuedMessages Queued messages transferred from ConnectionManager
          */
         @Override
-        public void reattach(List<ConnectionManager.QueuedMessage> queuedMessages) {
+        public void transferToChannels(List<ConnectionManager.QueuedMessage> queuedMessages) {
             final Map<String, List<ConnectionManager.QueuedMessage>> channelQueueMap  = new HashMap<>();
             for (ConnectionManager.QueuedMessage queuedMessage : queuedMessages) {
                 final String channelName = queuedMessage.msg.channel;
@@ -256,9 +256,9 @@ public class AblyRealtime extends AblyRest {
                     Log.d(TAG, "reAttach(); channel = " + channel.name);
 
                     if (channelQueueMap.containsKey(channel.name)){
-                        channel.reattach(channelQueueMap.get(channel.name));
+                        channel.transferQueuedMessages(channelQueueMap.get(channel.name));
                     }else {
-                        channel.reattach(null);
+                        channel.transferQueuedMessages(null);
                     }
                 }
             }

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -1250,12 +1250,6 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
             switch(oldState) {
                 case attached:
                     /* Unexpected detach, reattach when possible */
-                    if (msg.error != null){
-                        System.out.println("Unexpected detach "+msg.error);
-                    }else {
-                        System.out.println("Unexpected detach ");
-                    }
-
                     setDetached((msg.error != null) ? msg.error : REASON_NOT_ATTACHED);
                     Log.v(TAG, String.format(Locale.ROOT, "Server initiated detach for channel %s; attempting reattach", name));
                     try {
@@ -1269,7 +1263,6 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
                 case attaching:
                     /* RTL13b says we need to be suspended, but continue to retry */
                     Log.v(TAG, String.format(Locale.ROOT, "Server initiated detach for channel %s whilst attaching; moving to suspended", name));
-                    System.out.println("test for suspended: from attaching (onChannelMessage)");
                     setSuspended(msg.error, true);
                     reattachAfterTimeout();
                     break;

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -663,7 +663,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
             Log.v(TAG, "setSuspended(); channel = " + name);
             presence.setSuspended(reason);
             setState(ChannelState.suspended, reason, false, notifyStateChange);
-            // failQueuedMessages(reason);
+            failQueuedMessages(reason);
         }
     }
 

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -207,16 +207,8 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
                     PresenceMessage[] presenceMessages = queuedMessage.msg.presence;
                     if (presenceMessages != null && presenceMessages.length > 0){
                         for (PresenceMessage presenceMessage : presenceMessages) {
-                            String clientId;
-                            try {
-                                clientId = ably.auth.checkClientId(presenceMessage, false, true);
-                            } catch(AblyException e) {
-                                if(queuedMessage.listener != null) {
-                                    queuedMessage.listener.onError(e.errorInfo);
-                                }
-                                return;
-                            }
-                            this.presence.addPendingPresence(clientId, presenceMessage, queuedMessage.listener);
+                            this.presence.addPendingPresence(presenceMessage.clientId, presenceMessage,
+                                queuedMessage.listener);
                         }
                     }
                 }

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -202,9 +202,8 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
         if (messagesToTransfer != null) {
             for (QueuedMessage queuedMessage : messagesToTransfer) {
                 if (queuedMessage.msg.action == Action.message) {
-
                     queuedMessages.add(queuedMessage);
-                }else if (queuedMessage.msg.action == Action.presence) {
+                } else if (queuedMessage.msg.action == Action.presence) {
                     PresenceMessage[] presenceMessages = queuedMessage.msg.presence;
                     if (presenceMessages != null && presenceMessages.length > 0){
                         for (PresenceMessage presenceMessage : presenceMessages) {
@@ -447,7 +446,6 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
                 t.cancel();
                 t.purge();
             }
-
         }
     }
 

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -1,6 +1,5 @@
 package io.ably.lib.realtime;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -386,7 +385,6 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
         } else {
             this.attachResume = true;
             setState(ChannelState.attached, message.error, resumed);
-            sendQueuedMessages();
             presence.setAttached(message.hasFlag(Flag.has_presence), this.ably.connection.id);
         }
     }
@@ -396,7 +394,6 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
         Log.v(TAG, "setDetached(); channel = " + name);
         presence.setDetached(reason);
         setState(ChannelState.detached, reason);
-        failQueuedMessages(reason);
     }
 
     private void setFailed(ErrorInfo reason) {
@@ -405,7 +402,6 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
         presence.setDetached(reason);
         this.attachResume = false;
         setState(ChannelState.failed, reason);
-        failQueuedMessages(reason);
     }
 
     /* Timer for attach operation */
@@ -639,7 +635,6 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
             Log.v(TAG, "setSuspended(); channel = " + name);
             presence.setSuspended(reason);
             setState(ChannelState.suspended, reason, false, notifyStateChange);
-            failQueuedMessages(reason);
         }
     }
 
@@ -1048,46 +1043,6 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
         }
     }
 
-    private void sendQueuedMessages() {
-        Log.v(TAG, "sendQueuedMessages()");
-        ArrayList<FailedMessage> failedMessages = new ArrayList<>();
-        synchronized (this) {
-            boolean queueMessages = ably.options.queueMessages;
-            ConnectionManager connectionManager = ably.connection.connectionManager;
-            for (QueuedMessage msg : queuedMessages)
-                try {
-                    connectionManager.send(msg.msg, queueMessages, msg.listener);
-                } catch (AblyException e) {
-                    Log.e(TAG, "sendQueuedMessages(): Unexpected exception sending message", e);
-                    if (msg.listener != null)
-                        failedMessages.add(new FailedMessage(msg, e.errorInfo));
-                }
-            queuedMessages.clear();
-        }
-
-        /* Call completion callbacks for failed messages without holding the lock */
-        for (FailedMessage failed: failedMessages) {
-            callCompletionListenerError(failed.msg.listener, failed.reason);
-        }
-    }
-
-    private void failQueuedMessages(ErrorInfo reason) {
-        Log.v(TAG, "failQueuedMessages()");
-
-        ArrayList<FailedMessage> failedMessages = new ArrayList<>();
-        synchronized (this) {
-            for (QueuedMessage msg: queuedMessages) {
-                if (msg.listener != null)
-                    failedMessages.add(new FailedMessage(msg, reason));
-            }
-            queuedMessages.clear();
-        }
-
-        for(FailedMessage failed : failedMessages) {
-            callCompletionListenerError(failed.msg.listener, failed.reason);
-        }
-    }
-
     static Param[] replacePlaceholderParams(Channel channel, Param[] placeholderParams) throws AblyException {
         if (placeholderParams == null) {
             return null;
@@ -1123,7 +1078,6 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
 
     private static final String KEY_UNTIL_ATTACH = "untilAttach";
     private static final String KEY_FROM_SERIAL = "fromSerial";
-    private List<QueuedMessage> queuedMessages;
 
     /************************************
      * Channel history
@@ -1282,7 +1236,6 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
         this.presence = new Presence((Channel) this);
         this.attachResume = false;
         state = ChannelState.initialized;
-        queuedMessages = new ArrayList<QueuedMessage>();
         this.decodingContext = new DecodingContext();
     }
 

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -188,9 +188,9 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
 
     /**
      * This method carries queued messages accumulated on connection manager while the channel
-     * isn't attached yet. It's added in the queue here and start a new attach call
+     * isn't attached yet. It's added in the queue here
      * */
-    void reattach(List<QueuedMessage> messagesToTransfer) {
+    synchronized void transferQueuedMessages(List<QueuedMessage> messagesToTransfer) {
         state = ChannelState.attaching;
         if (messagesToTransfer != null) {
             for (QueuedMessage queuedMessage : messagesToTransfer) {

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -190,19 +190,15 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
      * This method carries queued messages accumulated on connection manager while the channel
      * isn't attached yet. It's added in the queue here
      * */
-    synchronized void transferQueuedMessages(List<QueuedMessage> messagesToTransfer) {
+    synchronized void transferQueuedPresenceMessages(List<QueuedMessage> messagesToTransfer) {
         state = ChannelState.attaching;
         if (messagesToTransfer != null) {
             for (QueuedMessage queuedMessage : messagesToTransfer) {
-                if (queuedMessage.msg.action == Action.message) {
-                    queuedMessages.add(queuedMessage);
-                } else if (queuedMessage.msg.action == Action.presence) {
-                    PresenceMessage[] presenceMessages = queuedMessage.msg.presence;
-                    if (presenceMessages != null && presenceMessages.length > 0){
-                        for (PresenceMessage presenceMessage : presenceMessages) {
-                            this.presence.addPendingPresence(presenceMessage.clientId, presenceMessage,
-                                queuedMessage.listener);
-                        }
+                PresenceMessage[] presenceMessages = queuedMessage.msg.presence;
+                if (presenceMessages != null && presenceMessages.length > 0) {
+                    for (PresenceMessage presenceMessage : presenceMessages) {
+                        this.presence.addPendingPresence(presenceMessage.clientId, presenceMessage,
+                            queuedMessage.listener);
                     }
                 }
             }

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -391,7 +391,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
             this.attachResume = true;
             setState(ChannelState.attached, message.error, resumed);
             sendQueuedMessages();
-            presence.setAttached(message.hasFlag(Flag.has_presence));
+            presence.setAttached(message.hasFlag(Flag.has_presence), this.ably.connection.id);
         }
     }
 

--- a/lib/src/main/java/io/ably/lib/realtime/Presence.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Presence.java
@@ -117,6 +117,11 @@ public class Presence {
         return get(new Param(GET_WAITFORSYNC, String.valueOf(wait)), new Param(GET_CLIENTID, clientId));
     }
 
+    void addPendingPresence(String clientId, PresenceMessage presenceMessage, CompletionListener listener) {
+        final QueuedPresence queuedPresence = new QueuedPresence(presenceMessage,listener);
+        pendingPresence.put(clientId,queuedPresence);
+    }
+
     /**
      * An interface allowing a listener to be notified of arrival of a presence message.
      */

--- a/lib/src/main/java/io/ably/lib/realtime/Presence.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Presence.java
@@ -117,7 +117,7 @@ public class Presence {
         return get(new Param(GET_WAITFORSYNC, String.valueOf(wait)), new Param(GET_CLIENTID, clientId));
     }
 
-    void addPendingPresence(String clientId, PresenceMessage presenceMessage, CompletionListener listener) {
+    synchronized void addPendingPresence(String clientId, PresenceMessage presenceMessage, CompletionListener listener) {
         final QueuedPresence queuedPresence = new QueuedPresence(presenceMessage,listener);
         pendingPresence.put(clientId,queuedPresence);
     }

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1255,15 +1255,15 @@ public class ConnectionManager implements ConnectListener {
     private void addPendingMessagesToQueuedMessages(boolean resetMessageSerial) {
         // Add messages from pending messages to front of queuedMessages in order to retry them
         queuedMessages.addAll(0, pendingMessages.queue);
-        //rewind start serial back to the first serial since we are clearing the queue if the queue is not empty
-        //this shouldn't be the case for resume failure
-        if (!resetMessageSerial && !pendingMessages.queue.isEmpty()){
-            msgSerial =  pendingMessages.queue.get(0).msg.msgSerial;
-            pendingMessages.resetStartSerial((int) (msgSerial));
-        }else if (resetMessageSerial){
+
+        if (resetMessageSerial){  // failed resume, so all new published messages start with msgSerial = 0
             msgSerial = 0; //msgSerial will increase in sendImpl when messages are sent
             pendingMessages.resetStartSerial(0);
+        } else if(!pendingMessages.queue.isEmpty()) { // pendingMessages needs to expect next msgSerial to be the earliest previously unacknowledged message
+            msgSerial =  pendingMessages.queue.get(0).msg.msgSerial;
+            pendingMessages.resetStartSerial((int) (msgSerial));
         }
+
         pendingMessages.queue.clear();
     }
 

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1270,18 +1270,20 @@ public class ConnectionManager implements ConnectListener {
      * on pending queue, for example when a connection resume failed
      */
     private void addPendingMessagesToQueuedMessages(boolean resetMessageSerial) {
-        // Add messages from pending messages to front of queuedMessages in order to retry them
-        queuedMessages.addAll(0, pendingMessages.queue);
+        synchronized (this) {
+            // Add messages from pending messages to front of queuedMessages in order to retry them
+            queuedMessages.addAll(0, pendingMessages.queue);
 
-        if (resetMessageSerial){  // failed resume, so all new published messages start with msgSerial = 0
-            msgSerial = 0; //msgSerial will increase in sendImpl when messages are sent
-            pendingMessages.resetStartSerial(0);
-        } else if(!pendingMessages.queue.isEmpty()) { // pendingMessages needs to expect next msgSerial to be the earliest previously unacknowledged message
-            msgSerial =  pendingMessages.queue.get(0).msg.msgSerial;
-            pendingMessages.resetStartSerial((int) (msgSerial));
+            if (resetMessageSerial){  // failed resume, so all new published messages start with msgSerial = 0
+                msgSerial = 0; //msgSerial will increase in sendImpl when messages are sent
+                pendingMessages.resetStartSerial(0);
+            } else if(!pendingMessages.queue.isEmpty()) { // pendingMessages needs to expect next msgSerial to be the earliest previously unacknowledged message
+                msgSerial =  pendingMessages.queue.get(0).msg.msgSerial;
+                pendingMessages.resetStartSerial((int) (msgSerial));
+            }
+
+            pendingMessages.queue.clear();
         }
-
-        pendingMessages.queue.clear();
     }
 
     public List<QueuedMessage> getPendingMessages() {

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1216,7 +1216,6 @@ public class ConnectionManager implements ConnectListener {
                 // Add pending messages to the front of queued messages to be sent later
                 addPendingMessagesToQueuedMessages(false);
             } else {
-                System.out.println("resume_channel_test: resume has failed ");
                 // RTN15c3: resume failed
                 if (error != null){
                     Log.d(TAG, "connection resume failed with error: " + error.message);

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1201,6 +1201,7 @@ public class ConnectionManager implements ConnectListener {
                 // Add pending messages to the front of queued messages to be sent later
                 addPendingMessagesToQueuedMessages(false);
             } else {
+                System.out.println("resume_channel_test: resume has failed ");
                 // RTN15c3: resume failed
                 if (error != null){
                     Log.d(TAG, "connection resume failed with error: " + error.message);

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -82,7 +82,7 @@ public class ConnectionManager implements ConnectListener {
         void suspendAll(ErrorInfo error, boolean notifyStateChange);
         Iterable<Channel> values();
 
-        void reattach(List<QueuedMessage> queuedMessages);
+        void transferToChannels(List<QueuedMessage> queuedMessages);
     }
 
     /***********************************
@@ -1228,7 +1228,7 @@ public class ConnectionManager implements ConnectListener {
 
                 //We are going to transfer those messages to channel level so that they are published after
                 //their respective channels are attached
-                channels.reattach(new ArrayList<>(queuedMessages));
+                channels.transferToChannels(new ArrayList<>(queuedMessages));
                 queuedMessages.clear();
                 reattachOnResumeFailure = true;
             }

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1644,6 +1644,9 @@ public class ConnectionManager implements ConnectListener {
                 }
             }
             queuedMessages.clear();
+
+            //also fail pending messages
+            pendingMessages.failAll(reason);
         }
     }
 
@@ -1756,6 +1759,19 @@ public class ConnectionManager implements ConnectListener {
         }
 
         synchronized void clearQueue() {
+            queue.clear();
+        }
+        /**
+         * Fails all messages in pending queue and calls the error callback for each
+         * and clears the queue
+         * @param reason Reason for failing
+        * */
+        synchronized void failAll(ErrorInfo reason) {
+            for (QueuedMessage queuedMessage : queue) {
+                if (queuedMessage.listener != null) {
+                    queuedMessage.listener.onError(reason);
+                }
+            }
             queue.clear();
         }
     }

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeResumeTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeResumeTest.java
@@ -928,11 +928,6 @@ public class RealtimeResumeTest extends ParameterizedTest {
             (new ChannelWaiter(senderChannel)).waitFor(ChannelState.attached);
             assertEquals("Connection has the same id", ChannelState.attached, senderChannel.state);
 
-            try {
-                Thread.sleep(3000);
-            } catch (InterruptedException e) {
-            }
-
             ErrorInfo[] resendErrors = senderCompletion.waitFor();
             assertTrue(
                 "Second round of messages (queued) has errors",

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeResumeTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeResumeTest.java
@@ -759,7 +759,8 @@ public class RealtimeResumeTest extends ParameterizedTest {
 
             final String connectionId = sender.connection.id;
 
-            //now let's disconnect
+            //block connect send before disconnecting
+            mockWebsocketFactory.blockSend(message -> message.action == ProtocolMessage.Action.connect);
             sender.connection.connectionManager.requestState(ConnectionState.disconnected);
             (new ConnectionWaiter(sender.connection)).waitFor(ConnectionState.disconnected);
             assertEquals("Connection must be connected", ConnectionState.disconnected, sender.connection.state);
@@ -771,6 +772,8 @@ public class RealtimeResumeTest extends ParameterizedTest {
                 senderChannel.publish("queued_message_" + i, "Test pending queued messages " + i,
                     senderCompletion.add());
             }
+            //now allow send
+            mockWebsocketFactory.allowSend();
             System.out.println("resume_publish_test: Unblocking receiver");
             //now let's unblock the ack nacks and reconnect
             mockWebsocketFactory.blockReceiveProcessing(message -> false);

--- a/lib/src/test/java/io/ably/lib/test/util/MockWebsocketFactory.java
+++ b/lib/src/test/java/io/ably/lib/test/util/MockWebsocketFactory.java
@@ -3,8 +3,6 @@ package io.ably.lib.test.util;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import io.ably.lib.transport.ConnectionManager;

--- a/lib/src/test/java/io/ably/lib/test/util/MockWebsocketFactory.java
+++ b/lib/src/test/java/io/ably/lib/test/util/MockWebsocketFactory.java
@@ -85,8 +85,11 @@ public class MockWebsocketFactory implements ITransport.Factory {
         sendBehaviour = SendBehaviour.block;
     }
 
-    //use the same filters temporarily
-    public void blockReceive(MessageFilter filter) {
+    /*
+    We cannot prevent server sending us messages from here so instead, this will block processing messages from this
+    point. That is they will not be triggering connection manager's onMessage which will help simulate some conditions
+    * */
+    public void blockReceiveProcessing(MessageFilter filter) {
         receiveMessageFilter = filter;
         receiveBehaviour = ReceiveBehaviour.block;
     }


### PR DESCRIPTION
This PR fixes two issues

* When `queueEvents` is false, pending messages will also be cleared which was missing before. 
* Fixes the issue of reattachment when a connection resume failed.

Previously as soon as connected message was received by connection manager, channels would directly attempt to attach. I have changed the behaviour so that after a resume failure (connected event with a new connection id) I transfer all queued messages (if any) from the connection manager to associated channel. This sets a flag for later to be processed from `setConnected`. Previously when attempted to call directly to attach from reattach, that would also fail and retry would happen quite a bit later. Attach would time out and then a reattach with some delay would be invoked. I also removed a sync() call from `setConnected()` as recommended by @paddybyers . 

There was also an issue with previously enters members wouldn't automatically reenter. There should be a fix for this and a test that confirms the behaviour.

There are also some test and test utilities improvements.

Fixes https://github.com/ably/ably-java/issues/905
Fixes https://github.com/ably/ably-java/issues/904