### PR TITLE
feat: include `X-Ably-ClientId` for each request (RSA7e2)

### DIFF
--- a/lib/src/main/java/io/ably/lib/http/HttpCore.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpCore.java
@@ -28,6 +28,7 @@ import io.ably.lib.types.ErrorResponse;
 import io.ably.lib.types.Param;
 import io.ably.lib.types.ProxyOptions;
 import io.ably.lib.util.AgentHeaderCreator;
+import io.ably.lib.util.Base64Coder;
 import io.ably.lib.util.Log;
 import io.ably.lib.util.PlatformAgentProvider;
 
@@ -211,6 +212,7 @@ public class HttpCore {
             /* pass required headers */
             conn.setRequestProperty(Defaults.ABLY_PROTOCOL_VERSION_HEADER, Defaults.ABLY_PROTOCOL_VERSION); // RSC7a
             conn.setRequestProperty(Defaults.ABLY_AGENT_HEADER, AgentHeaderCreator.create(options.agents, platformAgentProvider));
+            if (options.clientId != null) conn.setRequestProperty(Defaults.ABLY_CLIENT_ID_HEADER, Base64Coder.encodeString(options.clientId));
 
             /* prepare request body */
             byte[] body = null;

--- a/lib/src/main/java/io/ably/lib/transport/Defaults.java
+++ b/lib/src/main/java/io/ably/lib/transport/Defaults.java
@@ -22,6 +22,7 @@ public class Defaults {
 
     /* http headers */
     public static final String ABLY_PROTOCOL_VERSION_HEADER = "X-Ably-Version";
+    public static final String ABLY_CLIENT_ID_HEADER = "X-Ably-ClientId";
     public static final String ABLY_AGENT_HEADER = "Ably-Agent";
 
     /* Hosts */


### PR DESCRIPTION
Resolves https://github.com/ably/ably-java/issues/1015

