### PR TITLE
[ECO-4972] Fix implicit channel ATTACH

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -695,7 +695,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
      * Checks if {@link io.ably.lib.types.ChannelOptions#attachOnSubscribe} is true.
      * </p>
      * Defaults to {@code true} when {@link io.ably.lib.realtime.ChannelBase#options} is null.
-     * <p>Spec: TB4, RTL7g, RTL7gh, RTP6d, RTP6e</p>
+     * <p>Spec: TB4, RTL7g, RTL7h, RTP6d, RTP6e</p>
      */
     protected boolean attachOnSubscribeEnabled() {
         return options == null || options.attachOnSubscribe;

--- a/lib/src/main/java/io/ably/lib/realtime/Presence.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Presence.java
@@ -296,27 +296,26 @@ public class Presence {
         eventListeners.clear();
     }
 
-
-    /***
-     * internal
-     *
-     */
-
     /**
-     * Implicitly attach channel on subscribe. Throw exception if channel is in failed state
-     * @param completionListener
-     * @throws AblyException
+     * Implicitly attach channel on subscribe. Throw exception if channel is in failed state.
+     * @param completionListener Registers listener, gets called when ATTACH operation is a success.
+     * @throws AblyException Throws exception when channel is in failed state.
      */
     private void implicitAttachOnSubscribe(CompletionListener completionListener) throws AblyException {
+        // RTP6e
         if (!channel.attachOnSubscribeEnabled()) {
             if (completionListener != null) {
-                completionListener.onSuccess();
+                String errorString = String.format(Locale.ROOT,
+                    "Channel %s: attachOnSubscribe=false doesn't expect attach completion callback", channel.name);
+                Log.e(TAG, errorString);
+                ErrorInfo errorInfo = new ErrorInfo(errorString, 400,40000);
+                throw AblyException.fromErrorInfo(errorInfo);
             }
             return;
         }
         if (channel.state == ChannelState.failed) {
             String errorString = String.format(Locale.ROOT, "Channel %s: subscribe in FAILED channel state", channel.name);
-            Log.v(TAG, errorString);
+            Log.e(TAG, errorString);
             ErrorInfo errorInfo = new ErrorInfo(errorString, 90001);
             throw AblyException.fromErrorInfo(errorInfo);
         }

--- a/lib/src/main/java/io/ably/lib/realtime/Presence.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Presence.java
@@ -305,7 +305,7 @@ public class Presence {
         // RTP6e
         if (!channel.attachOnSubscribeEnabled()) {
             if (completionListener != null) {
-                String errorString = String.format(Locale.ROOT,
+                String errorString = String.format(
                     "Channel %s: attachOnSubscribe=false doesn't expect attach completion callback", channel.name);
                 Log.e(TAG, errorString);
                 ErrorInfo errorInfo = new ErrorInfo(errorString, 400,40000);

--- a/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
+++ b/lib/src/main/java/io/ably/lib/types/ChannelOptions.java
@@ -47,7 +47,7 @@ public class ChannelOptions {
      * should trigger an implicit attach.
      * </p>
      * <p>Defaults to {@code true}.</p>
-     * <p>Spec: TB4, RTL7g, RTL7gh, RTP6d, RTP6e</p>
+     * <p>Spec: TB4, RTL7g, RTL7h, RTP6d, RTP6e</p>
      */
     public boolean attachOnSubscribe = true;
 

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -396,7 +396,7 @@ public class RealtimeChannelTest extends ParameterizedTest {
     /**
      * <p>
      * Validates a client can subscribe to messages without implicit channel attach
-     * Refer Spec TB4, RTL7g, RTL7gh
+     * Refer Spec TB4, RTL7g, RTL7h
      * </p>
      * @throws AblyException
      */

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimePresenceTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimePresenceTest.java
@@ -1692,14 +1692,11 @@ public class RealtimePresenceTest extends ParameterizedTest {
      * @throws AblyException
      */
     @Test
-    public void presence_subscribe_without_implicit_attach_and_completion_listener_throws_exception() {
+    public void presence_subscribe_without_implicit_attach_and_completion_listener_throws_exception() throws AblyException {
         String ablyChannel = "subscribe_" + testParams.name;
-        AblyRealtime ably = null;
-        try {
-            ClientOptions option1 = createOptions(testVars.keys[0].keyStr);
-            option1.clientId = "client1";
-            ably = new AblyRealtime(option1);
-
+        ClientOptions option1 = createOptions(testVars.keys[0].keyStr);
+        option1.clientId = "client1";
+        try (AblyRealtime ably = new AblyRealtime(option1)) {
             /* create a channel and set attachOnSubscribe to false */
             final Channel channel = ably.channels.get(ablyChannel);
             ChannelOptions chOpts = new ChannelOptions();
@@ -1720,9 +1717,6 @@ public class RealtimePresenceTest extends ParameterizedTest {
         } catch (AblyException e) {
             e.printStackTrace();
             fail("presence_subscribe_without_implicit_attach: Unexpected exception");
-        } finally {
-            if(ably != null)
-                ably.close();
         }
     }
 


### PR DESCRIPTION
- Fixed `presence.subscribe` based on updated spec -> https://github.com/ably/specification/pull/209/files, if completionListener is passed, it should throw exception.
- Current `message.subscribe` doesn't accept optional `completionListener`, so no need to update spec for the same.
- Related to #1027 
- Upgrade for #1028

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for channel state in presence management.
	- Improved presence message handling for better user experience.

- **Bug Fixes**
	- Corrected documentation references for method specifications.

- **Tests**
	- Added new tests for channel attachment and detachment scenarios.
	- Added a test to validate exception handling when subscribing to presence without attaching the channel.
	- Updated existing tests for better coverage and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->