### PR TITLE
Drop messages where channel does not exist

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
+++ b/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
@@ -217,8 +217,12 @@ public class AblyRealtime extends AblyRest {
         @Override
         public void onMessage(ProtocolMessage msg) {
             String channelName = msg.channel;
-            Channel channel;
-            synchronized(this) { channel = channels.get(channelName); }
+            Channel channel = null;
+            synchronized(this) {
+                if (channels.containsKey(channelName)) {
+                    channel = channels.get(channelName);
+                }
+            }
             if(channel == null) {
                 Log.e(TAG, "Received channel message for non-existent channel");
                 return;

--- a/lib/src/test/java/io/ably/lib/test/common/Helpers.java
+++ b/lib/src/test/java/io/ably/lib/test/common/Helpers.java
@@ -632,24 +632,56 @@ public class Helpers {
          * Wait for a given number of messages
          */
         public void waitForRecv() {
-            waitForRecv(1);
+            waitForRecv(1, 6000000);
         }
         public void waitForSend() {
-            waitForSend(1);
+            waitForSend(1, 6000000);
+        }
+        public void waitForRecv(int count) {
+            waitForRecv(count, 6000000);
+        }
+        public void waitForSend(int count) {
+            waitForSend(count, 6000000);
         }
 
         /**
          * Wait for a given number of messages
          * @param count
          */
-        public synchronized void waitForRecv(int count) {
+        public synchronized void waitForRecv(int count, long timeoutInMillis) {
+            long timeoutAt = System.currentTimeMillis() + timeoutInMillis;
             while(receivedMessages.size() < count) {
-                try { wait(); } catch(InterruptedException e) {}
+                synchronized (this) {
+                    try {
+                        if (System.currentTimeMillis() > timeoutAt || receivedMessages.size() >= count) {
+                            break;
+                        }
+
+                        wait();
+                    } catch(InterruptedException e) {}
+                }
+            }
+
+            if (receivedMessages.size() < count) {
+                throw new AssertionError("Did not receive expected number of messages");
             }
         }
-        public synchronized void waitForSend(int count) {
+        public synchronized void waitForSend(int count, long timeoutInMillis) {
+            long timeoutAt = System.currentTimeMillis() + timeoutInMillis;
             while(sentMessages.size() < count) {
-                try { wait(); } catch(InterruptedException e) {}
+                synchronized (this) {
+                    try {
+                        if (System.currentTimeMillis() > timeoutAt || sentMessages.size() >= count) {
+                            break;
+                        }
+
+                        wait();
+                    } catch(InterruptedException e) {}
+                }
+            }
+
+            if (sentMessages.size() < count) {
+                throw new AssertionError("Did not send expected number of messages");
             }
         }
 

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -2008,34 +2008,31 @@ public class RealtimeChannelTest extends ParameterizedTest {
     }
 
     /*
-     * Without creating a channel, send a DETACHED protocol message to a named channel.
-     *
-     * Assert that the channel is not created when processing the message and that, therefore,
-     * the message is dropped. This prevents issues where releasing a channel - dropping it from
-     * the channel map and calling detach, can cause the channel to be re-created when the
-     * DETATCHED response comes back from ably.
+     * Checks that the DETACHED message sent by the server when a channel is released is dropped.
      */
     @Test
-    public void messages_to_non_existent_channels_are_dropped() throws AblyException {
+    public void detach_message_to_released_channel_is_dropped() throws AblyException {
         AblyRealtime ably = null;
         long oldRealtimeTimeout = Defaults.realtimeRequestTimeout;
-        final String channelName = "messages_to_non_existent_channels_are_dropped";
+        final String channelName = "detach_message_to_released_channel_is_dropped";
 
         try {
-            ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+            DebugOptions opts = createOptions(testVars.keys[0].keyStr);
+            Helpers.RawProtocolMonitor monitor = Helpers.RawProtocolMonitor.createReceiver(ProtocolMessage.Action.detached);
+            opts.protocolListener = monitor;
 
             /* Make test faster */
             Defaults.realtimeRequestTimeout = 1000;
             opts.channelRetryTimeout = 1000;
 
             ably = new AblyRealtime(opts);
+            Channel channel = ably.channels.get(channelName);
+            channel.attach();
+            (new ChannelWaiter(channel)).waitFor(ChannelState.attached);
 
-            /* Inject detached message as if from the server */
-            ProtocolMessage detachedMessage = new ProtocolMessage() {{
-                action = Action.detached;
-                channel = channelName;
-            }};
-            ably.connection.connectionManager.onMessage(null, detachedMessage);
+            // Listen for detach messages and release the channel
+            ably.channels.release(channelName);
+            monitor.waitForRecv(1, 10000);
 
             assertFalse(ably.channels.containsKey("messages_to_non_existent_channels_are_dropped"));
         } finally {


### PR DESCRIPTION
At the moment, if a message is received and a channel does not exist the channel is created (via channels.get) to process the message.

This can lead to issues with channels.release, which also detaches the channel after removing it from the channel map. If the timing is unfortunate, then the DETACH message will come back and re-create the channel, meaning it cannot be recreated afresh later.

This change fixes the issues by dropping any messages that are received for a non existent channel and logs the fact that this has happened.

Fixes #913