### PR TITLE
[ECO-4820] fix(ConnectionManager): update the connection close implementation to follow RTN12f

### DIFF
--- a/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/ConnectionManagerTest.java
@@ -397,6 +397,22 @@ public class ConnectionManagerTest extends ParameterizedTest {
     }
 
     /**
+     * (RTN12f) Close while in connecting state
+     */
+    @Test
+    public void connectionmanager_close_while_connecting() throws AblyException {
+        ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+        final AblyRealtime ably = new AblyRealtime(opts);
+        ably.close();
+
+        new Helpers.ConnectionWaiter(ably.connection).waitFor(ConnectionState.closed);
+        ConnectionManager connectionManager = ably.connection.connectionManager;
+
+        assertThat("connectionManager is closed", connectionManager.getConnectionState().state, is(ConnectionState.closed));
+        assertThat("fallback hasn't been invoked", connectionManager.getHost(), is(equalTo(opts.environment + "-realtime.ably.io")));
+    }
+
+    /**
      * Connect, and then perform a close();
      * verify that the closed state is reached, and immediately
      * reconnect; verify that it reconnects successfully


### PR DESCRIPTION
Resolves https://github.com/ably/ably-java/issues/1012

When `CONNECTING` state moves immediately to `CLOSING` we wait `CONNECTED` protocol message before sending `CLOSE`.