### PR TITLE
tests: Assert connection error code rather than message

### DIFF
--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -1669,7 +1669,7 @@ public class RealtimeChannelTest extends ParameterizedTest {
 
             ErrorInfo resumeError = connectionWaiter.waitFor(ConnectionState.connected);
             assertNotNull(resumeError);
-            assertTrue(resumeError.message.contains("Invalid connection key"));
+            assertEquals("Verify error code indicates invalid connection key", resumeError.code, 80018);
             assertSame(resumeError, ably.connection.connectionManager.getStateErrorInfo());
             assertNotEquals("A new connection was created", originalConnectionId, ably.connection.id);
 


### PR DESCRIPTION
The error messages are subject to change, but the codes are not, so assert the code instead.