### PR TITLE
Error log stack traces

### DIFF
--- a/lib/src/main/java/io/ably/lib/http/HttpCore.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpCore.java
@@ -251,7 +251,6 @@ public class HttpCore {
                 rawHttpListener.onRawHttpResponse(id, method, response);
             }
         } catch(IOException ioe) {
-            ioe.printStackTrace();
             if(rawHttpListener != null) {
                 rawHttpListener.onRawHttpException(id, method, ioe);
             }

--- a/lib/src/main/java/io/ably/lib/http/HttpCore.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpCore.java
@@ -216,12 +216,14 @@ public class HttpCore {
             byte[] body = null;
             if(requestBody != null) {
                 body = prepareRequestBody(requestBody, conn);
+                // Logging level is checked before logging for performance reasons in building the entry
                 if (Log.level <= Log.VERBOSE)
                     Log.v(TAG, System.lineSeparator() + new String(body));
             }
 
             /* log raw request details */
             Map<String, List<String>> requestProperties = conn.getRequestProperties();
+            // Logging level is checked before logging for performance reasons in building the entry
             if (Log.level <= Log.VERBOSE) {
                 Log.v(TAG, "HTTP request: " + conn.getURL() + " " + method);
                 if (credentialsIncluded)
@@ -399,6 +401,7 @@ public class HttpCore {
         for (Map.Entry<String, List<String>> entry : caseSensitiveHeaders.entrySet()) {
             if (entry.getKey() != null) {
                 response.headers.put(entry.getKey().toLowerCase(Locale.ROOT), entry.getValue());
+                // Logging level is checked before logging for performance reasons in building the entry
                 if (Log.level <= Log.VERBOSE)
                     for (String val : entry.getValue())
                         Log.v(TAG, entry.getKey() + ": " + val);

--- a/lib/src/main/java/io/ably/lib/http/HttpCore.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpCore.java
@@ -216,14 +216,14 @@ public class HttpCore {
             byte[] body = null;
             if(requestBody != null) {
                 body = prepareRequestBody(requestBody, conn);
-                // Logging level is checked before logging for performance reasons in building the entry
+                // Check the logging level to avoid performance hit associated with building the message
                 if (Log.level <= Log.VERBOSE)
                     Log.v(TAG, System.lineSeparator() + new String(body));
             }
 
             /* log raw request details */
             Map<String, List<String>> requestProperties = conn.getRequestProperties();
-            // Logging level is checked before logging for performance reasons in building the entry
+            // Check the logging level to avoid performance hit associated with building the message
             if (Log.level <= Log.VERBOSE) {
                 Log.v(TAG, "HTTP request: " + conn.getURL() + " " + method);
                 if (credentialsIncluded)
@@ -401,7 +401,7 @@ public class HttpCore {
         for (Map.Entry<String, List<String>> entry : caseSensitiveHeaders.entrySet()) {
             if (entry.getKey() != null) {
                 response.headers.put(entry.getKey().toLowerCase(Locale.ROOT), entry.getValue());
-                // Logging level is checked before logging for performance reasons in building the entry
+                // Check the logging level to avoid performance hit associated with building the message
                 if (Log.level <= Log.VERBOSE)
                     for (String val : entry.getValue())
                         Log.v(TAG, entry.getKey() + ": " + val);

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1136,6 +1136,7 @@ public class ConnectionManager implements ConnectListener {
         if (transport != null && this.transport != transport) {
             return;
         }
+        // Logging level is checked before logging for performance reasons in building the entry
         if (Log.level <= Log.VERBOSE) {
             Log.v(TAG, "onMessage() (transport = " + transport + "): " + message.action + ": " + new String(ProtocolSerializer.writeJSON(message)));
         }

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1591,6 +1591,7 @@ public class ConnectionManager implements ConnectListener {
         try {
             return HttpHelpers.getUrlString(ably.httpCore, INTERNET_CHECK_URL).contains(INTERNET_CHECK_OK);
         } catch(AblyException e) {
+            Log.d(TAG, "Exception whilst checking connectivity", e);
             return false;
         }
     }

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1136,7 +1136,7 @@ public class ConnectionManager implements ConnectListener {
         if (transport != null && this.transport != transport) {
             return;
         }
-        // Logging level is checked before logging for performance reasons in building the entry
+        // Check the logging level to avoid performance hit associated with building the message
         if (Log.level <= Log.VERBOSE) {
             Log.v(TAG, "onMessage() (transport = " + transport + "): " + message.action + ": " + new String(ProtocolSerializer.writeJSON(message)));
         }

--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -110,12 +110,15 @@ public class WebSocketTransport implements ITransport {
         try {
             if(channelBinaryMode) {
                 byte[] encodedMsg = ProtocolSerializer.writeMsgpack(msg);
+
+                // Logging level is checked before logging for performance reasons in building the entry
                 if (Log.level <= Log.VERBOSE) {
                     ProtocolMessage decodedMsg = ProtocolSerializer.readMsgpack(encodedMsg);
                     Log.v(TAG, "send(): " + decodedMsg.action + ": " + new String(ProtocolSerializer.writeJSON(decodedMsg)));
                 }
                 wsConnection.send(encodedMsg);
             } else {
+                // Logging level is checked before logging for performance reasons in building the entry
                 if (Log.level <= Log.VERBOSE)
                     Log.v(TAG, "send(): " + new String(ProtocolSerializer.writeJSON(msg)));
                 wsConnection.send(ProtocolSerializer.writeJSON(msg));

--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -111,14 +111,14 @@ public class WebSocketTransport implements ITransport {
             if(channelBinaryMode) {
                 byte[] encodedMsg = ProtocolSerializer.writeMsgpack(msg);
 
-                // Logging level is checked before logging for performance reasons in building the entry
+                // Check the logging level to avoid performance hit associated with building the message
                 if (Log.level <= Log.VERBOSE) {
                     ProtocolMessage decodedMsg = ProtocolSerializer.readMsgpack(encodedMsg);
                     Log.v(TAG, "send(): " + decodedMsg.action + ": " + new String(ProtocolSerializer.writeJSON(decodedMsg)));
                 }
                 wsConnection.send(encodedMsg);
             } else {
-                // Logging level is checked before logging for performance reasons in building the entry
+                // Check the logging level to avoid performance hit associated with building the message
                 if (Log.level <= Log.VERBOSE)
                     Log.v(TAG, "send(): " + new String(ProtocolSerializer.writeJSON(msg)));
                 wsConnection.send(ProtocolSerializer.writeJSON(msg));

--- a/lib/src/main/java/io/ably/lib/types/Message.java
+++ b/lib/src/main/java/io/ably/lib/types/Message.java
@@ -274,7 +274,7 @@ public class Message extends BaseMessage {
             }
             return messages;
         } catch(Exception e) {
-            e.printStackTrace();
+            Log.e(Message.class.getName(), e.getMessage(), e);
             throw MessageDecodeException.fromDescription(e.getMessage());
         }
     }
@@ -295,7 +295,7 @@ public class Message extends BaseMessage {
             JsonArray jsonArray = Serialisation.gson.fromJson(messagesArray, JsonArray.class);
             return fromEncodedArray(jsonArray, channelOptions);
         } catch(Exception e) {
-            e.printStackTrace();
+            Log.e(Message.class.getName(), e.getMessage(), e);
             throw MessageDecodeException.fromDescription(e.getMessage());
         }
     }
@@ -341,7 +341,7 @@ public class Message extends BaseMessage {
             try {
                 message.read((JsonObject)json);
             } catch (MessageDecodeException e) {
-                e.printStackTrace();
+                Log.e(Message.class.getName(), e.getMessage(), e);
                 throw new JsonParseException("Failed to deserialize Message from JSON.", e);
             }
             return message;


### PR DESCRIPTION
Replaces a number of places where exception information is sent to the system error log rather than custom error handlers that users may be using.

Fixes #963 