### PR TITLE
Add reason to pending message instead of creating an ErrorInfo

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1682,7 +1682,7 @@ public class ConnectionManager implements ConnectListener {
             queuedMessages.clear();
 
             //also pending messages
-            pendingMessages.fail();
+            pendingMessages.fail(reason);
         }
     }
 
@@ -1795,9 +1795,9 @@ public class ConnectionManager implements ConnectListener {
         }
 
         //fail all pending queued emssages
-        synchronized void fail() {
+        synchronized void fail(ErrorInfo reason) {
             for (QueuedMessage queuedMessage: queue){
-                queuedMessage.listener.onError(new ErrorInfo());
+                queuedMessage.listener.onError(reason);
             }
             queue.clear();
         }

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1797,7 +1797,9 @@ public class ConnectionManager implements ConnectListener {
         //fail all pending queued emssages
         synchronized void fail(ErrorInfo reason) {
             for (QueuedMessage queuedMessage: queue){
-                queuedMessage.listener.onError(reason);
+                if (queuedMessage.listener != null) {
+                    queuedMessage.listener.onError(reason);
+                }
             }
             queue.clear();
         }

--- a/lib/src/test/java/io/ably/lib/test/common/Helpers.java
+++ b/lib/src/test/java/io/ably/lib/test/common/Helpers.java
@@ -174,10 +174,13 @@ public class Helpers {
                     if (System.currentTimeMillis() > timeoutAt) {
                         break;
                     }
-                    
-                     wait(); 
+
+                     wait();
                 } catch(InterruptedException e) {}
             success = successCount >= count;
+            if (error != null) {
+                assertNotNull(error.message);
+            }
             return error;
         }
 


### PR DESCRIPTION
This PR passes `reason` to `fail()` from `failQueuedMessages` instead of creating an empty `ErrorInfo`.

Fixes https://github.com/ably/ably-java/issues/920