### PR TITLE
fix: create Cipher instance in place, do not store it in `ChannelOptions`

### DIFF
--- a/lib/src/main/java/io/ably/lib/rest/DeviceDetails.java
+++ b/lib/src/main/java/io/ably/lib/rest/DeviceDetails.java
@@ -142,6 +142,9 @@ public class DeviceDetails {
         thisJson.remove("deviceSecret");
         otherJson.remove("deviceSecret");
 
+        normalizeRecipientField(thisJson);
+        normalizeRecipientField(otherJson);
+
         if ((this.metadata == null || this.metadata.entrySet().isEmpty()) && (other.metadata == null || other.metadata.entrySet().isEmpty())) {
             // Empty metadata == null metadata.
             thisJson.remove("metadata");
@@ -170,4 +173,20 @@ public class DeviceDetails {
     public static HttpCore.ResponseHandler<DeviceDetails> httpResponseHandler = new Serialisation.HttpResponseHandler<DeviceDetails>(DeviceDetails.class, fromJsonElement);
 
     public static HttpCore.BodyHandler<DeviceDetails> httpBodyHandler = new Serialisation.HttpBodyHandler<DeviceDetails>(DeviceDetails[].class, fromJsonElement);
+
+    /**
+     * Push recipient can contain some additional field, but `transportType`, `deviceToken`, `registrationToken` only matters for equals
+     */
+    private static void normalizeRecipientField(JsonObject deviceDetailsJson) {
+        JsonElement push = deviceDetailsJson.get("push");
+        if (push == null) return;
+        JsonElement recipient = push.getAsJsonObject().get("recipient");
+        if (recipient == null) return;
+        JsonObject normalizedRecipient = JsonUtils.object()
+                .add("transportType", recipient.getAsJsonObject().get("transportType"))
+                .add("deviceToken", recipient.getAsJsonObject().get("deviceToken"))
+                .add("registrationToken", recipient.getAsJsonObject().get("registrationToken"))
+                .toJson();
+        push.getAsJsonObject().add("recipient", normalizedRecipient);
+    }
 }

--- a/lib/src/main/java/io/ably/lib/types/BaseMessage.java
+++ b/lib/src/main/java/io/ably/lib/types/BaseMessage.java
@@ -147,7 +147,7 @@ public class BaseMessage implements Cloneable {
                         case "cipher":
                             if(opts != null && opts.encrypted) {
                                 try {
-                                    DecryptingChannelCipher cipher = Crypto.createChannelDecipher(opts);
+                                    DecryptingChannelCipher cipher = Crypto.createChannelDecipher(opts.getCipherParamsOrDefault());
                                     data = cipher.decrypt((byte[]) data);
                                 } catch(AblyException e) {
                                     throw MessageDecodeException.fromDescription(e.errorInfo.message);
@@ -196,7 +196,7 @@ public class BaseMessage implements Cloneable {
             }
         }
         if (opts != null && opts.encrypted) {
-            EncryptingChannelCipher cipher = Crypto.createChannelEncipher(opts);
+            EncryptingChannelCipher cipher = Crypto.createChannelEncipher(opts.getCipherParamsOrDefault());
             data = cipher.encrypt((byte[]) data);
             encoding = ((encoding == null) ? "" : encoding + "/") + "cipher+" + cipher.getAlgorithm();
         }

--- a/lib/src/main/java/io/ably/lib/types/BaseMessage.java
+++ b/lib/src/main/java/io/ably/lib/types/BaseMessage.java
@@ -8,7 +8,9 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import io.ably.lib.util.Base64Coder;
+import io.ably.lib.util.Crypto;
 import io.ably.lib.util.Crypto.EncryptingChannelCipher;
+import io.ably.lib.util.Crypto.DecryptingChannelCipher;
 import io.ably.lib.util.Log;
 import io.ably.lib.util.Serialisation;
 import org.msgpack.core.MessageFormat;
@@ -145,7 +147,8 @@ public class BaseMessage implements Cloneable {
                         case "cipher":
                             if(opts != null && opts.encrypted) {
                                 try {
-                                    data = opts.getCipherSet().getDecipher().decrypt((byte[]) data);
+                                    DecryptingChannelCipher cipher = Crypto.createChannelDecipher(opts);
+                                    data = cipher.decrypt((byte[]) data);
                                 } catch(AblyException e) {
                                     throw MessageDecodeException.fromDescription(e.errorInfo.message);
                                 }
@@ -193,7 +196,7 @@ public class BaseMessage implements Cloneable {
             }
         }
         if (opts != null && opts.encrypted) {
-            EncryptingChannelCipher cipher = opts.getCipherSet().getEncipher();
+            EncryptingChannelCipher cipher = Crypto.createChannelEncipher(opts);
             data = cipher.encrypt((byte[]) data);
             encoding = ((encoding == null) ? "" : encoding + "/") + "cipher+" + cipher.getAlgorithm();
         }

--- a/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import io.ably.lib.util.Base64Coder;
 import io.ably.lib.util.Crypto;
+import io.ably.lib.util.Crypto.CipherParams;
 
 /**
  * Passes additional properties to a {@link io.ably.lib.rest.Channel} or {@link io.ably.lib.realtime.Channel} object,
@@ -104,5 +105,16 @@ public class ChannelOptions {
      */
     public static ChannelOptions withCipherKey(String base64Key) throws AblyException {
         return withCipherKey(Base64Coder.decode(base64Key));
+    }
+
+    /**
+     * Internal; returns cipher params or generate default
+     */
+    public synchronized CipherParams getCipherParamsOrDefault() throws AblyException {
+        CipherParams params = Crypto.checkCipherParams(this.cipherParams);
+        if (this.cipherParams == null) {
+            this.cipherParams = params;
+        }
+        return params;
     }
 }

--- a/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
@@ -4,8 +4,6 @@ import java.util.Map;
 
 import io.ably.lib.util.Base64Coder;
 import io.ably.lib.util.Crypto;
-import io.ably.lib.util.Crypto.ChannelCipher;
-import io.ably.lib.util.Crypto.ChannelCipherSet;
 
 /**
  * Passes additional properties to a {@link io.ably.lib.rest.Channel} or {@link io.ably.lib.realtime.Channel} object,
@@ -26,8 +24,6 @@ public class ChannelOptions {
      * Spec: TB2d
      */
     public ChannelMode[] modes;
-
-    private ChannelCipherSet cipherSet;
 
     /**
      * Requests encryption for this channel when not null,
@@ -57,58 +53,6 @@ public class ChannelOptions {
             flags |= mode.getMask();
         }
         return flags;
-    }
-
-    /**
-     * Returns a wrapper around the cipher set to be used for this channel. This wrapper is only available in this API
-     * to support customers who may have been using it in their applications with version 1.2.10 or before.
-     *
-     * @deprecated Since version 1.2.11, this method (which was only ever intended for internal use within this library
-     * has been replaced by {@link #getCipherSet()}. It will be removed in the future.
-     */
-    @Deprecated
-    public ChannelCipher getCipher() throws AblyException {
-        return new ChannelCipher() {
-            @Override
-            public byte[] encrypt(byte[] plaintext) throws AblyException {
-                return getCipherSet().getEncipher().encrypt(plaintext);
-            }
-
-            @Override
-            public byte[] decrypt(byte[] ciphertext) throws AblyException {
-                return getCipherSet().getDecipher().decrypt(ciphertext);
-            }
-
-            @Override
-            public String getAlgorithm() {
-                try {
-                    return getCipherSet().getEncipher().getAlgorithm();
-                } catch (final AblyException e) {
-                    throw new IllegalStateException("Unexpected exception when using legacy crypto cipher interface.", e);
-                }
-            }
-        };
-    }
-
-    /**
-     * Internal; this method is not intended for use by application developers. It may be changed or removed in future.
-     *
-     * Returns the cipher set to be used for encrypting and decrypting data on a channel, given the current state of
-     * this instance. On the first call to this method a new cipher set instance is created, with subsequent callers to
-     * this method being returned that same cipher set instance. This method is safe to be called from any thread.
-     *
-     * @apiNote Once this method has been called then the cipher set is fixed based on the value of the
-     * {@link #cipherParams} field at that time. If that field is then mutated, the cipher set will not be updated.
-     * This is not great API design and we should fix this under https://github.com/ably/ably-java/issues/745
-     */
-    public synchronized ChannelCipherSet getCipherSet() throws AblyException {
-        if (!encrypted) {
-            throw new IllegalStateException("ChannelOptions encrypted field value is false.");
-        }
-        if (null == cipherSet) {
-            cipherSet = Crypto.createChannelCipherSet(cipherParams);
-        }
-        return cipherSet;
     }
 
     /**

--- a/lib/src/main/java/io/ably/lib/util/Crypto.java
+++ b/lib/src/main/java/io/ably/lib/util/Crypto.java
@@ -6,7 +6,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.ConcurrentModificationException;
 import java.util.Locale;
-import java.util.concurrent.Semaphore;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
@@ -177,22 +176,6 @@ public class Crypto {
     }
 
     /**
-     * Interface for a ChannelCipher instance that may be associated with a Channel.
-     *
-     * The operational methods implemented by channel cipher instances (encrypt and decrypt) are not designed to be
-     * safe to be called from any thread.
-     *
-     * @deprecated Since version 1.2.11, this interface (which was only ever intended for internal use within this
-     * library) has been replaced by {@link ChannelCipherSet}. It will be removed in the future.
-     */
-    @Deprecated
-    public interface ChannelCipher {
-        byte[] encrypt(byte[] plaintext) throws AblyException;
-        byte[] decrypt(byte[] ciphertext) throws AblyException;
-        String getAlgorithm();
-    }
-
-    /**
      * Internal; a cipher used to encrypt plaintext to ciphertext, for a channel.
      */
     public interface EncryptingChannelCipher {
@@ -227,40 +210,27 @@ public class Crypto {
     }
 
     /**
-     * Internal; a matching encipher and decipher pair, where both are guaranteed to have been configured with the same
-     * {@link CipherParams} as each other.
+     * Internal; get an encrypting cipher instance based on the given channel options.
      */
-    public interface ChannelCipherSet {
-        EncryptingChannelCipher getEncipher();
-        DecryptingChannelCipher getDecipher();
+    public static EncryptingChannelCipher createChannelEncipher(final Object cipherParams) throws AblyException {
+        return new EncryptingCBCCipher(checkCipherParams(cipherParams));
     }
 
     /**
-     * Internal; get an encrypting cipher instance based on the given channel options.
+     * Internal; get a decrypting cipher instance based on the given channel options.
      */
-    public static ChannelCipherSet createChannelCipherSet(final Object cipherParams) throws AblyException {
-        final CipherParams nonNullParams;
-        if (null == cipherParams)
-            nonNullParams = Crypto.getDefaultParams();
-        else if (cipherParams instanceof CipherParams)
-            nonNullParams = (CipherParams)cipherParams;
-        else
+    public static DecryptingChannelCipher createChannelDecipher(final Object cipherParams) throws AblyException {
+        return new DecryptingCBCCipher(checkCipherParams(cipherParams));
+    }
+
+    private static CipherParams checkCipherParams(final Object cipherParams) throws AblyException {
+        if (null == cipherParams) {
+            return Crypto.getDefaultParams();
+        } else if (cipherParams instanceof CipherParams) {
+            return (CipherParams) cipherParams;
+        } else {
             throw AblyException.fromErrorInfo(new ErrorInfo("ChannelOptions not supported", 400, 40000));
-
-        return new ChannelCipherSet() {
-            private final EncryptingChannelCipher encipher = new EncryptingCBCCipher(nonNullParams);
-            private final DecryptingChannelCipher decipher = new DecryptingCBCCipher(nonNullParams);
-
-            @Override
-            public EncryptingChannelCipher getEncipher() {
-                return encipher;
-            }
-
-            @Override
-            public DecryptingChannelCipher getDecipher() {
-                return decipher;
-            }
-        };
+        }
     }
 
     /**
@@ -277,7 +247,6 @@ public class Crypto {
         protected final Cipher cipher;
         protected final int blockLength;
         protected final String algorithm;
-        private final Semaphore semaphore = new Semaphore(1);
 
         protected CBCCipher(final CipherParams params) throws AblyException {
             final String cipherAlgorithm = params.getAlgorithm();
@@ -292,28 +261,6 @@ public class Crypto {
             catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
                 throw AblyException.fromThrowable(e);
             }
-        }
-
-        /**
-         * Subclasses must call this method before performing any work that uses the {@link #cipher} or otherwise
-         * mutates the state of this instance.
-         *
-         * TODO: under https://github.com/ably/ably-java/issues/747 we can then:
-         * - remove the need for the {@link #releaseOperationalPermit()} method, and
-         * - make this method return an AutoCloseable implementation that releases the semaphore.
-         */
-        protected void acquireOperationalPermit() {
-            if (!semaphore.tryAcquire()) {
-                throw new ConcurrentModificationException("ChannelCipher instances are not designed to be operated from multiple threads simultaneously.");
-            }
-        }
-
-        /**
-         * Subclasses must call this method after performing any work that uses the {@link #cipher} or otherwise
-         * mutates the state of this instance.
-         */
-        protected void releaseOperationalPermit() {
-            semaphore.release();
         }
     }
 
@@ -390,23 +337,17 @@ public class Crypto {
         public byte[] encrypt(byte[] plaintext) {
             if (plaintext == null) return null;
 
-            acquireOperationalPermit();
-            try {
-                final int plaintextLength = plaintext.length;
-                final int paddedLength = getPaddedLength(plaintextLength);
-                final byte[] cipherIn = new byte[paddedLength];
-                final byte[] ciphertext = new byte[paddedLength + blockLength];
-                final int padding = paddedLength - plaintextLength;
-                System.arraycopy(plaintext, 0, cipherIn, 0, plaintextLength);
-                System.arraycopy(pkcs5Padding[padding], 0, cipherIn, plaintextLength, padding);
-                System.arraycopy(getNextIv(), 0, ciphertext, 0, blockLength);
-                final byte[] cipherOut = cipher.update(cipherIn);
-                System.arraycopy(cipherOut, 0, ciphertext, blockLength, paddedLength);
-                return ciphertext;
-            } finally {
-                // TODO: under https://github.com/ably/ably-java/issues/747 we will remove this call.
-                releaseOperationalPermit();
-            }
+            final int plaintextLength = plaintext.length;
+            final int paddedLength = getPaddedLength(plaintextLength);
+            final byte[] cipherIn = new byte[paddedLength];
+            final byte[] ciphertext = new byte[paddedLength + blockLength];
+            final int padding = paddedLength - plaintextLength;
+            System.arraycopy(plaintext, 0, cipherIn, 0, plaintextLength);
+            System.arraycopy(pkcs5Padding[padding], 0, cipherIn, plaintextLength, padding);
+            System.arraycopy(getNextIv(), 0, ciphertext, 0, blockLength);
+            final byte[] cipherOut = cipher.update(cipherIn);
+            System.arraycopy(cipherOut, 0, ciphertext, blockLength, paddedLength);
+            return ciphertext;
         }
     }
 
@@ -417,17 +358,13 @@ public class Crypto {
 
         @Override
         public byte[] decrypt(byte[] ciphertext) throws AblyException {
-            if(ciphertext == null) return null;
+            if (ciphertext == null) return null;
 
-            acquireOperationalPermit();
             try {
                 cipher.init(Cipher.DECRYPT_MODE, keySpec, new IvParameterSpec(ciphertext, 0, blockLength));
                 return cipher.doFinal(ciphertext, blockLength, ciphertext.length - blockLength);
             } catch (InvalidAlgorithmParameterException | IllegalBlockSizeException | BadPaddingException | InvalidKeyException e) {
                 throw AblyException.fromThrowable(e);
-            } finally {
-                // TODO: under https://github.com/ably/ably-java/issues/747 we will remove this call.
-                releaseOperationalPermit();
             }
         }
     }

--- a/lib/src/main/java/io/ably/lib/util/Crypto.java
+++ b/lib/src/main/java/io/ably/lib/util/Crypto.java
@@ -212,18 +212,21 @@ public class Crypto {
     /**
      * Internal; get an encrypting cipher instance based on the given channel options.
      */
-    public static EncryptingChannelCipher createChannelEncipher(final Object cipherParams) throws AblyException {
-        return new EncryptingCBCCipher(checkCipherParams(cipherParams));
+    public static EncryptingChannelCipher createChannelEncipher(final CipherParams cipherParams) throws AblyException {
+        return new EncryptingCBCCipher(cipherParams);
     }
 
     /**
      * Internal; get a decrypting cipher instance based on the given channel options.
      */
-    public static DecryptingChannelCipher createChannelDecipher(final Object cipherParams) throws AblyException {
-        return new DecryptingCBCCipher(checkCipherParams(cipherParams));
+    public static DecryptingChannelCipher createChannelDecipher(final CipherParams cipherParams) throws AblyException {
+        return new DecryptingCBCCipher(cipherParams);
     }
 
-    private static CipherParams checkCipherParams(final Object cipherParams) throws AblyException {
+    /**
+     * Internal; if `cipherParams` is null returns default params otherwise check if params valid and returns them
+     */
+    public static CipherParams checkCipherParams(final Object cipherParams) throws AblyException {
         if (null == cipherParams) {
             return Crypto.getDefaultParams();
         } else if (cipherParams instanceof CipherParams) {

--- a/lib/src/test/java/io/ably/lib/rest/DeviceDetailsTest.java
+++ b/lib/src/test/java/io/ably/lib/rest/DeviceDetailsTest.java
@@ -1,0 +1,37 @@
+package io.ably.lib.rest;
+
+import io.ably.lib.util.JsonUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class DeviceDetailsTest {
+
+    @Test
+    public void shouldIgnoreUnrelatedRecipientFields() {
+        DeviceDetails details = DeviceDetails.fromJsonObject(JsonUtils.object()
+                .add("id", "testDeviceDetails")
+                .add("platform", "ios")
+                .add("formFactor", "phone")
+                .add("metadata", JsonUtils.object())
+                .add("push", JsonUtils.object()
+                        .add("recipient", JsonUtils.object()
+                                .add("transportType", "apns")
+                                .add("deviceToken", "foo")
+                                .add("apnsDeviceTokens", JsonUtils.object().add("default", "foo"))))
+                .toJson());
+
+        DeviceDetails otherDetails = DeviceDetails.fromJsonObject(JsonUtils.object()
+                .add("id", "testDeviceDetails")
+                .add("platform", "ios")
+                .add("formFactor", "phone")
+                .add("metadata", JsonUtils.object())
+                .add("push", JsonUtils.object()
+                        .add("recipient", JsonUtils.object()
+                                .add("transportType", "apns")
+                                .add("deviceToken", "foo")))
+                .toJson());
+
+        assertTrue("Should ignore `apnsDeviceTokens` field",  details.equals(otherDetails));
+    }
+}

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeCryptoTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeCryptoTest.java
@@ -121,7 +121,9 @@ public class RealtimeCryptoTest extends ParameterizedTest {
             final CipherParams params = Crypto.getDefaultParams(key);
 
             /* create a channel */
-            ChannelOptions channelOpts = new ChannelOptions() {{ encrypted = true; this.cipherParams = params; }};
+            ChannelOptions channelOpts = new ChannelOptions();
+            channelOpts.encrypted = true;
+            channelOpts.cipherParams = params;
             final Channel channel = ably.channels.get(channelName, channelOpts);
 
             /* attach */
@@ -276,9 +278,16 @@ public class RealtimeCryptoTest extends ParameterizedTest {
             final CipherParams params = Crypto.getDefaultParams();
 
             /* create a channel */
-            final ChannelOptions senderChannelOpts = new ChannelOptions() {{ encrypted = true; cipherParams = params; }};
+            final ChannelOptions senderChannelOpts = new ChannelOptions();
+            senderChannelOpts.encrypted = true;
+            senderChannelOpts.cipherParams = params;
+
             final Channel senderChannel = sender.channels.get(channelName, senderChannelOpts);
-            final ChannelOptions receiverChannelOpts = new ChannelOptions() {{ encrypted = true; cipherParams = params; }};
+
+            final ChannelOptions receiverChannelOpts = new ChannelOptions();
+            receiverChannelOpts.encrypted = true;
+            receiverChannelOpts.cipherParams = params;
+
             final Channel receiverChannel = receiver.channels.get(channelName, receiverChannelOpts);
 
             /* attach */
@@ -570,9 +579,14 @@ public class RealtimeCryptoTest extends ParameterizedTest {
             final CipherParams params1 = Crypto.getDefaultParams();
 
             /* create a channel */
-            ChannelOptions senderChannelOpts = new ChannelOptions() {{ encrypted = true; cipherParams = params1; }};
+            ChannelOptions senderChannelOpts = new ChannelOptions();
+            senderChannelOpts.encrypted = true;
+            senderChannelOpts.cipherParams = params1;
             final Channel senderChannel = sender.channels.get("set_cipher_params", senderChannelOpts);
-            ChannelOptions receiverChannelOpts = new ChannelOptions() {{ encrypted = true; cipherParams = params1; }};
+
+            ChannelOptions receiverChannelOpts = new ChannelOptions();
+            receiverChannelOpts.encrypted = true;
+            receiverChannelOpts.cipherParams = params1;
             final Channel receiverChannel = receiver.channels.get("set_cipher_params", receiverChannelOpts);
 
             /* attach */

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeCryptoTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeCryptoTest.java
@@ -33,7 +33,8 @@ import io.ably.lib.types.ChannelOptions;
 import io.ably.lib.types.ClientOptions;
 import io.ably.lib.types.ErrorInfo;
 import io.ably.lib.util.Crypto;
-import io.ably.lib.util.Crypto.ChannelCipherSet;
+import io.ably.lib.util.Crypto.EncryptingChannelCipher;
+import io.ably.lib.util.Crypto.DecryptingChannelCipher;
 import io.ably.lib.util.Crypto.CipherParams;
 
 public class RealtimeCryptoTest extends ParameterizedTest {
@@ -805,12 +806,13 @@ public class RealtimeCryptoTest extends ParameterizedTest {
     @Test
     public void encodeDecodeVariableSizesWithAES256CBC() throws NoSuchAlgorithmException, AblyException {
         final CipherParams params = Crypto.getParams("aes", generateNonce(32), generateNonce(16));
-        final ChannelCipherSet cipherSet = Crypto.createChannelCipherSet(params);
+        final Crypto.EncryptingChannelCipher encipher = Crypto.createChannelEncipher(params);
+        final Crypto.DecryptingChannelCipher decipher = Crypto.createChannelDecipher(params);
         for (int i=1; i<1000; i++) {
             final int size = RANDOM.nextInt(2000) + 1;
             final byte[] message = generateNonce(size);
-            final byte[] encrypted = cipherSet.getEncipher().encrypt(message);
-            final byte[] decrypted = cipherSet.getDecipher().decrypt(encrypted);
+            final byte[] encrypted = encipher.encrypt(message);
+            final byte[] decrypted = decipher.decrypt(encrypted);
             try {
                 assertArrayEquals(message, decrypted);
             } catch (final AssertionError e) {
@@ -1066,12 +1068,13 @@ public class RealtimeCryptoTest extends ParameterizedTest {
             // We have to create a new ChannelCipher for each message we encode because
             // cipher instances only use the IV we've supplied via CipherParams for the
             // encryption of the very first message.
-            final ChannelCipherSet cipherSet = Crypto.createChannelCipherSet(params);
+            final EncryptingChannelCipher encipher = Crypto.createChannelEncipher(params);
+            final DecryptingChannelCipher decipher = Crypto.createChannelDecipher(params);
 
             final byte[] appleMessage = hexStringToByteArray(entry.getKey());
             final byte[] appleEncrypted = hexStringToByteArray(entry.getValue());
-            final byte[] encrypted = cipherSet.getEncipher().encrypt(appleMessage);
-            final byte[] decrypted = cipherSet.getDecipher().decrypt(appleEncrypted);
+            final byte[] encrypted = encipher.encrypt(appleMessage);
+            final byte[] decrypted = decipher.decrypt(appleEncrypted);
 
             try {
                 assertArrayEquals(appleMessage, decrypted);

--- a/lib/src/test/java/io/ably/lib/util/CryptoMessageTest.java
+++ b/lib/src/test/java/io/ably/lib/util/CryptoMessageTest.java
@@ -88,7 +88,9 @@ public class CryptoMessageTest {
         final String algorithm = testData.algorithm;
 
         final CipherParams params = Crypto.getParams(algorithm, fixtureSet.key, fixtureSet.iv);
-        final ChannelOptions options = new ChannelOptions() {{encrypted = true; cipherParams = params;}};
+        final ChannelOptions options = new ChannelOptions();
+        options.encrypted = true;
+        options.cipherParams = params;
 
         for(final CryptoTestItem item : testData.items) {
             final Message plain = item.encoded;
@@ -116,7 +118,10 @@ public class CryptoMessageTest {
         final CipherParams params = Crypto.getParams(algorithm, fixtureSet.key, fixtureSet.iv);
 
         for(final CryptoTestItem item : testData.items) {
-            final ChannelOptions options = new ChannelOptions() {{encrypted = true; cipherParams = params;}};
+            final ChannelOptions options = new ChannelOptions();
+            options.encrypted = true;
+            options.cipherParams = params;
+
             final Message plain = item.encoded;
             final Message encrypted = item.encrypted;
             assertThat(encrypted.encoding, endsWith(fixtureSet.cipherName + "/base64"));


### PR DESCRIPTION
**Before:** Cipher instances was cached per `ChannelOptions` that probably increased performance a little bit, but it was causing `ConcurrentModificationException`. 

**Now:** we create cipher instance during encryption/decryption process to avoid this.

see https://github.com/ably/ably-flutter/issues/483