### PR TITLE
fix: fallback hosts always being used on transport error

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -265,6 +265,12 @@ public class ConnectionManager implements ConnectListener {
         void enactForChannel(StateIndication stateIndication, ConnectionStateChange change, Channel channel) {
             channel.setConnected(stateIndication.reattachOnResumeFailure);
         }
+
+        @Override
+        void enact(StateIndication stateIndication, ConnectionStateChange change) {
+            super.enact(stateIndication, change);
+            pendingConnect = null;
+        }
     }
 
     /**************************************************


### PR DESCRIPTION
Prior to this change, a websocket transport error (whether that's a clean close, abnormal close or some others) would immediately result in a fallback host being used, even if the original host was entirely operational.

This is because the decision on whether to fallback is partly based on the presence of a "pending connection", which is set when the connecting state is entered. This pending connection is never cleared, except for when the decision is not to use a fallback. The result of this, is that a websocket error event (following a successful connection) will always have a lingering pending connection, so if the error from the websocket is "server-related" (the other part of the decision), it will automatically use a fallback host.

This change fixes the issue by clearing the pending connection whenever a connected state is reached. By doing this, it means that a simple disconnection (e.g. from a scaling event) will automatically retry the same host, wheras a disconnection during the connection process will try a fallback.

Fixes #950


To test this:

```
AblyRealtime ably = new AblyRealtime(options);
ably.connection.once(ConnectionEvent.connected, state -> {
    // Once connected, force the wss to drop out with abnormal close

    ConnectionManager connectionManager = ably.connection.connectionManager;
    try {
        Field transportField = connectionManager.getClass().getDeclaredField("transport");
        transportField.setAccessible(true);
        WebSocketTransport transport = (WebSocketTransport) transportField.get(connectionManager);
        transport.close();
    } catch (NoSuchFieldException e) {
        throw new RuntimeException(e);
    } catch (IllegalAccessException e) {
        throw new RuntimeException(e);
    }
});
ably.connect();

```

The above code will connect to Ably, then once connected, force a transport close. On the current `main` this will cause the client to immediately reconnect on a fallback host (failed resume), whereas on this branch, it will connect back (hopefully!) to the original host.

The behaviour implemented is in the spirit of RTN17c, but the spec could do with an update to make it clearer as to what lifecycle conditions in a Realtime connection constitutes the need to use a fallback host (our interpretation is that the spec references RSC17l, which refers to errors in the REST API, so it follows that we'd expect this to apply to the `CONNECTING` state for a Realtime connection.