### PR TITLE
fix: use appropriate error code for channel attachment timeout

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -479,7 +479,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
                             }
                             attachTimer = null;
                             if(state == ChannelState.attaching) {
-                                setSuspended(new ErrorInfo(errorMessage, 91200), true);
+                                setSuspended(new ErrorInfo(errorMessage, 90007), true);
                                 reattachAfterTimeout();
                             }
                         }

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -1808,7 +1808,7 @@ public class RealtimeChannelTest extends ParameterizedTest {
 
             /* Should get to suspended soon because send() is blocked */
             ErrorInfo suspendReason = channelWaiter.waitFor(ChannelState.suspended);
-            assertEquals("Verify the suspended event contains the detach reason", 91200, suspendReason.code);
+            assertEquals("Verify the suspended event contains the detach reason", 90007, suspendReason.code);
 
             /* Unblock send(), and expect a transition to attached */
             mockTransport.allowSend();


### PR DESCRIPTION
Previously, for channel attachment timeouts we were using error code 91200 which is not documented for users and was removed from the specification somewhere around version 0.9. It looks like it was removed almost immediately after it was implemented in ably-java.

This change fixes this by changing the code to 90007 which is used elsewhere and more appropriate for this use-case (used in detach in ably-java, and in ably-js).

Fixes #959