### PR TITLE
fix: do not clear ably client on reset

### DIFF
--- a/android/src/main/java/io/ably/lib/push/ActivationContext.java
+++ b/android/src/main/java/io/ably/lib/push/ActivationContext.java
@@ -116,8 +116,6 @@ public class ActivationContext {
     public void reset() {
         Log.v(TAG, "reset()");
 
-        ably = null;
-
         getActivationStateMachine().reset();
         activationStateMachine = null;
 


### PR DESCRIPTION
Looks like it unnecessary to delete ably client on reset, it breaks push logic