### PR TITLE
[ECO-5139] feat: add `action` and `serial` fields

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -25,6 +25,7 @@ import io.ably.lib.types.DecodingContext;
 import io.ably.lib.types.DeltaExtras;
 import io.ably.lib.types.ErrorInfo;
 import io.ably.lib.types.Message;
+import io.ably.lib.types.MessageAction;
 import io.ably.lib.types.MessageDecodeException;
 import io.ably.lib.types.MessageSerializer;
 import io.ably.lib.types.PaginatedResult;
@@ -843,6 +844,12 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
             if(msg.connectionId == null) msg.connectionId = protocolMessage.connectionId;
             if(msg.timestamp == 0) msg.timestamp = protocolMessage.timestamp;
             if(msg.id == null) msg.id = protocolMessage.id + ':' + i;
+            // (TM2p)
+            if(msg.version == null) msg.version = String.format("%s:%03d", protocolMessage.channelSerial, i);
+            // (TM2k)
+            if(msg.serial == null && msg.action == MessageAction.MESSAGE_CREATE) msg.serial = msg.version;
+            // (TM2o)
+            if(msg.createdAt == null && msg.action == MessageAction.MESSAGE_CREATE) msg.createdAt = msg.timestamp;
 
             try {
                 msg.decode(options, decodingContext);

--- a/lib/src/main/java/io/ably/lib/types/BaseMessage.java
+++ b/lib/src/main/java/io/ably/lib/types/BaseMessage.java
@@ -278,6 +278,20 @@ public class BaseMessage implements Cloneable {
         return element.getAsLong();
     }
 
+    /**
+     * Read an optional numerical value.
+     * @return The value, or null if the key was not present in the map.
+     * @throws ClassCastException if an element exists for that key and that element is not a {@link JsonPrimitive}
+     * or is not a valid int value.
+     */
+    protected Integer readInt(final JsonObject map, final String key) {
+        final JsonElement element = map.get(key);
+        if (null == element || element instanceof JsonNull) {
+            return null;
+        }
+        return element.getAsInt();
+    }
+
     /* Msgpack processing */
     boolean readField(MessageUnpacker unpacker, String fieldName, MessageFormat fieldType) throws IOException {
         boolean result = true;

--- a/lib/src/main/java/io/ably/lib/types/MessageAction.java
+++ b/lib/src/main/java/io/ably/lib/types/MessageAction.java
@@ -1,0 +1,15 @@
+package io.ably.lib.types;
+
+public enum MessageAction {
+    MESSAGE_UNSET, // 0
+    MESSAGE_CREATE, // 1
+    MESSAGE_UPDATE, // 2
+    MESSAGE_DELETE, // 3
+    ANNOTATION_CREATE, // 4
+    ANNOTATION_DELETE, // 5
+    META_OCCUPANCY; // 6
+
+    static MessageAction tryFindByOrdinal(int ordinal) {
+        return values().length <= ordinal ? null: values()[ordinal];
+    }
+}

--- a/lib/src/test/java/io/ably/lib/types/MessageTest.java
+++ b/lib/src/test/java/io/ably/lib/types/MessageTest.java
@@ -46,4 +46,69 @@ public class MessageTest {
         assertEquals("test-data", serializedObject.get("data").getAsString());
         assertEquals("test-name", serializedObject.get("name").getAsString());
     }
+
+    @Test
+    public void serialize_message_with_serial() {
+        // Given
+        Message message = new Message("test-name", "test-data");
+        message.clientId = "test-client-id";
+        message.connectionKey = "test-key";
+        message.action = MessageAction.MESSAGE_CREATE;
+        message.serial = "01826232498871-001@abcdefghij:001";
+
+        // When
+        JsonElement serializedElement = serializer.serialize(message, null, null);
+
+        // Then
+        JsonObject serializedObject = serializedElement.getAsJsonObject();
+        assertEquals("test-client-id", serializedObject.get("clientId").getAsString());
+        assertEquals("test-key", serializedObject.get("connectionKey").getAsString());
+        assertEquals("test-data", serializedObject.get("data").getAsString());
+        assertEquals("test-name", serializedObject.get("name").getAsString());
+        assertEquals(1, serializedObject.get("action").getAsInt());
+        assertEquals("01826232498871-001@abcdefghij:001", serializedObject.get("serial").getAsString());
+    }
+
+    @Test
+    public void deserialize_message_with_serial() throws Exception {
+        // Given
+       JsonObject jsonObject = new JsonObject();
+       jsonObject.addProperty("clientId", "test-client-id");
+       jsonObject.addProperty("data", "test-data");
+       jsonObject.addProperty("name", "test-name");
+       jsonObject.addProperty("action", 1);
+       jsonObject.addProperty("serial", "01826232498871-001@abcdefghij:001");
+
+        // When
+        Message message = Message.fromEncoded(jsonObject, new ChannelOptions());
+
+        // Then
+        assertEquals("test-client-id", message.clientId);
+        assertEquals("test-data", message.data);
+        assertEquals("test-name", message.name);
+        assertEquals(MessageAction.MESSAGE_CREATE, message.action);
+        assertEquals("01826232498871-001@abcdefghij:001", message.serial);
+    }
+
+
+    @Test
+    public void deserialize_message_with_unknown_action() throws Exception {
+        // Given
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("clientId", "test-client-id");
+        jsonObject.addProperty("data", "test-data");
+        jsonObject.addProperty("name", "test-name");
+        jsonObject.addProperty("action", 10);
+        jsonObject.addProperty("serial", "01826232498871-001@abcdefghij:001");
+
+        // When
+        Message message = Message.fromEncoded(jsonObject, new ChannelOptions());
+
+        // Then
+        assertEquals("test-client-id", message.clientId);
+        assertEquals("test-data", message.data);
+        assertEquals("test-name", message.name);
+        assertNull(message.action);
+        assertEquals("01826232498871-001@abcdefghij:001", message.serial);
+    }
 }

--- a/lib/src/test/resources/local/testAppSpec.json
+++ b/lib/src/test/resources/local/testAppSpec.json
@@ -19,8 +19,11 @@
 		},
 		{
 			"capability": "{\"persisted:text_protocol:channel0\":[\"publish\",\"subscribe\",\"history\"],\"persisted:text_protocol:channel1\":[\"publish\",\"subscribe\",\"history\"],\"persisted:binary_protocol:channel0\":[\"publish\",\"subscribe\",\"history\"],\"persisted:binary_protocol:channel1\":[\"publish\",\"subscribe\",\"history\"],\"persisted:*\":[\"subscribe\",\"history\"]}"
-		}
-	],
+		},
+    {
+      "capability": "{ \"[*]*\":[\"*\"] }"
+    }
+  ],
 	"namespaces": [
 		{
 			"id": "persisted",


### PR DESCRIPTION
Add `action` and `serial` fields to the message object for the Chat SDK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method for reading optional integer values from JSON.
	- Added new fields (`serial`, `version`, `action`, `createdAt`) to the Message class for enhanced message details.
	- Created a new enum (`MessageAction`) to represent various message actions.
	- Enhanced message handling logic to improve tracking of message versions during transmission.
	- Added a new capability in the JSON configuration to allow all actions.

- **Bug Fixes**
	- Improved serialization and deserialization processes to handle new fields effectively.
	- Refined error handling and state management during message processing and recovery.

- **Tests**
	- Expanded test coverage for the Message class, including new tests for serialization and deserialization with the new fields.
	- Added tests to validate message properties in the RealtimeMessageTest class.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->