### PR TITLE
[RTL13] Fix existing impl. for server sent DETACH

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -350,8 +350,9 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
             default:
         }
         ConnectionManager connectionManager = ably.connection.connectionManager;
-        if(!connectionManager.isActive())
+        if(!connectionManager.isActive()) { // RTL5g
             throw AblyException.fromErrorInfo(connectionManager.getStateErrorInfo());
+        }
 
         sendDetachMessage(listener);
     }
@@ -609,6 +610,7 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
             detachImpl(completionListener);
         } catch (AblyException e) {
             attachTimer = null;
+            callCompletionListenerError(listener, e.errorInfo); // RTL5g
         }
 
         if(attachTimer == null) {

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -1813,11 +1813,16 @@ public class RealtimeChannelTest extends ParameterizedTest {
             ProtocolMessage detachedMessage = new ProtocolMessage() {{
                 action = Action.detached;
                 channel = channelName;
+                error = new ErrorInfo("Simulated detach", 40000);
             }};
             ably.connection.connectionManager.onMessage(null, detachedMessage);
 
             /* Channel should transition to attaching, then to attached */
-            channelWaiter.waitFor(ChannelState.attaching);
+            ErrorInfo detachErr = channelWaiter.waitFor(ChannelState.attaching);
+            Assert.assertNotNull(detachErr);
+            Assert.assertEquals(40000, detachErr.code);
+            Assert.assertEquals("Simulated detach", detachErr.message);
+
             channelWaiter.waitFor(ChannelState.attached);
 
             List<ChannelState> channelStates = channelWaiter.getRecordedStates();
@@ -1869,11 +1874,16 @@ public class RealtimeChannelTest extends ParameterizedTest {
             ProtocolMessage detachedMessage = new ProtocolMessage() {{
                 action = Action.detached;
                 channel = channelName;
+                error = new ErrorInfo("Simulated detach", 40000);
             }};
             ably.connection.connectionManager.onMessage(null, detachedMessage);
 
             /* Channel should transition to attaching, then to attached */
-            channelWaiter.waitFor(ChannelState.attaching);
+            ErrorInfo detachError = channelWaiter.waitFor(ChannelState.attaching);
+            Assert.assertNotNull(detachError);
+            Assert.assertEquals(40000, detachError.code);
+            Assert.assertEquals("Simulated detach", detachError.message);
+
             channelWaiter.waitFor(ChannelState.attached);
 
             List<ChannelState> channelStates = channelWaiter.getRecordedStates();


### PR DESCRIPTION
- Fixed #1051 
- Fixed #1055 
- Fixed missing RTL5g impl. from https://github.com/ably/ably-java/issues/1045

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of channel state transitions and error information during attachment and detachment processes.
	- Added a new test to verify channel behavior during detach events in suspended state.

- **Bug Fixes**
	- Streamlined reattachment logic for channels after unexpected detach events.
	- Improved error handling to ensure accurate propagation during channel state changes.

- **Refactor**
	- Clarified state management logic and updated method signatures for better clarity and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->