### PR TITLE
Suspend timer is set when transport is unavailable and last state was connected

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1465,6 +1465,11 @@ public class ConnectionManager implements ConnectListener {
             return;
         }
 
+        // If we're currently connected, start the suspend timer
+        if (currentState.state == ConnectionState.connected) {
+            setSuspendTime();
+        }
+
         /* if this is a failure of a pending connection attempt, decide whether or not to attempt a fallback host */
         StateIndication fallbackAttempt = checkFallback(reason);
         if(fallbackAttempt != null) {


### PR DESCRIPTION
Previously, a connection that had been connected for longer than the suspend timer period (set in onConnected) would have immediately transitioned to suspended when the transport became unavailable. This is because the timer is not reset the first time the transport fails.

This change fixes this by resetting the suspend timer when the transport becomes unavailable, if the current connection state is connected.

Also included are some unit tests on the connection manager which force the connection into a desired state, and then test the behaviour.

Fixes #925