### PR TITLE
Improve `1.2`-series Release Process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,14 +207,13 @@ This library uses [semantic versioning](http://semver.org/). For each release, t
 5. Make a PR against `main`
 6. Once the PR is approved, merge it into `main`
 7. From the updated `main` branch on your local workstation, assemble and upload:
-    1. Comment out local `repository` lines in the two `maven.gradle` files temporarily (this is horrible but is [in our backlog to be fixed](https://github.com/ably/ably-java/issues/566))
-    2. Run `./gradlew java:assembleRelease` to build and upload `ably-java` to Nexus staging repository
-    3. Run `./gradlew android:assembleRelease` build and upload `ably-android` to Nexus staging repository
-    4. Find the new staging repository using the [Nexus Repository Manager](https://oss.sonatype.org/#stagingRepositories)
-    5. Check that it contains `ably-android` and `ably-java` releases
-    6. "Close" it - this will take a few minutes during which time it will say (after a refresh of your browser) that "Activity: Operation in Progress"
-    7. Once it has closed you will have "Release" available. You can allow it to "automatically drop" after successful release. A refresh or two later of the browser and the staging repository will have disappeared from the list (i.e. it's been dropped which implies it was released successfully)
-    8. A [search for Ably packages](https://oss.sonatype.org/#nexus-search;quick~io.ably) should now list the new version for both `ably-android` and `ably-java`
+    1. Run `./gradlew java:assembleRelease -PpublishTarget=MavenCentral` to build and upload `ably-java` to Nexus staging repository
+    2. Run `./gradlew android:assembleRelease -PpublishTarget=MavenCentral` build and upload `ably-android` to Nexus staging repository
+    3. Find the new staging repository using the [Nexus Repository Manager](https://oss.sonatype.org/#stagingRepositories)
+    4. Check that it contains `ably-android` and `ably-java` releases
+    5. "Close" it - this will take a few minutes during which time it will say (after a refresh of your browser) that "Activity: Operation in Progress"
+    6. Once it has closed you will have "Release" available. You can allow it to "automatically drop" after successful release. A refresh or two later of the browser and the staging repository will have disappeared from the list (i.e. it's been dropped which implies it was released successfully)
+    7. A [search for Ably packages](https://oss.sonatype.org/#nexus-search;quick~io.ably) should now list the new version for both `ably-android` and `ably-java`
 8. Add a tag and push to origin - e.g.: `git tag v1.2.4 && git push origin v1.2.4`
 9. Create the release on Github including populating the release notes
 10. Create the entry on the [Ably Changelog](https://changelog.ably.com/) (via [headwayapp](https://headwayapp.co/))

--- a/android/maven.gradle
+++ b/android/maven.gradle
@@ -4,11 +4,11 @@ apply plugin: 'signing'
 final String GROUP_ID = 'io.ably'
 final String ARTIFACT_ID = 'ably-android'
 final String LOCAL_RELEASE_DESTINATION = "${buildDir}/release/${version}"
-final MAVEN_USER = findProperty('ossrhUsername')
-final MAVEN_PASSWORD = findProperty('ossrhPassword')
+final String MAVEN_USER = findProperty('ossrhUsername')
+final String MAVEN_PASSWORD = findProperty('ossrhPassword')
 
-final isPublishingToMavenCentral = findProperty('publishTarget') == 'MavenCentral'
-if (isPublishingToMavenCentral && (null == MAVEN_USER || null == MAVEN_PASSWORD)) {
+final boolean IS_PUBLISHING_TO_MAVEN_CENTRAL = findProperty('publishTarget') == 'MavenCentral'
+if (IS_PUBLISHING_TO_MAVEN_CENTRAL && (MAVEN_USER == null || MAVEN_PASSWORD == null)) {
     throw new GradleException('Either ossrhUsername or ossrhPassword not specified when publishTarget is MavenCentral.')
 }
 
@@ -77,7 +77,7 @@ uploadArchives {
             }
         }
 
-        if (isPublishingToMavenCentral) {
+        if (IS_PUBLISHING_TO_MAVEN_CENTRAL) {
             repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
                 authentication(userName: MAVEN_USER, password: MAVEN_PASSWORD)
             }
@@ -105,7 +105,7 @@ tasks.whenTaskAdded { task ->
     if (task.name == 'assembleRelease') {
         task.doLast {
             if (isPublishingToMavenCentral) {
-                logger.quiet("✅ Release uploaded to Sonatype Staging Repository")
+                logger.quiet('✅ Release uploaded to Sonatype Staging Repository')
             } else {
                 logger.quiet("✅ Release ${version} can be found at ${LOCAL_RELEASE_DESTINATION}/")
                 logger.quiet("✅ Release ${version} zipped can be found ${buildDir}/release-${version}.zip")

--- a/android/maven.gradle
+++ b/android/maven.gradle
@@ -4,8 +4,13 @@ apply plugin: 'signing'
 final String GROUP_ID = 'io.ably'
 final String ARTIFACT_ID = 'ably-android'
 final String LOCAL_RELEASE_DESTINATION = "${buildDir}/release/${version}"
-final String MAVEN_USER = hasProperty('ossrhUsername') ? ossrhUsername : ''
-final String MAVEN_PASSWORD = hasProperty('ossrhPassword') ? ossrhPassword : ''
+final MAVEN_USER = findProperty('ossrhUsername')
+final MAVEN_PASSWORD = findProperty('ossrhPassword')
+
+final isPublishingToMavenCentral = findProperty('publishTarget') == 'MavenCentral'
+if (isPublishingToMavenCentral && (null == MAVEN_USER || null == MAVEN_PASSWORD)) {
+    throw new GradleException('Either ossrhUsername or ossrhPassword not specified when publishTarget is MavenCentral.')
+}
 
 /*
  * Task which signs and uploads the Android artifacts to Nexus OSSRH.
@@ -15,17 +20,8 @@ uploadArchives {
         sign configurations.archives
     }
     repositories.mavenDeployer {
-        logger.lifecycle('OSSRH auth with username: ' + MAVEN_USER)
-
         beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-        repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
-            authentication(userName: MAVEN_USER, password: MAVEN_PASSWORD)
-        }
-
-        snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/') {
-            authentication(userName: MAVEN_USER, password: MAVEN_PASSWORD)
-        }
         pom.groupId = GROUP_ID
         pom.artifactId = ARTIFACT_ID
         pom.version = version
@@ -81,15 +77,21 @@ uploadArchives {
             }
         }
 
-        // Export to local Maven cache
-        // COMMENT OUT THIS LINE AND THE ONE BELOW IN ORDER TO RELEASE TO SONATYPE NEXUS STAGING
-        // TODO https://github.com/ably/ably-java/issues/566
-        repository(url: repositories.mavenLocal().url)
+        if (isPublishingToMavenCentral) {
+            repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
+                authentication(userName: MAVEN_USER, password: MAVEN_PASSWORD)
+            }
 
-        // Export files to local storage
-        // COMMENT OUT THIS LINE AND THE ONE ABOVE IN ORDER TO RELEASE TO SONATYPE NEXUS STAGING
-        // TODO https://github.com/ably/ably-java/issues/566
-        repository(url: "file://${LOCAL_RELEASE_DESTINATION}")
+            snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/') {
+                authentication(userName: MAVEN_USER, password: MAVEN_PASSWORD)
+            }
+        } else {
+            // Export to local Maven cache
+            repository(url: repositories.mavenLocal().url)
+
+            // Export files to local storage
+            repository(url: "file://${LOCAL_RELEASE_DESTINATION}")
+        }
     }
 }
 
@@ -102,8 +104,12 @@ task zipRelease(type: Zip) {
 tasks.whenTaskAdded { task ->
     if (task.name == 'assembleRelease') {
         task.doLast {
-            logger.quiet("Release ${version} can be found at ${LOCAL_RELEASE_DESTINATION}/")
-            logger.quiet("Release ${version} zipped can be found ${buildDir}/release-${version}.zip")
+            if (isPublishingToMavenCentral) {
+                logger.quiet("✅ Release uploaded to Sonatype Staging Repository")
+            } else {
+                logger.quiet("✅ Release ${version} can be found at ${LOCAL_RELEASE_DESTINATION}/")
+                logger.quiet("✅ Release ${version} zipped can be found ${buildDir}/release-${version}.zip")
+            }
         }
 
         task.dependsOn(uploadArchives)

--- a/java/maven.gradle
+++ b/java/maven.gradle
@@ -5,8 +5,13 @@ apply plugin: 'signing'
 final String GROUP_ID = 'io.ably'
 final String ARTIFACT_ID = 'ably-java'
 final String LOCAL_RELEASE_DESTINATION = "${buildDir}/release/${version}"
-final String MAVEN_USER = hasProperty('ossrhUsername') ? ossrhUsername : ''
-final String MAVEN_PASSWORD = hasProperty('ossrhPassword') ? ossrhPassword : ''
+final MAVEN_USER = findProperty('ossrhUsername')
+final MAVEN_PASSWORD = findProperty('ossrhPassword')
+
+final isPublishingToMavenCentral = findProperty('publishTarget') == 'MavenCentral'
+if (isPublishingToMavenCentral && (null == MAVEN_USER || null == MAVEN_PASSWORD)) {
+    throw new GradleException('Either ossrhUsername or ossrhPassword not specified when publishTarget is MavenCentral.')
+}
 
 /*
  * Task which signs and uploads the Java artifacts to Nexus OSSRH.
@@ -16,17 +21,7 @@ uploadArchives {
         sign configurations.archives
     }
     repositories.mavenDeployer {
-        logger.lifecycle('OSSRH auth with username: ' + MAVEN_USER)
-
         beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-        repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
-            authentication(userName: MAVEN_USER, password: MAVEN_PASSWORD)
-        }
-
-        snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/') {
-            authentication(userName: MAVEN_USER, password: MAVEN_PASSWORD)
-        }
 
         pom.groupId = GROUP_ID
         pom.artifactId = ARTIFACT_ID
@@ -76,10 +71,18 @@ uploadArchives {
             }
         }
 
-        // Export files to local storage
-        // COMMENT OUT THIS LINE IN ORDER TO RELEASE TO SONATYPE NEXUS STAGING
-        // TODO https://github.com/ably/ably-java/issues/566
-        repository(url: "file://${LOCAL_RELEASE_DESTINATION}")
+        if (isPublishingToMavenCentral) {
+            repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
+                authentication(userName: MAVEN_USER, password: MAVEN_PASSWORD)
+            }
+
+            snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/') {
+                authentication(userName: MAVEN_USER, password: MAVEN_PASSWORD)
+            }
+        } else {
+            // Export files to local storage
+            repository(url: "file://${LOCAL_RELEASE_DESTINATION}")
+        }
     }
 }
 
@@ -91,8 +94,12 @@ task zipRelease(type: Zip) {
 
 task assembleRelease {
     doLast {
-        logger.quiet("Release ${version} can be found at ${LOCAL_RELEASE_DESTINATION}")
-        logger.quiet("Release ${version} zipped can be found ${buildDir}/release-${version}.zip")
+        if (isPublishingToMavenCentral) {
+            logger.quiet("✅ Release uploaded to Sonatype Staging Repository")
+        } else {
+            logger.quiet("✅ Release ${version} can be found at ${LOCAL_RELEASE_DESTINATION}")
+            logger.quiet("✅ Release ${version} zipped can be found ${buildDir}/release-${version}.zip")
+        }
     }
     dependsOn(uploadArchives)
     dependsOn(zipRelease)

--- a/java/maven.gradle
+++ b/java/maven.gradle
@@ -5,11 +5,11 @@ apply plugin: 'signing'
 final String GROUP_ID = 'io.ably'
 final String ARTIFACT_ID = 'ably-java'
 final String LOCAL_RELEASE_DESTINATION = "${buildDir}/release/${version}"
-final MAVEN_USER = findProperty('ossrhUsername')
-final MAVEN_PASSWORD = findProperty('ossrhPassword')
+final String MAVEN_USER = findProperty('ossrhUsername')
+final String MAVEN_PASSWORD = findProperty('ossrhPassword')
 
-final isPublishingToMavenCentral = findProperty('publishTarget') == 'MavenCentral'
-if (isPublishingToMavenCentral && (null == MAVEN_USER || null == MAVEN_PASSWORD)) {
+final boolean IS_PUBLISHING_TO_MAVEN_CENTRAL = findProperty('publishTarget') == 'MavenCentral'
+if (IS_PUBLISHING_TO_MAVEN_CENTRAL && (MAVEN_USER == null || MAVEN_PASSWORD == null)) {
     throw new GradleException('Either ossrhUsername or ossrhPassword not specified when publishTarget is MavenCentral.')
 }
 
@@ -71,7 +71,7 @@ uploadArchives {
             }
         }
 
-        if (isPublishingToMavenCentral) {
+        if (IS_PUBLISHING_TO_MAVEN_CENTRAL) {
             repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
                 authentication(userName: MAVEN_USER, password: MAVEN_PASSWORD)
             }
@@ -94,8 +94,8 @@ task zipRelease(type: Zip) {
 
 task assembleRelease {
     doLast {
-        if (isPublishingToMavenCentral) {
-            logger.quiet("✅ Release uploaded to Sonatype Staging Repository")
+        if (IS_PUBLISHING_TO_MAVEN_CENTRAL) {
+            logger.quiet('✅ Release uploaded to Sonatype Staging Repository')
         } else {
             logger.quiet("✅ Release ${version} can be found at ${LOCAL_RELEASE_DESTINATION}")
             logger.quiet("✅ Release ${version} zipped can be found ${buildDir}/release-${version}.zip")


### PR DESCRIPTION
Removes the need to comment out lines in the Gradle files, at least.

This is in lieu of the much wider Maven Central distribution process changes made in [the v2 integration branch](https://github.com/ably/ably-java/pull/767).