### PR TITLE
flakey tests 

### DIFF
--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
@@ -615,9 +615,9 @@ public class RealtimeConnectFailTest extends ParameterizedTest {
                 System.out.println("higher range: " + higherRange + " - lower range: " + lowerRange + " | checked value: " + retryTime);
 
                 assertTrue("retry time higher range for count " + i + " is not in valid: " + retryTime + " expected: " + higherRange,
-                    retryTime < higherRange);
+                    retryTime <= higherRange);
                 assertTrue("retry time lower range for count " + i + " is not in valid: " + retryTime + " expected: " + lowerRange,
-                    retryTime > lowerRange);
+                    retryTime >= lowerRange);
             }
             System.out.println("------------------------------------------------------------");
         } catch (AblyException e) {

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeMessageTest.java
@@ -796,34 +796,18 @@ public class RealtimeMessageTest extends ParameterizedTest {
     }
 
     @Test
+
     public void reject_invalid_message_data() throws AblyException {
         HashMap<String, Integer> data = new HashMap<String, Integer>();
         Message message = new Message("event", data);
-        Log.LogHandler originalLogHandler = Log.handler;
-        int originalLogLevel = Log.level;
-        Log.setLevel(Log.DEBUG);
-        final ArrayList<LogLine> capturedLog = new ArrayList<>();
-        Log.setHandler(new Log.LogHandler() {
-            @Override
-            public void println(int severity, String tag, String msg, Throwable tr) {
-                capturedLog.add(new LogLine(severity, tag, msg, tr));
-            }
-        });
-
         try {
             message.encode(null);
+            fail("reject_invalid_message_data: Expected AblyException to be thrown.");
         } catch(AblyException e) {
             assertEquals(null, message.encoding);
             assertEquals(data, message.data);
-            assertEquals(1, capturedLog.size());
-            LogLine capturedLine = capturedLog.get(0);
-            assertTrue(capturedLine.tag.contains("ably"));
-            assertTrue(capturedLine.msg.contains("Message data must be either `byte[]`, `String` or `JSONElement`; implicit coercion of other types to String is deprecated"));
         } catch(Throwable t) {
             fail("reject_invalid_message_data: Unexpected exception");
-        } finally {
-            Log.setHandler(originalLogHandler);
-            Log.setLevel(originalLogLevel);
         }
     }
 

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeResumeTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeResumeTest.java
@@ -962,7 +962,7 @@ public class RealtimeResumeTest extends ParameterizedTest {
         options.realtimeRequestTimeout = 2000L;
 
         /* We want this greater than newTtl + newIdleInterval */
-        final long waitInDisconnectedState = 3000L;
+        final long waitInDisconnectedState = 5000L;
         options.transportFactory = mockWebsocketFactory;
         try(AblyRealtime ably = new AblyRealtime(options)) {
             final long newTtl = 1000L;
@@ -1017,12 +1017,6 @@ public class RealtimeResumeTest extends ParameterizedTest {
             mockWebsocketFactory.blockReceiveProcessing(message -> message.action == ProtocolMessage.Action.ack ||
                 message.action == ProtocolMessage.Action.nack);
 
-            /* Wait for the connection to go stale, then reconnect */
-            try {
-                Thread.sleep(waitInDisconnectedState);
-            } catch (InterruptedException e) {
-            }
-
             //enter next 3 clients
             for (int i = 0; i < 3; i++) {
                 senderChannel.presence.enterClient(clients[i+3],null,presenceCompletion.add());
@@ -1045,6 +1039,13 @@ public class RealtimeResumeTest extends ParameterizedTest {
             for (int i = 0; i < 3; i++) {
                 senderChannel.presence.enterClient(clients[i+6],null,presenceCompletion.add());
             }
+
+            /* Wait for the connection to go stale, then reconnect */
+            try {
+                Thread.sleep(waitInDisconnectedState);
+            } catch (InterruptedException e) {
+            }
+
             //now let's unblock the ack nacks and reconnect
             mockWebsocketFactory.blockReceiveProcessing(message -> false);
             /* Wait for the connection to go stale, then reconnect */


### PR DESCRIPTION
**JWT re-auth:**

The test would sometimes fail because we'd end up with two re-auths instead of one due to the token expiring in the middle of the test.

This change fixes the issue, by only caring about the first token regeneration.

**Message data:**

The test was failing as it was setting the log handler and level, which is static and therefore global. This logger is shared between tests that are not running in isolation, so other tests could write to the log, causing the log assertion to fail.

**Pending messages:**

The test uses a sleep to ensure that the TTLs pass and that the connection is marked as stale. However, it does this whilst the channel is still active, and websocket ping/pongs could still be sent, therefore its possible that on the channel reconnecting, a resume will take place.

This change fixes the bug by performing the wait when the channel has been disconnected (with retries suppressed) which guarantees that the connection will be stale when the test reconnects.

**Realtime connect fail:**

The comparison in the test breaks if the number is exactly on the lower bound. This change fixes it by making the check inclusive.
