### PR TITLE
[ECO-5163] fix: duplicated messages because of duplicated attach message

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -243,6 +243,16 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
             throw AblyException.fromErrorInfo(connectionManager.getStateErrorInfo());
         }
 
+        // (RTL4i)
+        if (connectionManager.getConnectionState().state == ConnectionState.connecting
+            || connectionManager.getConnectionState().state == ConnectionState.disconnected) {
+            if (listener != null) {
+                on(new ChannelStateCompletionListener(listener, ChannelState.attached, ChannelState.failed));
+            }
+            setState(ChannelState.attaching, null);
+            return;
+        }
+
         /* send attach request and pending state */
         Log.v(TAG, "attach(); channel = " + name + "; sending ATTACH request");
         ProtocolMessage attachMessage = new ProtocolMessage(Action.attach, this.name);

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -1684,9 +1684,14 @@ public class ConnectionManager implements ConnectListener {
 
     private void sendQueuedMessages() {
         synchronized(this) {
-            while(queuedMessages.size() > 0) {
+            while(!queuedMessages.isEmpty()) {
                 try {
-                    sendImpl(queuedMessages.get(0));
+                    QueuedMessage message = queuedMessages.get(0);
+                    // Do not send attach message from queued messages to prevent duplication
+                    // (we always send attach on connect event)
+                    if (message.msg.action != ProtocolMessage.Action.attach) {
+                        sendImpl(message);
+                    }
                 } catch (AblyException e) {
                     Log.e(TAG, "sendQueuedMessages(): Unexpected error sending queued messages", e);
                 } finally {

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeConnectFailTest.java
@@ -75,7 +75,8 @@ public class RealtimeConnectFailTest extends ParameterizedTest {
     public void connect_fail_authorized_error() throws AblyException {
         AblyRealtime ably = null;
         try {
-            ClientOptions opts = createOptions(testVars.appId + ".invalid_key_id:invalid_key_value");
+            String keyId = testVars.keys[0].keyName.split("\\.")[1];
+            ClientOptions opts = createOptions(testVars.appId + "." + keyId + ":invalid_key_value");
             ably = new AblyRealtime(opts);
             ConnectionWaiter connectionWaiter = new ConnectionWaiter(ably.connection);
 


### PR DESCRIPTION
Resolves https://github.com/ably/ably-java/issues/1050

Implemented missing [(RTL4i)](https://sdk.ably.com/builds/ably/specification/main/features/#RTL4i) spec point to prevent duplicated attach message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a conditional check to enhance channel attachment logic, preventing premature attach requests during specific connection states.
	- Introduced a new test to ensure message integrity by verifying that messages are not duplicated under certain subscription conditions.

- **Bug Fixes**
	- Improved message handling to prevent duplication of attach messages during connection events.

- **Tests**
	- Added a test method to validate message delivery without duplication.
	- Enhanced the flexibility of connection failure tests by using dynamic key assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->