### PR TITLE
fix: transport not disconnecting after ttl passed

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -311,31 +311,29 @@ public class WebSocketTransport implements ITransport {
                 Log.v(TAG, "checkActivity: infinite timeout");
                 return;
             }
-            if(activityTimerTask != null) {
-                /* timer already running */
+
+            // Check if timer already running
+            if (activityTimerTask != null) {
                 return;
             }
-            timeout += connectionManager.ably.options.realtimeRequestTimeout;
-            long now = System.currentTimeMillis();
-            long next = lastActivityTime + timeout;
-            if (now < next) {
-                /* We have not reached maxIdleInterval+realtimeRequestTimeout
-                 * of inactivity.  Schedule a new timer for that long after the
-                 * last activity time. */
-                Log.v(TAG, "checkActivity: ok");
+
+            // Start the activity timer task
+            startActivityTimer(timeout + 100);
+        }
+
+
+        private synchronized void startActivityTimer(long timeout)
+        {
+            if (activityTimerTask == null) {
                 schedule((activityTimerTask = new TimerTask() {
                     public void run() {
                         try {
-                            checkActivity();
+                            onActivityTimerExpiry();
                         } catch(Throwable t) {
                             Log.e(TAG, "Unexpected exception in activity timer handler", t);
                         }
                     }
-                }), next - now);
-            } else {
-                /* Timeout has been reached. Close the connection. */
-                Log.e(TAG, "No activity for " + timeout + "ms, closing connection");
-                closeConnection(CloseFrame.ABNORMAL_CLOSE, "timed out");
+                }), timeout);
             }
         }
 
@@ -347,6 +345,24 @@ public class WebSocketTransport implements ITransport {
                     Log.e(TAG, "Unexpected exception scheduling activity timer", ise);
                 }
             }
+        }
+
+        private synchronized void onActivityTimerExpiry()
+        {
+            activityTimerTask = null;
+            long timeSinceLastActivity = System.currentTimeMillis() - lastActivityTime;
+            long timeRemaining = connectionManager.maxIdleInterval - timeSinceLastActivity;
+
+            // If we have no time remaining, then close the connection
+            if (timeRemaining <= 0) {
+                Log.e(TAG, "No activity for " + connectionManager.maxIdleInterval + "ms, closing connection");
+                closeConnection(CloseFrame.ABNORMAL_CLOSE, "timed out");
+                return;
+            }
+
+            // Otherwise, we've had some activity, restart the timer for the next timeout
+            Log.v(TAG, "onActivityTimerExpiry: ok");
+            startActivityTimer(timeRemaining + 100);
         }
 
         /***************************

--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -306,7 +306,7 @@ public class WebSocketTransport implements ITransport {
         }
 
         private synchronized void checkActivity() {
-            long timeout = connectionManager.maxIdleInterval;
+            long timeout = getActivityTimeout();
             if (timeout == 0) {
                 Log.v(TAG, "checkActivity: infinite timeout");
                 return;
@@ -351,7 +351,7 @@ public class WebSocketTransport implements ITransport {
         {
             activityTimerTask = null;
             long timeSinceLastActivity = System.currentTimeMillis() - lastActivityTime;
-            long timeRemaining = connectionManager.maxIdleInterval - timeSinceLastActivity;
+            long timeRemaining = getActivityTimeout() - timeSinceLastActivity;
 
             // If we have no time remaining, then close the connection
             if (timeRemaining <= 0) {
@@ -363,6 +363,11 @@ public class WebSocketTransport implements ITransport {
             // Otherwise, we've had some activity, restart the timer for the next timeout
             Log.v(TAG, "onActivityTimerExpiry: ok");
             startActivityTimer(timeRemaining + 100);
+        }
+
+        private long getActivityTimeout()
+        {
+            return connectionManager.maxIdleInterval + connectionManager.ably.options.realtimeRequestTimeout;
         }
 
         /***************************

--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -355,7 +355,7 @@ public class WebSocketTransport implements ITransport {
 
             // If we have no time remaining, then close the connection
             if (timeRemaining <= 0) {
-                Log.e(TAG, "No activity for " + connectionManager.maxIdleInterval + "ms, closing connection");
+                Log.e(TAG, "No activity for " + getActivityTimeout() + "ms, closing connection");
                 closeConnection(CloseFrame.ABNORMAL_CLOSE, "timed out");
                 return;
             }

--- a/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
@@ -712,13 +712,13 @@ public class ConnectionManagerTest extends ParameterizedTest {
             });
             final Channel suspendedChannel = ably.channels.get("test-reattach-suspended-after-ttl" + testParams.name);
             suspendedChannel.state = ChannelState.suspended;
-            ChannelWaiter suspendedChannelWaiter = new Helpers.ChannelWaiter(suspendedChannel);
             suspendedChannel.on(new ChannelStateListener() {
                 @Override
                 public void onChannelStateChanged(ChannelStateChange stateChange) {
                     suspendedChannelHistory.add(stateChange.current.name());
                 }
             });
+            ChannelWaiter suspendedChannelWaiter = new Helpers.ChannelWaiter(suspendedChannel);
 
             /* attach first channel and wait for it to be attached */
             attachedChannel.attach();

--- a/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
@@ -554,6 +554,35 @@ public class ConnectionManagerTest extends ParameterizedTest {
     }
 
     /**
+     * RTN23
+     */
+    @Test
+    public void connection_is_closed_after_max_idle_interval() throws AblyException {
+        ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+        opts.realtimeRequestTimeout = 2000;
+        try(AblyRealtime ably = new AblyRealtime(opts)) {
+            final long newIdleInterval = 500L;
+
+            // When we connect, we set the max idle interval to be very small
+            ably.connection.on(ConnectionEvent.connected, state -> {
+                try {
+                    Field maxIdleField = ably.connection.connectionManager.getClass().getDeclaredField("maxIdleInterval");
+                    maxIdleField.setAccessible(true);
+                    maxIdleField.setLong(ably.connection.connectionManager, newIdleInterval);
+                } catch (NoSuchFieldException | IllegalAccessException e) {
+                    fail("Unexpected exception in checking connectionStateTtl");
+                }
+            });
+
+            // The original max idle interval we receive from the server is 15s.
+            // We should wait for this, plus a tiny bit extra (as we set the new idle interval to be very low
+            // after connecting) to make sure that the connection is disconnected
+            ConnectionWaiter connectionWaiter = new ConnectionWaiter(ably.connection);
+            assertTrue(connectionWaiter.waitFor(ConnectionState.disconnected, 1, 25000));
+        }
+    }
+
+    /**
      * RTN15g1, RTN15g2. Connect, disconnect, reconnect after (ttl + idle interval) period has passed,
      * check that the connection is a new one;
      */


### PR DESCRIPTION
Re-organises the activity timer logic to make sure that the timer runs. Previously the timer existence check in checkActivity() would cancel itself out because it would check (once the timer expires) that the timer was not set, when it was. So the disconnect logic would never get to run and a dead transport would linger until the underlying transport threw an exception which could be up to 2 minutes.

This change fixes this by moving the timer checking / timeout logic away from the existence check in checkActivity(). The arrangement of logic is more in line with the implementation in ably-js.

Fixes #932

To test:

- Connect up an Ably client, attach to channel etc
- Wait for a few websocket pings and "ok" logs from "onActivityTimerExpiry".
- Turn off the internet
- After ~15 seconds, the transport should be closed (when the bug was around, this would take > 2 minutes)
- Turn the internet back on
- Connection should resume somewhat swiftly