### PR TITLE
fix: deviceId and deviceToken consistence

### DIFF
--- a/android/src/androidTest/java/io/ably/lib/test/android/EventTest.java
+++ b/android/src/androidTest/java/io/ably/lib/test/android/EventTest.java
@@ -44,7 +44,7 @@ public class EventTest {
 
     @Test
     public void events_with_constructor_parameter_do_not_have_persisted_name() {
-        assertNull(new GotDeviceRegistration(null).getPersistedName());
+        assertNull(new GotDeviceRegistration(null, null).getPersistedName());
         assertNull(new GettingDeviceRegistrationFailed(null).getPersistedName());
         assertNull(new GettingPushDeviceDetailsFailed(null).getPersistedName());
         assertNull(new SyncRegistrationFailed(null).getPersistedName());

--- a/android/src/main/java/io/ably/lib/push/ActivationContext.java
+++ b/android/src/main/java/io/ably/lib/push/ActivationContext.java
@@ -174,6 +174,6 @@ public class ActivationContext {
     protected final SharedPreferences prefs;
     protected final Context context;
 
-    private static WeakHashMap<Context, ActivationContext> activationContexts = new WeakHashMap<Context, ActivationContext>();
+    private static final WeakHashMap<Context, ActivationContext> activationContexts = new WeakHashMap<>();
     private static final String TAG = ActivationContext.class.getName();
 }

--- a/android/src/main/java/io/ably/lib/push/LocalDevice.java
+++ b/android/src/main/java/io/ably/lib/push/LocalDevice.java
@@ -133,6 +133,7 @@ public class LocalDevice extends DeviceDetails {
         storage.put(SharedPrefKeys.DEVICE_ID, (id = UUID.randomUUID().toString()));
         storage.put(SharedPrefKeys.CLIENT_ID, (clientId = activationContext.clientId));
         storage.put(SharedPrefKeys.DEVICE_SECRET, (deviceSecret = generateSecret()));
+        storage.put(SharedPrefKeys.DEVICE_TOKEN, (deviceIdentityToken = null));
     }
 
     public void reset() {


### PR DESCRIPTION
Resolves [SDK-3950](https://ably.atlassian.net/browse/SDK-3950)

According to the logs, in some situations, `deviceId` doesn't agree with `deviceToken`. 

I added additional checks when we setup `deviceToken` to prevent this inconsitency.
Also during `LocalDevice#create` method, where we create `deviceId` I also clear `deviceToken` if it exists.

[SDK-3950]: https://ably.atlassian.net/browse/SDK-3950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ