### PR TITLE
chore(Auth): get rid of unnecessary padding removal for Auth tokens

### DIFF
--- a/lib/src/main/java/io/ably/lib/rest/Auth.java
+++ b/lib/src/main/java/io/ably/lib/rest/Auth.java
@@ -1121,14 +1121,14 @@ public class Auth {
     private void setTokenDetails(String token) throws AblyException {
         Log.i("TokenAuth.setTokenDetails()", "");
         this.tokenDetails = new TokenDetails(token);
-        this.encodedToken = Base64Coder.encodeString(token).replace("=", "");
+        this.encodedToken = Base64Coder.encodeString(token);
     }
 
     private void setTokenDetails(TokenDetails tokenDetails) throws AblyException {
         Log.i("TokenAuth.setTokenDetails()", "");
         setClientId(tokenDetails.clientId);
         this.tokenDetails = tokenDetails;
-        this.encodedToken = Base64Coder.encodeString(tokenDetails.token).replace("=", "");
+        this.encodedToken = Base64Coder.encodeString(tokenDetails.token);
     }
 
     private void clearTokenDetails() {


### PR DESCRIPTION
Makes ably-java SDK consistent with other SDKs. In other SDKs we use base64 encoding with padding for Auth tokens