### PR TITLE
[ECO-4244] fix: adjust default timeouts according to the spec

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/Defaults.java
+++ b/lib/src/main/java/io/ably/lib/transport/Defaults.java
@@ -39,7 +39,7 @@ public class Defaults {
     /* TO3l3 */
     public static int TIMEOUT_HTTP_OPEN = 4000;
     /* TO3l4 */
-    public static int TIMEOUT_HTTP_REQUEST = 15000;
+    public static int TIMEOUT_HTTP_REQUEST = 10000;
     /* TO3l6 */
     public static int httpMaxRetryDuration = 15000;
 


### PR DESCRIPTION
Resolves https://github.com/ably/ably-java/issues/310
Jira issue [ECO-4244](https://ably.atlassian.net/browse/ECO-4244)

Adjust default timeouts according to the spec

[ECO-4244]: https://ably.atlassian.net/browse/ECO-4244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ