### PR TITLE
Fix implicit attach on subscribe

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -693,7 +693,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     /**
      * Checks for null channelOptions and checks if options.attachOnSubscribe is true
      * Defaults to @true@ when channelOptions is null.
-     * Spec: RTP6d, RTP6e, TB4
+     * Spec: TB4, RTL7g, RTL7gh, RTP6d, RTP6e
      */
     protected boolean attachOnSubscribeEnabled() {
         return options == null || options.attachOnSubscribe;

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -691,9 +691,11 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     }
 
     /**
-     * Checks for null channelOptions and checks if options.attachOnSubscribe is true
-     * Defaults to @true@ when channelOptions is null.
-     * Spec: TB4, RTL7g, RTL7gh, RTP6d, RTP6e
+     * <p>
+     * Checks if {@link io.ably.lib.types.ChannelOptions#attachOnSubscribe} is true.
+     * </p>
+     * Defaults to {@code true} when {@link io.ably.lib.realtime.ChannelBase#options} is null.
+     * <p>Spec: TB4, RTL7g, RTL7gh, RTP6d, RTP6e</p>
      */
     protected boolean attachOnSubscribeEnabled() {
         return options == null || options.attachOnSubscribe;

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -691,6 +691,15 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     }
 
     /**
+     * Checks for null channelOptions and checks if options.attachOnSubscribe is true
+     * Defaults to @true@ when channelOptions is null.
+     * Spec: RTP6d, RTP6e, TB4
+     */
+    protected boolean attachOnSubscribeEnabled() {
+        return options == null || options.attachOnSubscribe;
+    }
+
+    /**
      * Registers a listener for messages on this channel.
      * The caller supplies a listener function, which is called each time one or more messages arrives on the channel.
      * <p>
@@ -704,7 +713,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     public synchronized void subscribe(MessageListener listener) throws AblyException {
         Log.v(TAG, "subscribe(); channel = " + this.name);
         listeners.add(listener);
-        if (options.attachOnSubscribe) {
+        if (attachOnSubscribeEnabled()) {
             attach();
         }
     }
@@ -741,7 +750,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     public synchronized void subscribe(String name, MessageListener listener) throws AblyException {
         Log.v(TAG, "subscribe(); channel = " + this.name + "; event = " + name);
         subscribeImpl(name, listener);
-        if (options.attachOnSubscribe) {
+        if (attachOnSubscribeEnabled()) {
             attach();
         }
     }
@@ -777,7 +786,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
         Log.v(TAG, "subscribe(); channel = " + this.name + "; (multiple events)");
         for(String name : names)
             subscribeImpl(name, listener);
-        if (options.attachOnSubscribe) {
+        if (attachOnSubscribeEnabled()) {
             attach();
         }
     }

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -704,7 +704,9 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     public synchronized void subscribe(MessageListener listener) throws AblyException {
         Log.v(TAG, "subscribe(); channel = " + this.name);
         listeners.add(listener);
-        attach();
+        if (options.attachOnSubscribe) {
+            attach();
+        }
     }
 
     /**
@@ -739,7 +741,9 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     public synchronized void subscribe(String name, MessageListener listener) throws AblyException {
         Log.v(TAG, "subscribe(); channel = " + this.name + "; event = " + name);
         subscribeImpl(name, listener);
-        attach();
+        if (options.attachOnSubscribe) {
+            attach();
+        }
     }
 
     /**
@@ -773,7 +777,9 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
         Log.v(TAG, "subscribe(); channel = " + this.name + "; (multiple events)");
         for(String name : names)
             subscribeImpl(name, listener);
-        attach();
+        if (options.attachOnSubscribe) {
+            attach();
+        }
     }
 
     /**

--- a/lib/src/main/java/io/ably/lib/realtime/Presence.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Presence.java
@@ -309,7 +309,9 @@ public class Presence {
      */
     private void implicitAttachOnSubscribe(CompletionListener completionListener) throws AblyException {
         if (!channel.attachOnSubscribeEnabled()) {
-            completionListener.onSuccess();
+            if (completionListener != null) {
+                completionListener.onSuccess();
+            }
             return;
         }
         if (channel.state == ChannelState.failed) {

--- a/lib/src/main/java/io/ably/lib/realtime/Presence.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Presence.java
@@ -308,7 +308,7 @@ public class Presence {
      * @throws AblyException
      */
     private void implicitAttachOnSubscribe(CompletionListener completionListener) throws AblyException {
-        if (!channel.options.attachOnSubscribe) {
+        if (!channel.attachOnSubscribeEnabled()) {
             completionListener.onSuccess();
             return;
         }

--- a/lib/src/main/java/io/ably/lib/realtime/Presence.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Presence.java
@@ -308,6 +308,10 @@ public class Presence {
      * @throws AblyException
      */
     private void implicitAttachOnSubscribe(CompletionListener completionListener) throws AblyException {
+        if (!channel.options.attachOnSubscribe) {
+            completionListener.onSuccess();
+            return;
+        }
         if (channel.state == ChannelState.failed) {
             String errorString = String.format(Locale.ROOT, "Channel %s: subscribe in FAILED channel state", channel.name);
             Log.v(TAG, errorString);

--- a/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
@@ -40,6 +40,13 @@ public class ChannelOptions {
      */
     public boolean encrypted;
 
+    /**
+     * Determines whether calling @subscribe@ on a channel or presence object should trigger an implicit attach.
+     * Defaults to @true@.
+     * Spec: RTP6d, RTP6e, TB4
+     */
+    public boolean attachOnSubscribe = true;
+
     public boolean hasModes() {
         return null != modes && 0 != modes.length;
     }

--- a/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
@@ -43,7 +43,7 @@ public class ChannelOptions {
     /**
      * Determines whether calling @subscribe@ on a channel or presence object should trigger an implicit attach.
      * Defaults to @true@.
-     * Spec: RTP6d, RTP6e, TB4
+     * Spec: TB4, RTL7g, RTL7gh, RTP6d, RTP6e
      */
     public boolean attachOnSubscribe = true;
 

--- a/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
@@ -41,9 +41,13 @@ public class ChannelOptions {
     public boolean encrypted;
 
     /**
-     * Determines whether calling @subscribe@ on a channel or presence object should trigger an implicit attach.
-     * Defaults to @true@.
-     * Spec: TB4, RTL7g, RTL7gh, RTP6d, RTP6e
+     * <p>
+     * Determines whether calling {@link io.ably.lib.realtime.Channel#subscribe Channel.subscribe} or
+     * {@link io.ably.lib.realtime.Presence#subscribe Presence.subscribe} method
+     * should trigger an implicit attach.
+     * </p>
+     * <p>Defaults to {@code true}.</p>
+     * <p>Spec: TB4, RTL7g, RTL7gh, RTP6d, RTP6e</p>
      */
     public boolean attachOnSubscribe = true;
 

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -395,6 +395,68 @@ public class RealtimeChannelTest extends ParameterizedTest {
 
     /**
      * <p>
+     * Validates a client can subscribe to messages without implicit channel attach
+     * Refer Spec TB4, RTL7g, RTL7gh
+     * </p>
+     * @throws AblyException
+     */
+    @Test
+    public void subscribe_without_implicit_attach() {
+        String channelName = "subscribe_" + testParams.name;
+        AblyRealtime ably = null;
+        try {
+            ClientOptions opts = createOptions(testVars.keys[0].keyStr);
+            ably = new AblyRealtime(opts);
+
+            /* create a channel and set attachOnSubscribe to false */
+            final Channel channel = ably.channels.get(channelName);
+            ChannelOptions chOpts = new ChannelOptions();
+            chOpts.attachOnSubscribe = false;
+            channel.setOptions(chOpts);
+
+            List<Object> receivedMsg = new ArrayList<>();
+
+            /* Check for all subscriptions without ATTACHING state */
+            channel.subscribe(message -> receivedMsg.add(true));
+            assertEquals(channel.state, ChannelState.initialized);
+
+            channel.subscribe("test_event", message -> receivedMsg.add(true));
+            assertEquals(channel.state, ChannelState.initialized);
+
+            channel.subscribe(new String[]{"test_event1", "test_event2"}, message -> receivedMsg.add(true));
+            assertEquals(channel.state, ChannelState.initialized);
+
+            channel.attach();
+            (new ChannelWaiter(channel)).waitFor(ChannelState.attached);
+
+            channel.publish("test_event", "hi there");
+            Exception conditionError = new Helpers.ConditionalWaiter().
+                wait(() -> receivedMsg.size() == 2, 5000);
+            assertNull(conditionError);
+
+            receivedMsg.clear();
+            channel.publish("test_event1", "hi there");
+            conditionError = new Helpers.ConditionalWaiter().
+                wait(() -> receivedMsg.size() == 2, 5000);
+            assertNull(conditionError);
+
+            receivedMsg.clear();
+            channel.publish("test_event2", "hi there");
+            conditionError = new Helpers.ConditionalWaiter().
+                wait(() -> receivedMsg.size() == 2, 5000);
+            assertNull(conditionError);
+
+        } catch (AblyException e) {
+            e.printStackTrace();
+            fail("init0: Unexpected exception instantiating library");
+        } finally {
+            if(ably != null)
+                ably.close();
+        }
+    }
+
+    /**
+     * <p>
      * Verifies that unsubscribe call with no argument removes all listeners,
      * and any of the previously subscribed listeners doesn't receive any message
      * after that.


### PR DESCRIPTION
Fixed #1027 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a configurable option for channel subscriptions to control automatic attachment behavior.
	- Added a new field `attachOnSubscribe` in `ChannelOptions` to manage implicit attachment during subscriptions.

- **Bug Fixes**
	- Improved control flow in subscription methods to prevent unnecessary operations when implicit attachment is disabled.

- **Tests**
	- Added tests to validate subscription behavior without implicit channel attachment for both messages and presence events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->