### PR TITLE
908 presence message superseded

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -196,8 +196,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
                 PresenceMessage[] presenceMessages = queuedMessage.msg.presence;
                 if (presenceMessages != null && presenceMessages.length > 0) {
                     for (PresenceMessage presenceMessage : presenceMessages) {
-                        this.presence.addPendingPresence(presenceMessage.clientId, presenceMessage,
-                            queuedMessage.listener);
+                        this.presence.addPendingPresence(presenceMessage, queuedMessage.listener);
                     }
                 }
             }

--- a/lib/src/main/java/io/ably/lib/realtime/Presence.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Presence.java
@@ -117,9 +117,11 @@ public class Presence {
         return get(new Param(GET_WAITFORSYNC, String.valueOf(wait)), new Param(GET_CLIENTID, clientId));
     }
 
-    synchronized void addPendingPresence(String clientId, PresenceMessage presenceMessage, CompletionListener listener) {
-        final QueuedPresence queuedPresence = new QueuedPresence(presenceMessage,listener);
-        pendingPresence.put(clientId,queuedPresence);
+    void addPendingPresence(PresenceMessage presenceMessage, CompletionListener listener) {
+        synchronized(channel) {
+            final QueuedPresence queuedPresence = new QueuedPresence(presenceMessage,listener);
+            pendingPresence.add(queuedPresence);
+        }
     }
 
     /**

--- a/lib/src/main/java/io/ably/lib/realtime/Presence.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Presence.java
@@ -734,7 +734,7 @@ public class Presence {
      * @throws AblyException
      */
     public void updatePresence(PresenceMessage msg, CompletionListener listener) throws AblyException {
-        Log.v(TAG, "update(); channel = " + channel.name);
+        Log.v(TAG, "updatePresence(); channel = " + channel.name);
 
         AblyRealtime ably = channel.ably;
         boolean connected = (ably.connection.state == ConnectionState.connected);

--- a/lib/src/test/java/io/ably/lib/test/common/Helpers.java
+++ b/lib/src/test/java/io/ably/lib/test/common/Helpers.java
@@ -164,15 +164,35 @@ public class Helpers {
             error = null;
         }
 
-        public synchronized ErrorInfo waitFor(int count) {
+        /**
+         * Wait for a specified amount of time, or until success occurs.
+         */
+        public synchronized ErrorInfo waitFor(int count, long timeoutInMillis) {
+            long timeoutAt = System.currentTimeMillis() + timeoutInMillis;
             while(successCount<count && error == null)
-                try { wait(); } catch(InterruptedException e) {}
+                try {
+                    if (System.currentTimeMillis() > timeoutAt) {
+                        break;
+                    }
+                    
+                     wait(); 
+                } catch(InterruptedException e) {}
             success = successCount >= count;
             return error;
         }
 
+        /**
+         * Wait for a specified number of successes, with an arbitrarily long timeout.
+         */
+        public synchronized ErrorInfo waitFor(int count) {
+            return waitFor(count, 600000);
+        }
+
+        /**
+         * Wait for a single success with an arbitrarily long timeout.
+         */
         public synchronized ErrorInfo waitFor() {
-            return waitFor(1);
+            return waitFor(1, 600000);
         }
 
         /**

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimePresenceTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimePresenceTest.java
@@ -1696,9 +1696,11 @@ public class RealtimePresenceTest extends ParameterizedTest {
             });
 
             /* Start emitting channel with ably client 1 (emitter) */
-            channel1.presence.enter("Hello, #2!", messageCompletionListener);
-            channel1.presence.update("Lorem ipsum", messageCompletionListener);
-            channel1.presence.update("Dolor sit!", messageCompletionListener);
+            synchronized (channel1) {
+                channel1.presence.enter("Hello, #2!", messageCompletionListener);
+                channel1.presence.update("Lorem ipsum", messageCompletionListener);
+                channel1.presence.update("Dolor sit!", messageCompletionListener);
+            }
 
             /* Wait until receiver client (ably2) observes {@code Action.leave}
              * is emitted from emitter client (ably1)

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimePresenceTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimePresenceTest.java
@@ -1695,7 +1695,12 @@ public class RealtimePresenceTest extends ParameterizedTest {
                 }
             });
 
-            /* Start emitting channel with ably client 1 (emitter) */
+            /*
+                Start emitting channel with ably client 1 (emitter)
+
+                This is synchronized against the channel so that channel.setState cant mark
+                the channel as attached until we're done queueing up events.
+            */
             synchronized (channel1) {
                 channel1.presence.enter("Hello, #2!", messageCompletionListener);
                 channel1.presence.update("Lorem ipsum", messageCompletionListener);

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimePresenceTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimePresenceTest.java
@@ -1744,15 +1744,17 @@ public class RealtimePresenceTest extends ParameterizedTest {
 
             /*
              * Validate that
-             * - our listeners are called
+             * - our listeners are called within 10 seconds
              */
+            long waitUntil = System.currentTimeMillis() + 10000;
             try {
                 while (true) {
                     synchronized (messageCompletionListener) {
                         assertEquals(0, messageCompletionListener.failedListeners);
 
                         if (messageCompletionListener.successfulListeners != 3) {
-                            messageCompletionListener.wait(5000);
+                            messageCompletionListener.wait(500);
+                            assertTrue(System.currentTimeMillis() < waitUntil);
                             continue;
                         }
                     }

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimePresenceTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimePresenceTest.java
@@ -1649,6 +1649,125 @@ public class RealtimePresenceTest extends ParameterizedTest {
         }
     }
 
+    private final class CountingCompletionListener implements CompletionListener
+    {
+        public int successfulListeners = 0;
+        public int failedListeners = 0;
+
+        @Override
+        public void onSuccess() {
+            synchronized(this) {
+                successfulListeners++;
+                notifyAll();
+            }
+        }
+
+        @Override
+        public void onError(ErrorInfo reason) {
+            synchronized(this) {
+                failedListeners++;
+                notifyAll();
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * Validates a client sending multiple presence updates when the channel is in the attaching
+     * state will have all messages sent once the channel attaches, and all listeners will be called.
+     * </p>
+     *
+     * @throws AblyException
+     */
+    @Test
+    public void realtime_presence_update_multiple_queued_messages() throws AblyException {
+        /* Ably instance that will emit presence events */
+        AblyRealtime ably1 = null;
+        /* Ably instance that will receive presence events */
+        AblyRealtime ably2 = null;
+
+        String channelName = "test.presence.subscribe.update_multiple_queued_messages" + System.currentTimeMillis();
+        EnumSet<PresenceMessage.Action> actions = EnumSet.of(Action.update, Action.enter);
+
+        try {
+            ClientOptions option1 = createOptions(testVars.keys[0].keyStr);
+            option1.clientId = "emitter client";
+            ClientOptions option2 = createOptions(testVars.keys[0].keyStr);
+            option2.clientId = "receiver client";
+
+            ably1 = new AblyRealtime(option1);
+            ably2 = new AblyRealtime(option2);
+
+            Channel channel1 = ably1.channels.get(channelName);
+
+            Channel channel2 = ably2.channels.get(channelName);
+            channel2.attach();
+            (new ChannelWaiter(channel2)).waitFor(ChannelState.attached);
+
+            CountingCompletionListener messageCompletionListener = new CountingCompletionListener();
+
+            final ArrayList<PresenceMessage> receivedMessageStack = new ArrayList<>();
+            channel2.presence.subscribe(actions, new Presence.PresenceListener() {
+                @Override
+                public void onPresenceMessage(PresenceMessage message) {
+                    synchronized (receivedMessageStack) {
+                        receivedMessageStack.add(message);
+                        receivedMessageStack.notify();
+                    }
+                }
+            });
+
+            /* Start emitting channel with ably client 1 (emitter) */
+            channel1.presence.enter("Hello, #2!", messageCompletionListener);
+            channel1.presence.update("Lorem ipsum", messageCompletionListener);
+            channel1.presence.update("Dolor sit!", messageCompletionListener);
+
+            /* Wait until receiver client (ably2) observes {@code Action.leave}
+             * is emitted from emitter client (ably1)
+             */
+            try {
+                synchronized (receivedMessageStack) {
+                    while (receivedMessageStack.size() == 0 ||
+                            !receivedMessageStack.get(receivedMessageStack.size()-1).clientId.equals(ably1.options.clientId) ||
+                            !receivedMessageStack.get(receivedMessageStack.size()-1).data.equals("Dolor sit!"))
+                                receivedMessageStack.wait();
+                }
+            } catch(InterruptedException e) {}
+
+            /* Validate that,
+             *- we received specific actions
+             */
+            assertThat(receivedMessageStack.size(), is(equalTo(3)));
+            for (PresenceMessage message : receivedMessageStack) {
+                assertTrue(actions.contains(message.action));
+            }
+
+            /*
+             * Validate that
+             * - our listeners are called
+             */
+            try {
+                while (true) {
+                    synchronized (messageCompletionListener) {
+                        assertEquals(0, messageCompletionListener.failedListeners);
+
+                        if (messageCompletionListener.successfulListeners != 3) {
+                            messageCompletionListener.wait(5000);
+                            continue;
+                        }
+                    }
+
+                    break;
+                }
+            } catch (InterruptedException exception) {
+                fail();
+            }
+        } finally {
+            if (ably1 != null) ably1.close();
+            if (ably2 != null) ably2.close();
+        }
+    }
+
     /**
      * <p>
      * Validates a client can observe presence messages of other client,


### PR DESCRIPTION
This change:

- Changes Presence.pendingPresence to a List from a HashMap
- When waiting for channel to attach, if multiple presence updates are received, these are all queued up for sending once attach completes (resulting in all completion listeners being called). This is a change from before, whereby only the most recent presence message for each client id was sent.
- The above behaviour is consistent with ably-js, though not specifically mandated in the specification

Fixes #908 