### PR TITLE
[ECO-5188] MessageAction enum changes

### DIFF
--- a/lib/src/main/java/io/ably/lib/types/MessageAction.java
+++ b/lib/src/main/java/io/ably/lib/types/MessageAction.java
@@ -1,13 +1,11 @@
 package io.ably.lib.types;
 
 public enum MessageAction {
-    MESSAGE_UNSET, // 0
-    MESSAGE_CREATE, // 1
-    MESSAGE_UPDATE, // 2
-    MESSAGE_DELETE, // 3
-    ANNOTATION_CREATE, // 4
-    ANNOTATION_DELETE, // 5
-    META_OCCUPANCY; // 6
+    MESSAGE_CREATE, // 0
+    MESSAGE_UPDATE, // 1
+    MESSAGE_DELETE, // 2
+    META_OCCUPANCY, // 3
+    MESSAGE_SUMMARY; // 4
 
     static MessageAction tryFindByOrdinal(int ordinal) {
         return values().length <= ordinal ? null: values()[ordinal];

--- a/lib/src/test/java/io/ably/lib/types/MessageTest.java
+++ b/lib/src/test/java/io/ably/lib/types/MessageTest.java
@@ -65,7 +65,7 @@ public class MessageTest {
         assertEquals("test-key", serializedObject.get("connectionKey").getAsString());
         assertEquals("test-data", serializedObject.get("data").getAsString());
         assertEquals("test-name", serializedObject.get("name").getAsString());
-        assertEquals(1, serializedObject.get("action").getAsInt());
+        assertEquals(0, serializedObject.get("action").getAsInt());
         assertEquals("01826232498871-001@abcdefghij:001", serializedObject.get("serial").getAsString());
     }
 
@@ -76,7 +76,7 @@ public class MessageTest {
        jsonObject.addProperty("clientId", "test-client-id");
        jsonObject.addProperty("data", "test-data");
        jsonObject.addProperty("name", "test-name");
-       jsonObject.addProperty("action", 1);
+       jsonObject.addProperty("action", 0);
        jsonObject.addProperty("serial", "01826232498871-001@abcdefghij:001");
 
         // When


### PR DESCRIPTION
per https://github.com/ably/specification/pull/263

Breaking change but this was agreed, as no clients are currently using the action yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Breaking Changes**
	- Removed `MESSAGE_UNSET`, `ANNOTATION_CREATE`, and `ANNOTATION_DELETE` enum values
	- Adjusted ordinal values for `MESSAGE_CREATE`, `MESSAGE_UPDATE`, and `MESSAGE_DELETE`
	- Added new `MESSAGE_SUMMARY` enum value

- **Updates**
	- Updated `META_OCCUPANCY` ordinal value
	- Modified message action serialization and deserialization tests to reflect new enum configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->