### PR TITLE
Message interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,42 @@ channel.publishAsync(message, new CompletionListener() {
 });
 ```
 
+### Message interactions
+
+Message Interactions allow you to interact with messages previously sent to a channel. Once a channel is enabled with Message Interactions, messages received by that channel will contain a unique `timeSerial` that can be referenced by later messages.
+
+#### Publishing an Interaction
+
+This example assumes you are using the Google Gson library and that a message with timeserial `1656424960320-1` has previously been published on the channel.
+
+```java
+  String extrasJson = "{\"ref\": {\"type\": \"com.ably.reaction\", \"timeserial\": \"1656424960320-1\"}}";
+  MessageExtras extras = new MessageExtras(JsonParser.parseString(extrasJson).getAsJsonObject());
+  Message message = new Message("message-name", "message-data", extras);
+  channel.publish(message);
+```
+
+
+#### Subscribing to Interactions
+
+You can also filter messages received on the channel so that only messages matching the filter are passed on to your listener.
+
+The following example sets up a listener that only receives messages that have an interaction type of `com.ably.reaction`.
+
+```java
+  MessageFilter filter = new MessageFilter();
+  filter.refType = "com.ably.reaction";
+  channel.subscribe(
+      filter,
+      new Channel.MessageListener() {
+          @Override
+          public void onMessage(Message message) {
+              System.out.println(message.data);
+          }
+      }
+  );
+```
+
 #### Querying the history
 
 ```java

--- a/lib/src/main/java/io/ably/lib/realtime/FilteredListeners.java
+++ b/lib/src/main/java/io/ably/lib/realtime/FilteredListeners.java
@@ -1,0 +1,147 @@
+package io.ably.lib.realtime;
+
+import io.ably.lib.types.Message;
+import io.ably.lib.types.MessageFilter;
+
+import java.util.*;
+
+public class FilteredListeners implements IFilteredListeners {
+
+    /**
+     * All the filtered subscriptions, by filter.
+     */
+    private final Map<ChannelBase.MessageListener, HashMap<MessageFilter, ArrayList<FilteredMessageListener>>> filteredListeners = new HashMap<>();
+
+    public Map<ChannelBase.MessageListener, HashMap<MessageFilter, ArrayList<FilteredMessageListener>>> getFilteredListeners() {
+        return filteredListeners;
+    }
+
+    public synchronized ChannelBase.MessageListener addFilteredListener(MessageFilter filter, ChannelBase.MessageListener originalListener) {
+        MessageExtrasFilter extrasFilter = new MessageExtrasFilter(filter);
+        FilteredMessageListener filteredListener = new FilteredMessageListener(originalListener, extrasFilter);
+
+        if (!filteredListeners.containsKey(originalListener)) {
+            filteredListeners.put(originalListener, new HashMap<>());
+        }
+
+        HashMap<MessageFilter, ArrayList<FilteredMessageListener>> filteredListeners = this.filteredListeners.get(originalListener);
+        if (!filteredListeners.containsKey(filter)) {
+            filteredListeners.put(filter, new ArrayList<>());
+        }
+
+        Objects.requireNonNull(filteredListeners.get(filter)).add(filteredListener);
+
+        return filteredListener;
+    }
+
+    public synchronized ArrayList<ChannelBase.MessageListener> removeFilteredListener(MessageFilter filter, ChannelBase.MessageListener originalListener) {
+
+        // Only a filter passed, remove all listeners for that filter
+        if (originalListener == null && filter != null) {
+            return removeAllListenersForFilter(filter);
+        }
+
+        // Nothing for this listener
+        if (originalListener == null || !filteredListeners.containsKey(originalListener)) {
+            return new ArrayList<>();
+        }
+
+        // No filter, so remove all listeners for the specified original
+        if (filter == null) {
+            return removeAllFilteredListenersForListener(originalListener);
+        }
+
+        // Remove all listeners for the specified original that match the filter.
+        return removeAllFilteredListenersForListenerAndFilter(originalListener, filter);
+    }
+
+    private ArrayList<ChannelBase.MessageListener> removeAllListenersForFilter(MessageFilter filter) {
+        Iterator<Map.Entry<ChannelBase.MessageListener, HashMap<MessageFilter, ArrayList<FilteredMessageListener>>>> iterator = filteredListeners.entrySet().iterator();
+
+        ArrayList<ChannelBase.MessageListener> listenersToRemove = new ArrayList<>();
+        while (iterator.hasNext()) {
+            Map.Entry<ChannelBase.MessageListener, HashMap<MessageFilter, ArrayList<FilteredMessageListener>>> entriesForListener = iterator.next();
+
+            // Remove all the entries for the given filter, if it exists for the listener
+            if (entriesForListener.getValue().containsKey(filter)) {
+                listenersToRemove.addAll(entriesForListener.getValue().get(filter));
+                entriesForListener.getValue().remove(filter);
+
+                // If there are no filters left for the liftener now, remove the listener completely
+                if (entriesForListener.getValue().isEmpty()) {
+                    iterator.remove();
+                }
+            }
+        }
+
+        return listenersToRemove;
+    }
+
+    private ArrayList<ChannelBase.MessageListener> removeAllFilteredListenersForListener(ChannelBase.MessageListener originalListener) {
+        ArrayList<ChannelBase.MessageListener> listenersToRemove = new ArrayList<>();
+
+        HashMap<MessageFilter, ArrayList<FilteredMessageListener>> filteredListenersForListener = filteredListeners.get(originalListener);
+        Iterator<Map.Entry<MessageFilter, ArrayList<FilteredMessageListener>>> iterator = filteredListenersForListener.entrySet().iterator();
+
+        // Cycle each filter that the listener has, add the filtered listeners, and then remove the listener
+        while (iterator.hasNext()) {
+            listenersToRemove.addAll(iterator.next().getValue());
+        }
+
+        this.filteredListeners.remove(originalListener);
+
+        return listenersToRemove;
+    }
+
+    private ArrayList<ChannelBase.MessageListener> removeAllFilteredListenersForListenerAndFilter(ChannelBase.MessageListener originalListener, MessageFilter filter) {
+
+        HashMap<MessageFilter, ArrayList<FilteredMessageListener>> filteredListenersForListener = filteredListeners.get(originalListener);
+        if (!filteredListenersForListener.containsKey(filter)) {
+            return new ArrayList<>();
+        }
+
+        ArrayList<ChannelBase.MessageListener> listenersToRemove = new ArrayList<ChannelBase.MessageListener>() {{
+            addAll(filteredListenersForListener.get(filter));
+        }};
+
+        filteredListenersForListener.remove(filter);
+
+        if (filteredListenersForListener.isEmpty()) {
+            filteredListeners.remove(originalListener);
+        }
+
+        return listenersToRemove;
+    }
+
+    /**
+     * Interface for a class that can filter messages for us, based on the user-provided
+     * message filters.
+     */
+    public interface IMessageFilter {
+        boolean onMessage(Message message);
+    }
+
+    /**
+     * Filtered message listener that only sends the event to the actual listener if
+     * the filter passes.
+     */
+    private static class FilteredMessageListener implements ChannelBase.MessageListener {
+        private final ChannelBase.MessageListener listener;
+
+        private final IMessageFilter filter;
+
+        private FilteredMessageListener(ChannelBase.MessageListener listener, IMessageFilter filter) {
+            this.listener = listener;
+            this.filter = filter;
+        }
+
+        @Override
+        public void onMessage(Message message) {
+            if (filter != null && !filter.onMessage(message)) {
+                return;
+            }
+
+            listener.onMessage(message);
+        }
+    }
+}

--- a/lib/src/main/java/io/ably/lib/realtime/FilteredListeners.java
+++ b/lib/src/main/java/io/ably/lib/realtime/FilteredListeners.java
@@ -3,7 +3,11 @@ package io.ably.lib.realtime;
 import io.ably.lib.types.Message;
 import io.ably.lib.types.MessageFilter;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
 
 public class FilteredListeners implements IFilteredListeners {
 

--- a/lib/src/main/java/io/ably/lib/realtime/FilteredListeners.java
+++ b/lib/src/main/java/io/ably/lib/realtime/FilteredListeners.java
@@ -16,6 +16,11 @@ public class FilteredListeners implements IFilteredListeners {
         return filteredListeners;
     }
 
+    public void clear()
+    {
+        filteredListeners.clear();
+    }
+
     public synchronized ChannelBase.MessageListener addFilteredListener(MessageFilter filter, ChannelBase.MessageListener originalListener) {
         MessageExtrasFilter extrasFilter = new MessageExtrasFilter(filter);
         FilteredMessageListener filteredListener = new FilteredMessageListener(originalListener, extrasFilter);

--- a/lib/src/main/java/io/ably/lib/realtime/IFilteredListeners.java
+++ b/lib/src/main/java/io/ably/lib/realtime/IFilteredListeners.java
@@ -1,0 +1,29 @@
+package io.ably.lib.realtime;
+
+import io.ably.lib.types.MessageFilter;
+
+import java.util.ArrayList;
+
+/**
+ * Interface for a class that maps user-provided message filters to wrapped listeners that are subscribed
+ * to the channel internaly.
+ */
+public interface IFilteredListeners {
+    /**
+     * Adds a filtered listener.
+     */
+    ChannelBase.MessageListener addFilteredListener(MessageFilter filter, ChannelBase.MessageListener originalListener);
+
+    /**
+     * Removes a filtered listener and returns the ones that need to be returned from the ChannelBase subscriptions.
+     * @param filter
+     * @param originalListener
+     * @return
+     */
+    ArrayList<ChannelBase.MessageListener> removeFilteredListener(MessageFilter filter, ChannelBase.MessageListener originalListener);
+
+    /**
+     * Removes all the listeners.
+     */
+    void clear();
+}

--- a/lib/src/main/java/io/ably/lib/realtime/MessageExtrasFilter.java
+++ b/lib/src/main/java/io/ably/lib/realtime/MessageExtrasFilter.java
@@ -1,0 +1,93 @@
+package io.ably.lib.realtime;
+
+import com.google.gson.JsonObject;
+import io.ably.lib.types.Message;
+
+/**
+ * A filter for inspecting the extras of a message to check if they match.
+ * Spec: RTL22c
+ */
+final class MessageExtrasFilter implements FilteredListeners.IMessageFilter {
+    public final io.ably.lib.types.MessageFilter filter;
+
+    public MessageExtrasFilter(io.ably.lib.types.MessageFilter filter) {
+        this.filter = filter;
+    }
+
+    @Override
+    public boolean onMessage(Message message) {
+        return clientIdMatchesFilter(message) &&
+            nameMatchesFilter(message) &&
+            referenceMatchesFilter(message);
+    }
+
+    private boolean nameMatchesFilter(Message message) {
+        return filter.name == null || message.name.equals(filter.name);
+    }
+
+    private boolean clientIdMatchesFilter(Message message) {
+        return filter.clientId == null || message.clientId.equals(filter.clientId);
+    }
+
+    private boolean referenceMatchesFilter(Message message) {
+        // No reference-based filters, so we can skip.
+        if (filter.isRef == null && filter.refType == null && filter.refTimeSerial == null) {
+            return true;
+        }
+
+        MessageRef messageRef = getMessageRef(message);
+
+        return isRefMatchesFilter(messageRef) &&
+            refTypeMatchesFilter(messageRef) &&
+            refTimeserialMatchesFilter(messageRef);
+    }
+
+    private MessageRef getMessageRef(Message message) {
+
+        // No extras
+        if (message.extras == null) {
+            return null;
+        }
+
+        JsonObject messageExtras = message.extras.asJsonObject();
+        if (!messageExtras.has("ref")) {
+            return null;
+        }
+
+        try {
+            JsonObject messageRef = message.extras.asJsonObject().get("ref").getAsJsonObject();
+            return new MessageRef(
+                messageRef.get("type").getAsJsonPrimitive().getAsString(),
+                messageRef.get("timeserial").getAsJsonPrimitive().getAsString()
+            );
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private boolean isRefMatchesFilter(MessageRef messageRef) {
+        return filter.isRef == null ||
+            (Boolean.TRUE.equals(filter.isRef) && messageRef != null) ||
+            (Boolean.FALSE.equals(filter.isRef) && messageRef == null);
+    }
+
+    private boolean refTypeMatchesFilter(MessageRef messageRef) {
+        return filter.refType == null || (messageRef != null && filter.refType.equals(messageRef.type));
+    }
+
+    private boolean refTimeserialMatchesFilter(MessageRef messageRef) {
+        return filter.refTimeSerial == null || (messageRef != null && filter.refTimeSerial.equals(messageRef.timeserial));
+    }
+
+    private static final class MessageRef {
+        public final String type;
+
+        public final String timeserial;
+
+
+        private MessageRef(String type, String timeserial) {
+            this.type = type;
+            this.timeserial = timeserial;
+        }
+    }
+}

--- a/lib/src/main/java/io/ably/lib/realtime/MessageExtrasFilter.java
+++ b/lib/src/main/java/io/ably/lib/realtime/MessageExtrasFilter.java
@@ -31,7 +31,7 @@ final class MessageExtrasFilter implements FilteredListeners.IMessageFilter {
 
     private boolean referenceMatchesFilter(Message message) {
         // No reference-based filters, so we can skip.
-        if (filter.isRef == null && filter.refType == null && filter.refTimeSerial == null) {
+        if (filter.isRef == null && filter.refType == null && filter.refTimeserial == null) {
             return true;
         }
 
@@ -76,7 +76,7 @@ final class MessageExtrasFilter implements FilteredListeners.IMessageFilter {
     }
 
     private boolean refTimeserialMatchesFilter(MessageRef messageRef) {
-        return filter.refTimeSerial == null || (messageRef != null && filter.refTimeSerial.equals(messageRef.timeserial));
+        return filter.refTimeserial == null || (messageRef != null && filter.refTimeserial.equals(messageRef.timeserial));
     }
 
     private static final class MessageRef {

--- a/lib/src/main/java/io/ably/lib/realtime/MessageExtrasFilter.java
+++ b/lib/src/main/java/io/ably/lib/realtime/MessageExtrasFilter.java
@@ -10,7 +10,7 @@ import io.ably.lib.types.Message;
 final class MessageExtrasFilter implements FilteredListeners.IMessageFilter {
     public final io.ably.lib.types.MessageFilter filter;
 
-    public MessageExtrasFilter(io.ably.lib.types.MessageFilter filter) {
+    MessageExtrasFilter(io.ably.lib.types.MessageFilter filter) {
         this.filter = filter;
     }
 

--- a/lib/src/main/java/io/ably/lib/types/MessageFilter.java
+++ b/lib/src/main/java/io/ably/lib/types/MessageFilter.java
@@ -1,0 +1,45 @@
+package io.ably.lib.types;
+
+/**
+ * Supplies filter options for subscriptions.
+ * Spec: MFI1, MFI2
+ */
+public final class MessageFilter {
+    /**
+     * Whether the message should contain a `extras.ref` field.
+     * Spec: MFI2a
+     */
+    public final boolean isRef;
+
+    /**
+     * Value to check against `extras.ref.timeserial`.
+     * Spec: MFI2b
+     */
+    public final String refTimeSerial;
+
+    /**
+     * Value to check against `extras.ref.type`.
+     * Spec: MFI2c
+     */
+    public final String refType;
+
+    /**
+     * Value to check against the `name` of a message.
+     * Spec: MFI2d
+     */
+    public final String name;
+
+    /**
+     * Value to check against the `cliendId` that published the message.
+     * Spec: MFI2e
+     */
+    public final String clientId;
+
+    public MessageFilter(boolean isRef, String refTimeSerial, String refType, String name, String clientId) {
+        this.isRef = isRef;
+        this.refTimeSerial = refTimeSerial;
+        this.refType = refType;
+        this.name = name;
+        this.clientId = clientId;
+    }
+}

--- a/lib/src/main/java/io/ably/lib/types/MessageFilter.java
+++ b/lib/src/main/java/io/ably/lib/types/MessageFilter.java
@@ -11,39 +11,31 @@ public final class MessageFilter {
      * Whether the message should contain a `extras.ref` field.
      * Spec: MFI2a
      */
-    public final Boolean isRef;
+    public Boolean isRef;
 
     /**
      * Value to check against `extras.ref.timeserial`.
      * Spec: MFI2b
      */
-    public final String refTimeSerial;
+    public String refTimeserial;
 
     /**
      * Value to check against `extras.ref.type`.
      * Spec: MFI2c
      */
-    public final String refType;
+    public String refType;
 
     /**
      * Value to check against the `name` of a message.
      * Spec: MFI2d
      */
-    public final String name;
+    public String name;
 
     /**
      * Value to check against the `cliendId` that published the message.
      * Spec: MFI2e
      */
-    public final String clientId;
-
-    public MessageFilter(Boolean isRef, String refTimeSerial, String refType, String name, String clientId) {
-        this.isRef = isRef;
-        this.refTimeSerial = refTimeSerial;
-        this.refType = refType;
-        this.name = name;
-        this.clientId = clientId;
-    }
+    public String clientId;
 
     @Override
     public boolean equals(Object o) {
@@ -52,7 +44,7 @@ public final class MessageFilter {
 
         MessageFilter that = (MessageFilter) o;
         return isRef == that.isRef &&
-            Objects.equals(refTimeSerial, that.refTimeSerial) &&
+            Objects.equals(refTimeserial, that.refTimeserial) &&
             Objects.equals(refType, that.refType) &&
             Objects.equals(name, that.name) &&
             Objects.equals(clientId, that.clientId);
@@ -60,6 +52,6 @@ public final class MessageFilter {
 
     @Override
     public int hashCode() {
-        return Objects.hash(isRef, refTimeSerial, refType, name, clientId);
+        return Objects.hash(isRef, refTimeserial, refType, name, clientId);
     }
 }

--- a/lib/src/main/java/io/ably/lib/types/MessageFilter.java
+++ b/lib/src/main/java/io/ably/lib/types/MessageFilter.java
@@ -1,5 +1,7 @@
 package io.ably.lib.types;
 
+import java.util.Objects;
+
 /**
  * Supplies filter options for subscriptions.
  * Spec: MFI1, MFI2
@@ -9,7 +11,7 @@ public final class MessageFilter {
      * Whether the message should contain a `extras.ref` field.
      * Spec: MFI2a
      */
-    public final boolean isRef;
+    public final Boolean isRef;
 
     /**
      * Value to check against `extras.ref.timeserial`.
@@ -35,11 +37,29 @@ public final class MessageFilter {
      */
     public final String clientId;
 
-    public MessageFilter(boolean isRef, String refTimeSerial, String refType, String name, String clientId) {
+    public MessageFilter(Boolean isRef, String refTimeSerial, String refType, String name, String clientId) {
         this.isRef = isRef;
         this.refTimeSerial = refTimeSerial;
         this.refType = refType;
         this.name = name;
         this.clientId = clientId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        MessageFilter that = (MessageFilter) o;
+        return isRef == that.isRef &&
+            Objects.equals(refTimeSerial, that.refTimeSerial) &&
+            Objects.equals(refType, that.refType) &&
+            Objects.equals(name, that.name) &&
+            Objects.equals(clientId, that.clientId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isRef, refTimeSerial, refType, name, clientId);
     }
 }

--- a/lib/src/test/java/io/ably/lib/realtime/FilteredListenersTest.java
+++ b/lib/src/test/java/io/ably/lib/realtime/FilteredListenersTest.java
@@ -8,7 +8,9 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class FilteredListenersTest {
 

--- a/lib/src/test/java/io/ably/lib/realtime/FilteredListenersTest.java
+++ b/lib/src/test/java/io/ably/lib/realtime/FilteredListenersTest.java
@@ -15,7 +15,10 @@ import static org.junit.Assert.assertFalse;
 public class FilteredListenersTest {
 
     private MessageFilter getFilter(String name) {
-        return new MessageFilter(null, null, null, name, null);
+        MessageFilter filter = new MessageFilter();
+        filter.name = name;
+
+        return filter;
     }
 
     private class MockListener implements ChannelBase.MessageListener {

--- a/lib/src/test/java/io/ably/lib/realtime/FilteredListenersTest.java
+++ b/lib/src/test/java/io/ably/lib/realtime/FilteredListenersTest.java
@@ -1,0 +1,324 @@
+package io.ably.lib.realtime;
+
+import com.google.gson.JsonObject;
+import io.ably.lib.types.Message;
+import io.ably.lib.types.MessageExtras;
+import io.ably.lib.types.MessageFilter;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.*;
+
+public class FilteredListenersTest {
+
+    private MessageFilter getFilter(String name) {
+        return new MessageFilter(null, null, null, name, null);
+    }
+
+    private class MockListener implements ChannelBase.MessageListener {
+        public final ArrayList<Message> calls = new ArrayList<>();
+
+
+        @Override
+        public void onMessage(Message message) {
+            calls.add(message);
+        }
+    }
+
+    @Test
+    public void it_adds_a_listener_with_a_filter() {
+        MessageFilter filter = getFilter("this-name-is-important");
+        Message message1 = new Message("this-name-is-important", new Object(), "client", new MessageExtras(new JsonObject()));
+        Message message2 = new Message("this-name-is-not-important", new Object(), "client", new MessageExtras(new JsonObject()));
+
+        MockListener listener = new MockListener();
+        FilteredListeners filteredListeners = new FilteredListeners();
+
+        ChannelBase.MessageListener filtered = filteredListeners.addFilteredListener(filter, listener);
+        filtered.onMessage(message1);
+        filtered.onMessage(message2);
+
+        assertEquals(1, listener.calls.size());
+        assertEquals(message1, listener.calls.get(0));
+
+        assertEquals(1, filteredListeners.getFilteredListeners().size());
+        assertEquals(1, filteredListeners.getFilteredListeners().get(listener).size());
+        assertEquals(1, filteredListeners.getFilteredListeners().get(listener).get(filter).size());
+        assertEquals(filtered, filteredListeners.getFilteredListeners().get(listener).get(filter).get(0));
+    }
+
+    @Test
+    public void it_adds_a_listener_with_a_filter_when_one_has_been_registered() {
+        MessageFilter filter = getFilter("this-name-is-important");
+        Message message1 = new Message("this-name-is-important", new Object(), "client", new MessageExtras(new JsonObject()));
+        Message message2 = new Message("this-name-is-not-important", new Object(), "client", new MessageExtras(new JsonObject()));
+
+        MockListener listener1 = new MockListener();
+        MockListener listener2 = new MockListener();
+        FilteredListeners filteredListeners = new FilteredListeners();
+
+        ChannelBase.MessageListener filtered1 = filteredListeners.addFilteredListener(filter, listener1);
+        ChannelBase.MessageListener filtered2 = filteredListeners.addFilteredListener(filter, listener2);
+        filtered1.onMessage(message1);
+        filtered1.onMessage(message2);
+        filtered2.onMessage(message1);
+        filtered2.onMessage(message2);
+
+        assertEquals(1, listener1.calls.size());
+        assertEquals(message1, listener1.calls.get(0));
+        assertEquals(1, listener2.calls.size());
+        assertEquals(message1, listener2.calls.get(0));
+
+        assertEquals(2, filteredListeners.getFilteredListeners().size());
+        assertEquals(1, filteredListeners.getFilteredListeners().get(listener1).size());
+        assertEquals(1, filteredListeners.getFilteredListeners().get(listener1).get(filter).size());
+        assertEquals(filtered1, filteredListeners.getFilteredListeners().get(listener1).get(filter).get(0));
+
+        assertEquals(1, filteredListeners.getFilteredListeners().get(listener2).size());
+        assertEquals(1, filteredListeners.getFilteredListeners().get(listener2).get(filter).size());
+        assertEquals(filtered2, filteredListeners.getFilteredListeners().get(listener2).get(filter).get(0));
+    }
+
+    @Test
+    public void it_adds_the_same_listener_with_a_different_filter() {
+        MessageFilter filter = getFilter("this-name-is-important");
+        MessageFilter filter2 = getFilter("this-name-is-also-important");
+        Message message1 = new Message("this-name-is-important", new Object(), "client", new MessageExtras(new JsonObject()));
+        Message message2 = new Message("this-name-is-also-important", new Object(), "client", new MessageExtras(new JsonObject()));
+
+        MockListener listener1 = new MockListener();
+        FilteredListeners filteredListeners = new FilteredListeners();
+
+        ChannelBase.MessageListener filtered1 = filteredListeners.addFilteredListener(filter, listener1);
+        ChannelBase.MessageListener filtered2 = filteredListeners.addFilteredListener(filter2, listener1);
+        filtered1.onMessage(message1);
+        filtered1.onMessage(message2);
+        filtered2.onMessage(message1);
+        filtered2.onMessage(message2);
+
+        assertEquals(2, listener1.calls.size());
+        assertEquals(message1, listener1.calls.get(0));
+        assertEquals(message2, listener1.calls.get(1));
+
+        assertEquals(1, filteredListeners.getFilteredListeners().size());
+        assertEquals(2, filteredListeners.getFilteredListeners().get(listener1).size());
+        assertEquals(1, filteredListeners.getFilteredListeners().get(listener1).get(filter).size());
+        assertEquals(filtered1, filteredListeners.getFilteredListeners().get(listener1).get(filter).get(0));
+        assertEquals(1, filteredListeners.getFilteredListeners().get(listener1).get(filter2).size());
+        assertEquals(filtered2, filteredListeners.getFilteredListeners().get(listener1).get(filter2).get(0));
+    }
+
+    @Test
+    public void it_adds_the_same_listener_with_the_same_filter() {
+        MessageFilter filter = getFilter("this-name-is-important");
+        Message message1 = new Message("this-name-is-important", new Object(), "client", new MessageExtras(new JsonObject()));
+        Message message2 = new Message("this-name-is-not-important", new Object(), "client", new MessageExtras(new JsonObject()));
+
+        MockListener listener1 = new MockListener();
+        FilteredListeners filteredListeners = new FilteredListeners();
+
+        ChannelBase.MessageListener filtered1 = filteredListeners.addFilteredListener(filter, listener1);
+        ChannelBase.MessageListener filtered2 = filteredListeners.addFilteredListener(filter, listener1);
+        filtered1.onMessage(message1);
+        filtered2.onMessage(message2);
+        filtered2.onMessage(message1);
+        filtered2.onMessage(message2);
+
+        assertEquals(2, listener1.calls.size());
+        assertEquals(message1, listener1.calls.get(0));
+        assertEquals(message1, listener1.calls.get(1));
+
+        assertEquals(1, filteredListeners.getFilteredListeners().size());
+        assertTrue(filteredListeners.getFilteredListeners().containsKey(listener1));
+        assertEquals(1, filteredListeners.getFilteredListeners().get(listener1).size());
+        assertTrue(filteredListeners.getFilteredListeners().get(listener1).containsKey(filter));
+        assertEquals(2, filteredListeners.getFilteredListeners().get(listener1).get(filter).size());
+        assertEquals(filtered1, filteredListeners.getFilteredListeners().get(listener1).get(filter).get(0));
+        assertEquals(filtered2, filteredListeners.getFilteredListeners().get(listener1).get(filter).get(1));
+    }
+
+    @Test
+    public void it_removes_all_listeners_for_filter() {
+        MessageFilter filterToBeRemoved = getFilter("this-name-is-important");
+        MessageFilter filterToBeKept = getFilter("this-name-is-not-important");
+
+        FilteredListeners filteredListeners = new FilteredListeners();
+        MockListener mockListener1 = new MockListener();
+        MockListener mockListener2 = new MockListener();
+        MockListener mockListener3 = new MockListener();
+        MockListener mockListener4 = new MockListener();
+        MockListener mockListener5 = new MockListener();
+
+        // Filtered 1 and 2 are on the "wrong" filter, so shouldn't be touched
+        ChannelBase.MessageListener filtered1 = filteredListeners.addFilteredListener(filterToBeKept, mockListener1);
+        ChannelBase.MessageListener filtered2 = filteredListeners.addFilteredListener(filterToBeKept, mockListener2);
+
+        // Filtered 3-5 are on the same listener, but 5 is on the filter to be kept. So we should lose 3 and 4, but 5 will remain.
+        ChannelBase.MessageListener filtered3 = filteredListeners.addFilteredListener(filterToBeRemoved, mockListener3);
+        ChannelBase.MessageListener filtered4 = filteredListeners.addFilteredListener(filterToBeRemoved, mockListener3);
+        ChannelBase.MessageListener filtered5 = filteredListeners.addFilteredListener(filterToBeKept, mockListener4);
+
+        // Filtered 6 is on the filter to be removed, and is the only filter. So the listener should be removed entirely.
+        ChannelBase.MessageListener filtered6 = filteredListeners.addFilteredListener(filterToBeRemoved, mockListener5);
+
+        ArrayList<ChannelBase.MessageListener> removed = filteredListeners.removeFilteredListener(filterToBeRemoved, null);
+
+        // Check we have expected filters removed
+        assertEquals(3, removed.size());
+        assertTrue(removed.contains(filtered3));
+        assertTrue(removed.contains(filtered4));
+        assertTrue(removed.contains(filtered6));
+
+        // Check what we have left
+        assertEquals(3, filteredListeners.getFilteredListeners().size());
+        assertEquals(filtered1, filteredListeners.getFilteredListeners().get(mockListener1).get(filterToBeKept).get(0));
+        assertEquals(filtered2, filteredListeners.getFilteredListeners().get(mockListener2).get(filterToBeKept).get(0));
+        assertEquals(filtered5, filteredListeners.getFilteredListeners().get(mockListener4).get(filterToBeKept).get(0));
+    }
+
+    @Test
+    public void it_removes_all_listeners_for_listener() {
+        MessageFilter filter1 = getFilter("this-name-is-important");
+        MessageFilter filter2 = getFilter("this-name-is-not-important");
+
+        FilteredListeners filteredListeners = new FilteredListeners();
+        MockListener mockListener1 = new MockListener();
+        MockListener mockListener2 = new MockListener();
+        MockListener mockListener3 = new MockListener();
+        MockListener mockListener4 = new MockListener();
+
+        // Filtered 1 and 2 are on the "wrong" listener, so shouldn't be touched
+        ChannelBase.MessageListener filtered1 = filteredListeners.addFilteredListener(filter2, mockListener1);
+        ChannelBase.MessageListener filtered2 = filteredListeners.addFilteredListener(filter2, mockListener2);
+
+        // Filtered 3-5 are on the same listener, so should all go.
+        ChannelBase.MessageListener filtered3 = filteredListeners.addFilteredListener(filter1, mockListener3);
+        ChannelBase.MessageListener filtered4 = filteredListeners.addFilteredListener(filter1, mockListener3);
+        ChannelBase.MessageListener filtered5 = filteredListeners.addFilteredListener(filter2, mockListener3);
+
+        // Filtered 6 are on the "wrong" listener
+        ChannelBase.MessageListener filtered6 = filteredListeners.addFilteredListener(filter1, mockListener4);
+
+        ArrayList<ChannelBase.MessageListener> removed = filteredListeners.removeFilteredListener(null, mockListener3);
+
+        // Check we have expected filters removed
+        assertEquals(3, removed.size());
+        assertTrue(removed.contains(filtered3));
+        assertTrue(removed.contains(filtered4));
+        assertTrue(removed.contains(filtered5));
+
+        // Check what we have left
+        assertEquals(3, filteredListeners.getFilteredListeners().size());
+        assertEquals(filtered1, filteredListeners.getFilteredListeners().get(mockListener1).get(filter2).get(0));
+        assertEquals(filtered2, filteredListeners.getFilteredListeners().get(mockListener2).get(filter2).get(0));
+        assertEquals(filtered6, filteredListeners.getFilteredListeners().get(mockListener4).get(filter1).get(0));
+    }
+
+    @Test
+    public void it_removes_all_listeners_for_listener_and_filter() {
+        MessageFilter filterToBeRemoved = getFilter("this-name-is-important");
+        MessageFilter filterToBeKept = getFilter("this-name-is-not-important");
+
+        FilteredListeners filteredListeners = new FilteredListeners();
+        MockListener mockListener1 = new MockListener();
+        MockListener mockListener2 = new MockListener();
+        MockListener mockListener3 = new MockListener();
+        MockListener mockListener4 = new MockListener();
+
+        // Filtered 1 and 2 are on the "wrong" listener, so shouldn't be touched
+        ChannelBase.MessageListener filtered1 = filteredListeners.addFilteredListener(filterToBeKept, mockListener1);
+        ChannelBase.MessageListener filtered2 = filteredListeners.addFilteredListener(filterToBeKept, mockListener2);
+
+        // Filtered 3-5 are on the same listener, but, only 3 and 4 should be removed as they are on the right filter
+        ChannelBase.MessageListener filtered3 = filteredListeners.addFilteredListener(filterToBeRemoved, mockListener3);
+        ChannelBase.MessageListener filtered4 = filteredListeners.addFilteredListener(filterToBeRemoved, mockListener3);
+        ChannelBase.MessageListener filtered5 = filteredListeners.addFilteredListener(filterToBeKept, mockListener3);
+
+        // Filtered 6 are on the "wrong" listener
+        ChannelBase.MessageListener filtered6 = filteredListeners.addFilteredListener(filterToBeRemoved, mockListener4);
+
+        ArrayList<ChannelBase.MessageListener> removed = filteredListeners.removeFilteredListener(filterToBeRemoved, mockListener3);
+
+        // Check we have expected filters removed
+        assertEquals(2, removed.size());
+        assertTrue(removed.contains(filtered3));
+        assertTrue(removed.contains(filtered4));
+
+        // Check what we have left
+        assertEquals(4, filteredListeners.getFilteredListeners().size());
+        assertEquals(filtered1, filteredListeners.getFilteredListeners().get(mockListener1).get(filterToBeKept).get(0));
+        assertEquals(filtered2, filteredListeners.getFilteredListeners().get(mockListener2).get(filterToBeKept).get(0));
+        assertEquals(filtered6, filteredListeners.getFilteredListeners().get(mockListener4).get(filterToBeRemoved).get(0));
+        assertEquals(1, filteredListeners.getFilteredListeners().get(mockListener3).size());
+        assertEquals(1, filteredListeners.getFilteredListeners().get(mockListener3).get(filterToBeKept).size());
+        assertEquals(filtered5, filteredListeners.getFilteredListeners().get(mockListener3).get(filterToBeKept).get(0));
+    }
+
+    @Test
+    public void it_removes_all_listeners_for_listener_and_filter_and_removes_listener_completely() {
+        MessageFilter filterToBeRemoved = getFilter("this-name-is-important");
+        MessageFilter filterToBeKept = getFilter("this-name-is-not-important");
+
+        FilteredListeners filteredListeners = new FilteredListeners();
+        MockListener mockListener1 = new MockListener();
+        MockListener mockListener2 = new MockListener();
+        MockListener mockListener3 = new MockListener();
+        MockListener mockListener4 = new MockListener();
+
+        // Filtered 1 and 2 are on the "wrong" listener, so shouldn't be touched
+        ChannelBase.MessageListener filtered1 = filteredListeners.addFilteredListener(filterToBeKept, mockListener1);
+        ChannelBase.MessageListener filtered2 = filteredListeners.addFilteredListener(filterToBeKept, mockListener2);
+
+        // Filtered 3 and 4 are on the same listener and should be removed
+        ChannelBase.MessageListener filtered3 = filteredListeners.addFilteredListener(filterToBeRemoved, mockListener3);
+        ChannelBase.MessageListener filtered4 = filteredListeners.addFilteredListener(filterToBeRemoved, mockListener3);
+
+        // Filtered 5 are on the "wrong" listener
+        ChannelBase.MessageListener filtered5 = filteredListeners.addFilteredListener(filterToBeRemoved, mockListener4);
+
+        ArrayList<ChannelBase.MessageListener> removed = filteredListeners.removeFilteredListener(filterToBeRemoved, mockListener3);
+
+        // Check we have expected filters removed
+        assertEquals(2, removed.size());
+        assertTrue(removed.contains(filtered3));
+        assertTrue(removed.contains(filtered4));
+
+        // Check what we have left
+        assertEquals(3, filteredListeners.getFilteredListeners().size());
+        assertEquals(filtered1, filteredListeners.getFilteredListeners().get(mockListener1).get(filterToBeKept).get(0));
+        assertEquals(filtered2, filteredListeners.getFilteredListeners().get(mockListener2).get(filterToBeKept).get(0));
+        assertEquals(filtered5, filteredListeners.getFilteredListeners().get(mockListener4).get(filterToBeRemoved).get(0));
+        assertFalse(filteredListeners.getFilteredListeners().containsKey(mockListener3));
+    }
+
+    @Test
+    public void it_handles_removing_non_existent_listener() {
+        FilteredListeners filteredListeners = new FilteredListeners();
+        MockListener mockListener1 = new MockListener();
+
+        ArrayList<ChannelBase.MessageListener> removed = filteredListeners.removeFilteredListener(null, mockListener1);
+        assertTrue(removed.isEmpty());
+    }
+
+    @Test
+    public void it_clears_listeners() {
+        MessageFilter filterToBeRemoved = getFilter("this-name-is-important");
+        MessageFilter filterToBeKept = getFilter("this-name-is-not-important");
+
+        FilteredListeners filteredListeners = new FilteredListeners();
+        MockListener mockListener1 = new MockListener();
+        MockListener mockListener2 = new MockListener();
+        MockListener mockListener3 = new MockListener();
+        MockListener mockListener4 = new MockListener();
+
+        filteredListeners.addFilteredListener(filterToBeKept, mockListener1);
+        filteredListeners.addFilteredListener(filterToBeKept, mockListener2);
+        filteredListeners.addFilteredListener(filterToBeRemoved, mockListener3);
+        filteredListeners.addFilteredListener(filterToBeRemoved, mockListener3);
+        filteredListeners.addFilteredListener(filterToBeRemoved, mockListener4);
+
+        filteredListeners.clear();
+        assertTrue(filteredListeners.getFilteredListeners().isEmpty());
+    }
+}

--- a/lib/src/test/java/io/ably/lib/realtime/MessageExtrasFilterTest.java
+++ b/lib/src/test/java/io/ably/lib/realtime/MessageExtrasFilterTest.java
@@ -20,9 +20,16 @@ public class MessageExtrasFilterTest {
         );
     }
 
-    private MessageExtrasFilter createFilter(Boolean isRef, String refTimeSerial, String refType, String name, String clientId)
+    private MessageExtrasFilter createFilter(Boolean isRef, String refTimeserial, String refType, String name, String clientId)
     {
-        return new MessageExtrasFilter(new MessageFilter(isRef, refTimeSerial, refType, name, clientId));
+        MessageFilter filter = new MessageFilter();
+        filter.isRef = isRef;
+        filter.refTimeserial = refTimeserial;
+        filter.refType = refType;
+        filter.name = name;
+        filter.clientId = clientId;
+
+        return new MessageExtrasFilter(filter);
     }
 
     @Test

--- a/lib/src/test/java/io/ably/lib/realtime/MessageExtrasFilterTest.java
+++ b/lib/src/test/java/io/ably/lib/realtime/MessageExtrasFilterTest.java
@@ -16,27 +16,13 @@ public class MessageExtrasFilterTest {
             name,
             new Object(), // Fake data
             clientId,
-            new MessageExtras(JsonParser.parseString(String.valueOf(extrasJson)).getAsJsonObject())
+            extrasJson == null ? null : new MessageExtras(JsonParser.parseString(extrasJson).getAsJsonObject())
         );
     }
 
     private MessageExtrasFilter createFilter(Boolean isRef, String refTimeSerial, String refType, String name, String clientId)
     {
         return new MessageExtrasFilter(new MessageFilter(isRef, refTimeSerial, refType, name, clientId));
-    }
-
-    @Test
-    public void it_fails_on_no_message_extras()
-    {
-        MessageExtrasFilter filter = createFilter(false, null, null, "name", "clientId");
-        Message message = new Message(
-            "name",
-            new Object(), // Fake data
-            "clientId",
-            null
-        );
-
-        assertFalse(filter.onMessage(message));
     }
 
     @Test
@@ -131,6 +117,19 @@ public class MessageExtrasFilterTest {
     }
 
     @Test
+    public void it_passes_on_clientId_no_extras()
+    {
+        MessageExtrasFilter filter = createFilter(null, null, null, null, "clientId");
+        Message message = createMessage(
+            null,
+            "name",
+            "clientId"
+        );
+
+        assertTrue(filter.onMessage(message));
+    }
+
+    @Test
     public void it_fails_on_clientId_mismatch()
     {
         MessageExtrasFilter filter = createFilter(null, null, null, null, "clientId");
@@ -149,6 +148,19 @@ public class MessageExtrasFilterTest {
         MessageExtrasFilter filter = createFilter(null, null, null, "name", null);
         Message message = createMessage(
             "{\"ref\": {\"type\": \"refType\", \"timeserial\": \"refTimeserial\"}}",
+            "name",
+            "clientId"
+        );
+
+        assertTrue(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_passes_on_name_match_no_extras()
+    {
+        MessageExtrasFilter filter = createFilter(null, null, null, "name", null);
+        Message message = createMessage(
+            null,
             "name",
             "clientId"
         );
@@ -209,7 +221,20 @@ public class MessageExtrasFilterTest {
     }
 
     @Test
-    public void it_fails_on_is_ref_mismatch_without_timeserial()
+    public void it_fails_on_is_ref_match_no_extras()
+    {
+        MessageExtrasFilter filter = createFilter(true, null, null, null, null);
+        Message message = createMessage(
+            null,
+            "name",
+            "clientId"
+        );
+
+        assertFalse(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_fails_on_is_ref_mismatch()
     {
         MessageExtrasFilter filter = createFilter(false, null, null, null, null);
         Message message = createMessage(
@@ -274,6 +299,19 @@ public class MessageExtrasFilterTest {
     }
 
     @Test
+    public void it_fails_on_is_refTimeserial_no_extras()
+    {
+        MessageExtrasFilter filter = createFilter(null, "refTimeserial", null, null, null);
+        Message message = createMessage(
+            null,
+            "name",
+            "clientId"
+        );
+
+        assertFalse(filter.onMessage(message));
+    }
+
+    @Test
     public void it_passes_on_refType_match()
     {
         MessageExtrasFilter filter = createFilter(null, null, "refType", null, null);
@@ -318,6 +356,19 @@ public class MessageExtrasFilterTest {
         MessageExtrasFilter filter = createFilter(null, null, "refType", null, null);
         Message message = createMessage(
             "{}",
+            "name",
+            "clientId"
+        );
+
+        assertFalse(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_fails_on_is_refType_no_extras()
+    {
+        MessageExtrasFilter filter = createFilter(null, null, "refType", null, null);
+        Message message = createMessage(
+            null,
             "name",
             "clientId"
         );

--- a/lib/src/test/java/io/ably/lib/realtime/MessageExtrasFilterTest.java
+++ b/lib/src/test/java/io/ably/lib/realtime/MessageExtrasFilterTest.java
@@ -1,0 +1,340 @@
+package io.ably.lib.realtime;
+
+import com.google.gson.JsonParser;
+import io.ably.lib.types.Message;
+import io.ably.lib.types.MessageExtras;
+import io.ably.lib.types.MessageFilter;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MessageExtrasFilterTest {
+    private Message createMessage(String extrasJson, String name, String clientId)
+    {
+        return new Message(
+            name,
+            new Object(), // Fake data
+            clientId,
+            new MessageExtras(JsonParser.parseString(String.valueOf(extrasJson)).getAsJsonObject())
+        );
+    }
+
+    private MessageExtrasFilter createFilter(Boolean isRef, String refTimeSerial, String refType, String name, String clientId)
+    {
+        return new MessageExtrasFilter(new MessageFilter(isRef, refTimeSerial, refType, name, clientId));
+    }
+
+    @Test
+    public void it_fails_on_no_message_extras()
+    {
+        MessageExtrasFilter filter = createFilter(false, null, null, "name", "clientId");
+        Message message = new Message(
+            "name",
+            new Object(), // Fake data
+            "clientId",
+            null
+        );
+
+        assertFalse(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_passes_on_all_fields_matching()
+    {
+        MessageExtrasFilter filter = createFilter(true, "refTimeserial", "refType", "name", "clientId");
+        Message message = createMessage(
+            "{\"ref\": {\"type\": \"refType\", \"timeserial\": \"refTimeserial\"}}",
+            "name",
+            "clientId"
+        );
+
+        assertTrue(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_passes_with_no_clientId_filter()
+    {
+        MessageExtrasFilter filter = createFilter(true, "refTimeserial", "refType", "name", null);
+        Message message = createMessage(
+            "{\"ref\": {\"type\": \"refType\", \"timeserial\": \"refTimeserial\"}}",
+            "name",
+            "clientId"
+        );
+
+        assertTrue(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_passes_with_no_name_filter()
+    {
+        MessageExtrasFilter filter = createFilter(true, "refTimeserial", "refType", null, "clientId");
+        Message message = createMessage(
+            "{\"ref\": {\"type\": \"refType\", \"timeserial\": \"refTimeserial\"}}",
+            "name",
+            "clientId"
+        );
+
+        assertTrue(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_passes_with_no_isRef_filter()
+    {
+        MessageExtrasFilter filter = createFilter(null, "refTimeserial", "refType", "name", "clientId");
+        Message message = createMessage(
+            "{\"ref\": {\"type\": \"refType\", \"timeserial\": \"refTimeserial\"}}",
+            "name",
+            "clientId"
+        );
+
+        assertTrue(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_passes_with_no_refType_filter()
+    {
+        MessageExtrasFilter filter = createFilter(true, "refTimeserial", null, "name", "clientId");
+        Message message = createMessage(
+            "{\"ref\": {\"type\": \"refType\", \"timeserial\": \"refTimeserial\"}}",
+            "name",
+            "clientId"
+        );
+
+        assertTrue(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_passes_with_no_refTimeserial_filter()
+    {
+        MessageExtrasFilter filter = createFilter(true, null, "refType", "name", "clientId");
+        Message message = createMessage(
+            "{\"ref\": {\"type\": \"refType\", \"timeserial\": \"refTimeserial\"}}",
+            "name",
+            "clientId"
+        );
+
+        assertTrue(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_passes_on_clientId_match()
+    {
+        MessageExtrasFilter filter = createFilter(null, null, null, null, "clientId");
+        Message message = createMessage(
+            "{\"ref\": {\"type\": \"refType\", \"timeserial\": \"refTimeserial\"}}",
+            "name",
+            "clientId"
+        );
+
+        assertTrue(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_fails_on_clientId_mismatch()
+    {
+        MessageExtrasFilter filter = createFilter(null, null, null, null, "clientId");
+        Message message = createMessage(
+            "{\"ref\": {\"type\": \"refType\", \"timeserial\": \"refTimeserial\"}}",
+            "name",
+            "clientId2"
+        );
+
+        assertFalse(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_passes_on_name_match()
+    {
+        MessageExtrasFilter filter = createFilter(null, null, null, "name", null);
+        Message message = createMessage(
+            "{\"ref\": {\"type\": \"refType\", \"timeserial\": \"refTimeserial\"}}",
+            "name",
+            "clientId"
+        );
+
+        assertTrue(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_fails_on_name_mismatch()
+    {
+        MessageExtrasFilter filter = createFilter(null, null, null, "name", null);
+        Message message = createMessage(
+            "{\"ref\": {\"type\": \"refType\", \"timeserial\": \"refTimeserial\"}}",
+            "name2",
+            "clientId"
+        );
+
+        assertFalse(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_passes_on_is_ref_match_with_timeserial()
+    {
+        MessageExtrasFilter filter = createFilter(true, null, null, null, null);
+        Message message = createMessage(
+            "{\"ref\": {\"type\": \"refType\", \"timeserial\": \"refTimeserial\"}}",
+            "name",
+            "clientId"
+        );
+
+        assertTrue(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_passes_on_is_ref_match_without_timeserial()
+    {
+        MessageExtrasFilter filter = createFilter(false, null, null, null, null);
+        Message message = createMessage(
+            "{}",
+            "name",
+            "clientId"
+        );
+
+        assertTrue(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_fails_on_is_ref_match_with_timeserial()
+    {
+        MessageExtrasFilter filter = createFilter(true, null, null, null, null);
+        Message message = createMessage(
+            "{}",
+            "name",
+            "clientId"
+        );
+
+        assertFalse(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_fails_on_is_ref_mismatch_without_timeserial()
+    {
+        MessageExtrasFilter filter = createFilter(false, null, null, null, null);
+        Message message = createMessage(
+            "{\"ref\": {\"type\": \"refType\", \"timeserial\": \"refTimeserial\"}}",
+            "name",
+            "clientId"
+        );
+
+        assertFalse(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_passes_on_refTimeserial_match()
+    {
+        MessageExtrasFilter filter = createFilter(null, "refTimeserial", null, null, null);
+        Message message = createMessage(
+            "{\"ref\": {\"type\": \"refType\", \"timeserial\": \"refTimeserial\"}}",
+            "name",
+            "clientId"
+        );
+
+        assertTrue(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_fails_on_refTimeserial_mismatch()
+    {
+        MessageExtrasFilter filter = createFilter(null, "refTimeserial", null, null, null);
+        Message message = createMessage(
+            "{\"ref\": {\"type\": \"refType\", \"timeserial\": \"refTimeserial2\"}}",
+            "name",
+            "clientId"
+        );
+
+        assertFalse(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_fails_on_refTimeserial_mismatch_no_timeserial()
+    {
+        MessageExtrasFilter filter = createFilter(null, "refTimeserial", null, null, null);
+        Message message = createMessage(
+            "{\"ref\": {\"type\": \"refType\"}}",
+            "name",
+            "clientId"
+        );
+
+        assertFalse(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_fails_on_is_refTimeserial_no_ref()
+    {
+        MessageExtrasFilter filter = createFilter(null, "refTimeserial", null, null, null);
+        Message message = createMessage(
+            "{}",
+            "name",
+            "clientId"
+        );
+
+        assertFalse(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_passes_on_refType_match()
+    {
+        MessageExtrasFilter filter = createFilter(null, null, "refType", null, null);
+        Message message = createMessage(
+            "{\"ref\": {\"type\": \"refType\", \"timeserial\": \"refTimeserial\"}}",
+            "name",
+            "clientId"
+        );
+
+        assertTrue(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_fails_on_refType_mismatch()
+    {
+        MessageExtrasFilter filter = createFilter(null, null, "refType2", null, null);
+        Message message = createMessage(
+            "{\"ref\": {\"type\": \"refType\", \"timeserial\": \"refTimeserial\"}}",
+            "name",
+            "clientId"
+        );
+
+        assertFalse(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_fails_on_refType_mismatch_no_refType()
+    {
+        MessageExtrasFilter filter = createFilter(null, null, "refType", null, null);
+        Message message = createMessage(
+            "{\"timeserial\": \"refTimeserial\"}",
+            "name",
+            "clientId"
+        );
+
+        assertFalse(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_fails_on_is_refType_no_ref()
+    {
+        MessageExtrasFilter filter = createFilter(null, null, "refType", null, null);
+        Message message = createMessage(
+            "{}",
+            "name",
+            "clientId"
+        );
+
+        assertFalse(filter.onMessage(message));
+    }
+
+    @Test
+    public void it_passes_on_empty_filter()
+    {
+        MessageExtrasFilter filter = createFilter(null, null, null, null, null);
+        Message message = createMessage(
+            "{}",
+            "name",
+            "clientId"
+        );
+
+        assertTrue(filter.onMessage(message));
+    }
+}

--- a/lib/src/test/java/io/ably/lib/test/common/Helpers.java
+++ b/lib/src/test/java/io/ably/lib/test/common/Helpers.java
@@ -44,6 +44,7 @@ import io.ably.lib.types.Callback;
 import io.ably.lib.types.ErrorInfo;
 import io.ably.lib.types.ErrorResponse;
 import io.ably.lib.types.Message;
+import io.ably.lib.types.MessageFilter;
 import io.ably.lib.types.PresenceMessage;
 import io.ably.lib.types.ProtocolMessage;
 import io.ably.lib.types.ProtocolMessage.Action;
@@ -254,6 +255,17 @@ public class Helpers {
             reset();
             try {
                 channel.subscribe(event, this);
+            } catch(AblyException e) {}
+        }
+
+        /**
+         * Track all messages on a channel, with a filter.
+         * @param channel
+         */
+        public MessageWaiter(Channel channel, MessageFilter filter) {
+            reset();
+            try {
+                channel.subscribe(filter, this);
             } catch(AblyException e) {}
         }
 

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -2059,7 +2059,10 @@ public class RealtimeChannelTest extends ParameterizedTest {
             // Create two channel subscribers, one with a filter and one without
             subscriber = new AblyRealtime(opts);
             Channel subscribeChannel = subscriber.channels.get(channelName);
-            MessageFilter filter = new MessageFilter(null, null, null, "event-name", null);
+
+            MessageFilter filter = new MessageFilter();
+            filter.name = "event-name";
+
             Helpers.MessageWaiter filteredWaiter = new Helpers.MessageWaiter(subscribeChannel, filter);
             Helpers.MessageWaiter unfilteredWaiter = new Helpers.MessageWaiter(subscribeChannel);
 

--- a/lib/src/test/java/io/ably/lib/types/MessageFilterTest.java
+++ b/lib/src/test/java/io/ably/lib/types/MessageFilterTest.java
@@ -1,35 +1,24 @@
 package io.ably.lib.types;
-import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
 
 public class MessageFilterTest {
 
-    /**
-     * Spec: MFI1, MFI2
-     */
-    @Test
-    public void it_sets_parameters() {
+    private MessageFilter createMessageFilter(boolean isRef, String refTimeserial, String refType, String name, String clientId) {
+        MessageFilter filter = new MessageFilter();
+        filter.isRef = isRef;
+        filter.refTimeserial = refTimeserial;
+        filter.refType = refType;
+        filter.name = name;
+        filter.clientId = clientId;
 
-        final MessageFilter filter = new MessageFilter(
-            true,
-            "message_timeserial",
-            "message_type",
-            "message_name",
-            "message_client_id"
-        );
-
-        assertTrue(filter.isRef);
-        assertEquals("message_timeserial", filter.refTimeSerial);
-        assertEquals("message_type", filter.refType);
-        assertEquals("message_name", filter.name);
-        assertEquals("message_client_id", filter.clientId);
+        return filter;
     }
 
     public void it_is_equal_to_itself() {
 
-        final MessageFilter filter1 = new MessageFilter(
+        final MessageFilter filter1 = createMessageFilter(
             true,
             "message_timeserial",
             "message_type",
@@ -42,7 +31,7 @@ public class MessageFilterTest {
 
     public void it_is_equal() {
 
-        final MessageFilter filter1 = new MessageFilter(
+        final MessageFilter filter1 = createMessageFilter(
             true,
             "message_timeserial",
             "message_type",
@@ -50,7 +39,7 @@ public class MessageFilterTest {
             "message_client_id"
         );
 
-        final MessageFilter filter2 = new MessageFilter(
+        final MessageFilter filter2 = createMessageFilter(
             true,
             "message_timeserial",
             "message_type",
@@ -63,7 +52,7 @@ public class MessageFilterTest {
 
     public void it_is_not_equal_different_is_ref() {
 
-        final MessageFilter filter1 = new MessageFilter(
+        final MessageFilter filter1 = createMessageFilter(
             true,
             "message_timeserial",
             "message_type",
@@ -71,7 +60,7 @@ public class MessageFilterTest {
             "message_client_id"
         );
 
-        final MessageFilter filter2 = new MessageFilter(
+        final MessageFilter filter2 = createMessageFilter(
             false,
             "message_timeserial",
             "message_type",
@@ -84,7 +73,7 @@ public class MessageFilterTest {
 
     public void it_is_not_equal_different_timeserial() {
 
-        final MessageFilter filter1 = new MessageFilter(
+        final MessageFilter filter1 = createMessageFilter(
             true,
             "message_timeserial",
             "message_type",
@@ -92,7 +81,7 @@ public class MessageFilterTest {
             "message_client_id"
         );
 
-        final MessageFilter filter2 = new MessageFilter(
+        final MessageFilter filter2 = createMessageFilter(
             true,
             "message_timeserial_2",
             "message_type",
@@ -105,7 +94,7 @@ public class MessageFilterTest {
 
     public void it_is_not_equal_different_type() {
 
-        final MessageFilter filter1 = new MessageFilter(
+        final MessageFilter filter1 = createMessageFilter(
             true,
             "message_timeserial",
             "message_type",
@@ -113,7 +102,7 @@ public class MessageFilterTest {
             "message_client_id"
         );
 
-        final MessageFilter filter2 = new MessageFilter(
+        final MessageFilter filter2 = createMessageFilter(
             true,
             "message_timeserial",
             "message_type_2",
@@ -126,7 +115,7 @@ public class MessageFilterTest {
 
     public void it_is_not_equal_different_name() {
 
-        final MessageFilter filter1 = new MessageFilter(
+        final MessageFilter filter1 = createMessageFilter(
             true,
             "message_timeserial",
             "message_type",
@@ -134,7 +123,7 @@ public class MessageFilterTest {
             "message_client_id"
         );
 
-        final MessageFilter filter2 = new MessageFilter(
+        final MessageFilter filter2 = createMessageFilter(
             true,
             "message_timeserial",
             "message_type",
@@ -147,7 +136,7 @@ public class MessageFilterTest {
 
     public void it_is_not_equal_different_client_id() {
 
-        final MessageFilter filter1 = new MessageFilter(
+        final MessageFilter filter1 = createMessageFilter(
             true,
             "message_timeserial",
             "message_type",
@@ -155,7 +144,7 @@ public class MessageFilterTest {
             "message_client_id"
         );
 
-        final MessageFilter filter2 = new MessageFilter(
+        final MessageFilter filter2 = createMessageFilter(
             true,
             "message_timeserial",
             "message_type",

--- a/lib/src/test/java/io/ably/lib/types/MessageFilterTest.java
+++ b/lib/src/test/java/io/ably/lib/types/MessageFilterTest.java
@@ -1,6 +1,8 @@
 package io.ably.lib.types;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public class MessageFilterTest {
 
@@ -23,5 +25,144 @@ public class MessageFilterTest {
         assertEquals("message_type", filter.refType);
         assertEquals("message_name", filter.name);
         assertEquals("message_client_id", filter.clientId);
+    }
+
+    public void it_is_equal_to_itself() {
+
+        final MessageFilter filter1 = new MessageFilter(
+            true,
+            "message_timeserial",
+            "message_type",
+            "message_name",
+            "message_client_id"
+        );
+
+        assertEquals(filter1, filter1);
+    }
+
+    public void it_is_equal() {
+
+        final MessageFilter filter1 = new MessageFilter(
+            true,
+            "message_timeserial",
+            "message_type",
+            "message_name",
+            "message_client_id"
+        );
+
+        final MessageFilter filter2 = new MessageFilter(
+            true,
+            "message_timeserial",
+            "message_type",
+            "message_name",
+            "message_client_id"
+        );
+
+        assertEquals(filter1, filter2);
+    }
+
+    public void it_is_not_equal_different_is_ref() {
+
+        final MessageFilter filter1 = new MessageFilter(
+            true,
+            "message_timeserial",
+            "message_type",
+            "message_name",
+            "message_client_id"
+        );
+
+        final MessageFilter filter2 = new MessageFilter(
+            false,
+            "message_timeserial",
+            "message_type",
+            "message_name",
+            "message_client_id"
+        );
+
+        assertNotEquals(filter1, filter2);
+    }
+
+    public void it_is_not_equal_different_timeserial() {
+
+        final MessageFilter filter1 = new MessageFilter(
+            true,
+            "message_timeserial",
+            "message_type",
+            "message_name",
+            "message_client_id"
+        );
+
+        final MessageFilter filter2 = new MessageFilter(
+            true,
+            "message_timeserial_2",
+            "message_type",
+            "message_name",
+            "message_client_id"
+        );
+
+        assertNotEquals(filter1, filter2);
+    }
+
+    public void it_is_not_equal_different_type() {
+
+        final MessageFilter filter1 = new MessageFilter(
+            true,
+            "message_timeserial",
+            "message_type",
+            "message_name",
+            "message_client_id"
+        );
+
+        final MessageFilter filter2 = new MessageFilter(
+            true,
+            "message_timeserial",
+            "message_type_2",
+            "message_name",
+            "message_client_id"
+        );
+
+        assertNotEquals(filter1, filter2);
+    }
+
+    public void it_is_not_equal_different_name() {
+
+        final MessageFilter filter1 = new MessageFilter(
+            true,
+            "message_timeserial",
+            "message_type",
+            "message_name",
+            "message_client_id"
+        );
+
+        final MessageFilter filter2 = new MessageFilter(
+            true,
+            "message_timeserial",
+            "message_type",
+            "message_name_2",
+            "message_client_id"
+        );
+
+        assertNotEquals(filter1, filter2);
+    }
+
+    public void it_is_not_equal_different_client_id() {
+
+        final MessageFilter filter1 = new MessageFilter(
+            true,
+            "message_timeserial",
+            "message_type",
+            "message_name",
+            "message_client_id"
+        );
+
+        final MessageFilter filter2 = new MessageFilter(
+            true,
+            "message_timeserial",
+            "message_type",
+            "message_name",
+            "message_client_id_2"
+        );
+
+        assertNotEquals(filter1, filter2);
     }
 }

--- a/lib/src/test/java/io/ably/lib/types/MessageFilterTest.java
+++ b/lib/src/test/java/io/ably/lib/types/MessageFilterTest.java
@@ -1,0 +1,27 @@
+package io.ably.lib.types;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class MessageFilterTest {
+
+    /**
+     * Spec: MFI1, MFI2
+     */
+    @Test
+    public void it_sets_parameters() {
+
+        final MessageFilter filter = new MessageFilter(
+            true,
+            "message_timeserial",
+            "message_type",
+            "message_name",
+            "message_client_id"
+        );
+
+        assertTrue(filter.isRef);
+        assertEquals("message_timeserial", filter.refTimeSerial);
+        assertEquals("message_type", filter.refType);
+        assertEquals("message_name", filter.name);
+        assertEquals("message_client_id", filter.clientId);
+    }
+}


### PR DESCRIPTION
This change implements the "subscription" aspect of the message interactions feature.

JIRA links:

- Epic: https://ably.atlassian.net/browse/CON-6
- Story: https://ably.atlassian.net/browse/CON-2

Spec points:

- RTL22
- MFI1
- MFI2

It contains the following changes:

- Introduction of the "MessageFilter" class as per MFI1/2. This allows the user to create and customise the filters they wish to apply to messages. The implementation is aimed to be idiomatic to how `ClientOptions` is instantiated in the library.
- Introduction of a class (MessageExtrasFilter) that is responsible for applying the above filter settings given a message.
- A manager class for MessageListeners that are "filtered" by the client - for management of listeners separate to the main channel object.
- Addition of additional `subscribe` and `unsubscribe` overloads to ChannelBase to provide the necessary methods for users to use the new filters, as per RTL22.
- README examples of publishing and subscribing to message interactions.

To test:

- Create an instance of `MessageFilter` and specify whatever filters you'd like to use
- Subscribe to a channel with that filter
- Publish messages to the channel that match your filter, they should be received by your subscriber
- Publish messages to the channel that do not match your filter, they should not be received by the connection (ie onMessage will be called), but not passed on to your subscriber.

Filters that can be tested:

- Whether the event "name" matches that of the filter
- Whether the publishing "clientId" matches that of the filter
- Whether (or not) the message references another
- Whether the referenced message timeserial matches the filter
- Whether the reference type matches the filter

JS implementation for reference:

https://github.com/ably/ably-js/pull/1003