### PR TITLE
[ECO-5193] Support message edits and deletes

### DIFF
--- a/lib/src/main/java/io/ably/lib/types/Message.java
+++ b/lib/src/main/java/io/ably/lib/types/Message.java
@@ -98,19 +98,25 @@ public class Message extends BaseMessage {
         public Map<String, String> metadata;
 
         void write(MessagePacker packer) throws IOException {
-            packer.packMapHeader(3);
-            if(clientId != null) {
+            int fieldCount = 0;
+            if (clientId != null) fieldCount++;
+            if (description != null) fieldCount++;
+            if (metadata != null) fieldCount++;
+
+            packer.packMapHeader(fieldCount);
+
+            if (clientId != null) {
                 packer.packString("clientId");
                 packer.packString(clientId);
             }
-            if(description != null) {
+            if (description != null) {
                 packer.packString("description");
                 packer.packString(description);
             }
-            if(metadata != null) {
+            if (metadata != null) {
                 packer.packString("metadata");
                 packer.packMapHeader(metadata.size());
-                for(Map.Entry<String, String> entry : metadata.entrySet()) {
+                for (Map.Entry<String, String> entry : metadata.entrySet()) {
                     packer.packString(entry.getKey());
                     packer.packString(entry.getValue());
                 }

--- a/lib/src/main/java/io/ably/lib/types/Message.java
+++ b/lib/src/main/java/io/ably/lib/types/Message.java
@@ -3,6 +3,7 @@ package io.ably.lib.types;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 
 import com.google.gson.JsonArray;
@@ -19,7 +20,6 @@ import org.msgpack.core.MessagePacker;
 import org.msgpack.core.MessageUnpacker;
 
 import io.ably.lib.util.Log;
-
 
 /**
  * Contains an individual message that is sent to, or received from, Ably.
@@ -95,7 +95,7 @@ public class Message extends BaseMessage {
     public static class Operation {
         public String clientId;
         public String description;
-        public JsonObject metadata;
+        public Map<String, String> metadata;
 
         void write(MessagePacker packer) throws IOException {
             packer.packMapHeader(3);
@@ -110,9 +110,9 @@ public class Message extends BaseMessage {
             if(metadata != null) {
                 packer.packString("metadata");
                 packer.packMapHeader(metadata.size());
-                for(Map.Entry<String, JsonElement> entry : metadata.entrySet()) {
+                for(Map.Entry<String, String> entry : metadata.entrySet()) {
                     packer.packString(entry.getKey());
-                    Serialisation.gsonToMsgpack(entry.getValue(), packer);
+                    packer.packString(entry.getValue());
                 }
             }
         }
@@ -131,11 +131,11 @@ public class Message extends BaseMessage {
                         break;
                     case "metadata":
                         int mapSize = unpacker.unpackMapHeader();
-                        operation.metadata = new JsonObject();
+                        operation.metadata = new HashMap<>(mapSize);
                         for (int j = 0; j < mapSize; j++) {
                             String key = unpacker.unpackString();
-                            JsonElement value = Serialisation.msgpackToGson(unpacker.unpackValue());
-                            operation.metadata.add(key, value);
+                            String value = unpacker.unpackString();
+                            operation.metadata.put(key, value);
                         }
                         break;
                     default:
@@ -155,7 +155,11 @@ public class Message extends BaseMessage {
                 operation.description = jsonObject.get("description").getAsString();
             }
             if (jsonObject.has("metadata")) {
-                operation.metadata = jsonObject.getAsJsonObject("metadata");
+                JsonObject metadataObject = jsonObject.getAsJsonObject("metadata");
+                operation.metadata = new HashMap<>();
+                for (Map.Entry<String, JsonElement> entry : metadataObject.entrySet()) {
+                    operation.metadata.put(entry.getKey(), entry.getValue().getAsString());
+                }
             }
             return operation;
         }

--- a/lib/src/test/java/io/ably/lib/chat/ChatMessagesTest.java
+++ b/lib/src/test/java/io/ably/lib/chat/ChatMessagesTest.java
@@ -108,4 +108,118 @@ public class ChatMessagesTest extends ParameterizedTest {
                 ably.close();
         }
     }
+
+    /**
+     * Test that a message updated via rest API is sent to a messages channel.
+     * It should be received by another client that is subscribed to the same messages channel.
+     * Make sure to use two clientIds: clientId1 and clientId2
+     */
+    @Test
+    public void test_room_message_is_updated() {
+        String roomId = "1234";
+        String channelName = roomId + "::$chat::$chatMessages";
+        AblyRealtime ablyClient1 = null;
+        AblyRealtime ablyClient2 = null;
+        try {
+            ClientOptions opts1 = createOptions(testVars.keys[7].keyStr);
+            opts1.clientId = "clientId1";
+            ablyClient1 = new AblyRealtime(opts1);
+
+            ClientOptions opts2 = createOptions(testVars.keys[7].keyStr);
+            opts2.clientId = "clientId2";
+            ablyClient2 = new AblyRealtime(opts2);
+
+            ChatRoom room = new ChatRoom(roomId, ablyClient1);
+
+            // Create a channel and attach with client1
+            final Channel channel1 = ablyClient1.channels.get(channelName);
+            channel1.attach();
+            (new Helpers.ChannelWaiter(channel1)).waitFor(ChannelState.attached);
+
+            // Subscribe to messages with client2
+            final Channel channel2 = ablyClient2.channels.get(channelName);
+            channel2.attach();
+            (new Helpers.ChannelWaiter(channel2)).waitFor(ChannelState.attached);
+
+            List<Message> receivedMsg = new ArrayList<>();
+            channel2.subscribe(receivedMsg::add);
+
+            // Send message to room
+            ChatRoom.SendMessageParams params = new ChatRoom.SendMessageParams();
+            params.text = "hello there";
+            JsonObject sendMessageResult = (JsonObject) room.sendMessage(params);
+            String originalSerial = sendMessageResult.get("serial").getAsString();
+            String originalCreatedAt = sendMessageResult.get("createdAt").getAsString();
+
+            // Wait for the message to be received
+            Exception err = new Helpers.ConditionalWaiter().wait(() -> !receivedMsg.isEmpty(), 10_000);
+            Assert.assertNull(err);
+
+            // Update the message
+            ChatRoom.UpdateMessageParams updateParams = new ChatRoom.UpdateMessageParams();
+            // Update message context
+            updateParams.message = new ChatRoom.SendMessageParams();
+            updateParams.message.text = "updated text";
+            JsonObject metaData = new JsonObject();
+            JsonObject foo = new JsonObject();
+            foo.addProperty("bar", 1);
+            metaData.add("foo", foo);
+            updateParams.message.metadata = metaData;
+            // Update description
+            updateParams.description = "message updated by clientId1";
+
+            // TODO - Update external metadata, this will be populated in operation field
+            // updateParams.metadata = params.metadata;
+
+            JsonObject updateMessageResult = (JsonObject) room.updateMessage(originalSerial, updateParams);
+            String updateResultVersion = updateMessageResult.get("version").getAsString();
+            String updateResultTimestamp = updateMessageResult.get("timestamp").getAsString();
+
+            // Wait for the updated message to be received
+            err = new Helpers.ConditionalWaiter().wait(() -> receivedMsg.size() == 2, 10_000);
+            Assert.assertNull(err);
+
+            // Verify the updated message
+            Message updatedMessage = receivedMsg.get(1);
+
+            Assert.assertEquals(MessageAction.MESSAGE_UPDATE, updatedMessage.action);
+
+            Assert.assertFalse("Message ID should not be empty", updatedMessage.id.isEmpty());
+            Assert.assertEquals("chat.message", updatedMessage.name);
+            Assert.assertEquals("clientId1", updatedMessage.clientId);
+
+            JsonObject data = (JsonObject) updatedMessage.data;
+            Assert.assertEquals(2, data.entrySet().size());
+            Assert.assertEquals("updated text", data.get("text").getAsString());
+            JsonObject metadata = data.getAsJsonObject("metadata");
+            Assert.assertTrue(metadata.has("foo"));
+            Assert.assertTrue(metadata.get("foo").isJsonObject());
+            Assert.assertEquals(1, metadata.getAsJsonObject("foo").get("bar").getAsInt());
+
+            Assert.assertEquals(originalSerial, updatedMessage.serial);
+            Assert.assertEquals(updateResultVersion, updatedMessage.version);
+
+            Assert.assertEquals(originalCreatedAt, updatedMessage.createdAt.toString());
+            Assert.assertEquals(updateResultTimestamp, String.valueOf(updatedMessage.timestamp));
+
+            // TODO - Add assertion for operation field
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail("Unexpected exception instantiating library");
+        } finally {
+            if (ablyClient1 != null) ablyClient1.close();
+            if (ablyClient2 != null) ablyClient2.close();
+        }
+    }
+
+    /**
+     * Test that a message deleted via rest API is sent to a messages channel.
+     * It should be received by another client that is subscribed to the same messages channel.
+     * Make sure to use two clientIds: clientId1 and clientId2
+     */
+    @Test
+    public void test_room_message_is_deleted() {
+
+    }
 }

--- a/lib/src/test/java/io/ably/lib/chat/ChatMessagesTest.java
+++ b/lib/src/test/java/io/ably/lib/chat/ChatMessagesTest.java
@@ -168,8 +168,11 @@ public class ChatMessagesTest extends ParameterizedTest {
             // Update description
             updateParams.description = "message updated by clientId1";
 
-            // TODO - Update external metadata, this will be populated in operation field
-            // updateParams.metadata = params.metadata;
+            // Update metadata, add few random fields
+            Map<String, String> operationMetadata = new HashMap<>();
+            operationMetadata.put("foo", "bar");
+            operationMetadata.put("naruto", "hero");
+            updateParams.metadata = operationMetadata;
 
             JsonObject updateMessageResult = (JsonObject) room.updateMessage(originalSerial, updateParams);
             String updateResultVersion = updateMessageResult.get("version").getAsString();
@@ -197,12 +200,18 @@ public class ChatMessagesTest extends ParameterizedTest {
             Assert.assertEquals(1, metadata.getAsJsonObject("foo").get("bar").getAsInt());
 
             Assert.assertEquals(originalSerial, updatedMessage.serial);
-            Assert.assertEquals(updateResultVersion, updatedMessage.version);
-
             Assert.assertEquals(originalCreatedAt, updatedMessage.createdAt.toString());
+
+            Assert.assertEquals(updateResultVersion, updatedMessage.version);
             Assert.assertEquals(updateResultTimestamp, String.valueOf(updatedMessage.timestamp));
 
-            // TODO - Add assertion for operation field
+            // updatedMessage contains `operation` with fields as clientId, description, metadata, assert for these fields
+            Message.Operation operation = updatedMessage.operation;
+            Assert.assertEquals("clientId1", operation.clientId);
+            Assert.assertEquals("message updated by clientId1", operation.description);
+            Assert.assertEquals(2, operation.metadata.size());
+            Assert.assertEquals("bar", operation.metadata.get("foo"));
+            Assert.assertEquals("hero", operation.metadata.get("naruto"));
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/lib/src/test/java/io/ably/lib/chat/ChatMessagesTest.java
+++ b/lib/src/test/java/io/ably/lib/chat/ChatMessagesTest.java
@@ -1,0 +1,86 @@
+package io.ably.lib.chat;
+
+import com.google.gson.JsonObject;
+import io.ably.lib.realtime.AblyRealtime;
+import io.ably.lib.realtime.Channel;
+import io.ably.lib.realtime.ChannelState;
+import io.ably.lib.test.common.Helpers;
+import io.ably.lib.test.common.ParameterizedTest;
+import io.ably.lib.types.ClientOptions;
+import io.ably.lib.types.Message;
+import io.ably.lib.types.MessageAction;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChatMessagesTest extends ParameterizedTest {
+    /**
+     * Connect to the service and attach, then subscribe and unsubscribe
+     */
+    @Test
+    public void test_room_message_is_published() {
+        String roomId = "1234";
+        String channelName = roomId + "::$chat::$chatMessages";
+        AblyRealtime ably = null;
+        try {
+            ClientOptions opts = createOptions(testVars.keys[7].keyStr);
+            opts.clientId = "sandbox-client";
+            ably = new AblyRealtime(opts);
+            ChatRoom room = new ChatRoom(roomId, ably);
+
+            /* create a channel and attach */
+            final Channel channel = ably.channels.get(channelName);
+            channel.attach();
+            (new Helpers.ChannelWaiter(channel)).waitFor(ChannelState.attached);
+
+            /* subscribe to messages */
+            List<Message> receivedMsg = new ArrayList<>();
+            channel.subscribe(receivedMsg::add);
+
+            // send message to room
+            ChatRoom.SendMessageParams params = new ChatRoom.SendMessageParams();
+            params.text = "hello there";
+            JsonObject sendMessageResult = (JsonObject) room.sendMessage(params);
+            // check sendMessageResult has 2 fields and are not null
+            Assert.assertEquals(2, sendMessageResult.entrySet().size());
+            String resultSerial = sendMessageResult.get("serial").getAsString();
+            Assert.assertFalse(resultSerial.isEmpty());
+            String resultCreatedAt = sendMessageResult.get("createdAt").getAsString();
+            Assert.assertFalse(resultCreatedAt.isEmpty());
+
+            Exception err = new Helpers.ConditionalWaiter().wait(() -> !receivedMsg.isEmpty(), 10_000);
+            Assert.assertNull(err);
+
+            Assert.assertEquals(1, receivedMsg.size());
+            Message message = receivedMsg.get(0);
+
+            Assert.assertFalse("Message ID should not be empty", message.id.isEmpty());
+            Assert.assertEquals("chat.message", message.name);
+            Assert.assertEquals("sandbox-client", message.clientId);
+
+            JsonObject data = (JsonObject) message.data;
+            // has two fields "text" and "metadata"
+            Assert.assertEquals(2, data.entrySet().size());
+            Assert.assertEquals("hello there", data.get("text").getAsString());
+            Assert.assertTrue(data.get("metadata").isJsonObject());
+
+            Assert.assertEquals(resultCreatedAt, String.valueOf(message.timestamp));
+
+            Assert.assertEquals(resultCreatedAt, message.createdAt.toString());
+            Assert.assertEquals(resultSerial, message.serial);
+            Assert.assertEquals(resultSerial, message.version);
+
+            Assert.assertEquals(MessageAction.MESSAGE_CREATE, message.action);
+            Assert.assertEquals(resultCreatedAt, message.createdAt.toString());
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail("init0: Unexpected exception instantiating library");
+        } finally {
+            if(ably != null)
+                ably.close();
+        }
+    }
+}

--- a/lib/src/test/java/io/ably/lib/chat/ChatMessagesTest.java
+++ b/lib/src/test/java/io/ably/lib/chat/ChatMessagesTest.java
@@ -316,4 +316,208 @@ public class ChatMessagesTest extends ParameterizedTest {
             if (ablyClient2 != null) ablyClient2.close();
         }
     }
+
+    /**
+     * Test that message is created, updated and then deleted serially
+     */
+    @Test
+    public void test_room_message_create_update_delete() {
+        String roomId = "1234";
+        String channelName = roomId + "::$chat::$chatMessages";
+        AblyRealtime ablyClient1 = null;
+        AblyRealtime ablyClient2 = null;
+        try {
+            ClientOptions opts1 = createOptions(testVars.keys[7].keyStr);
+            opts1.clientId = "clientId1";
+            ablyClient1 = new AblyRealtime(opts1);
+
+            ClientOptions opts2 = createOptions(testVars.keys[7].keyStr);
+            opts2.clientId = "clientId2";
+            ablyClient2 = new AblyRealtime(opts2);
+
+            ChatRoom room = new ChatRoom(roomId, ablyClient1);
+
+            // Create a channel and attach with client1
+            final Channel channel1 = ablyClient1.channels.get(channelName);
+            channel1.attach();
+            (new Helpers.ChannelWaiter(channel1)).waitFor(ChannelState.attached);
+
+            // Subscribe to messages with client2
+            final Channel channel2 = ablyClient2.channels.get(channelName);
+            channel2.attach();
+            (new Helpers.ChannelWaiter(channel2)).waitFor(ChannelState.attached);
+
+            List<Message> receivedMsg = new ArrayList<>();
+            channel2.subscribe(receivedMsg::add);
+
+            // Send message to room
+            ChatRoom.SendMessageParams sendParams = new ChatRoom.SendMessageParams();
+            sendParams.text = "hello there";
+
+            JsonObject sendMessageResult = (JsonObject) room.sendMessage(sendParams);
+            String originalSerial = sendMessageResult.get("serial").getAsString();
+            String originalCreatedAt = sendMessageResult.get("createdAt").getAsString();
+
+            // Wait for the message to be received
+            Exception err = new Helpers.ConditionalWaiter().wait(() -> !receivedMsg.isEmpty(), 10_000);
+            Assert.assertNull(err);
+
+            // Update the message
+            ChatRoom.UpdateMessageParams updateParams = new ChatRoom.UpdateMessageParams();
+            updateParams.message = new ChatRoom.SendMessageParams();
+            updateParams.message.text = "updated text";
+
+            JsonObject updateMessageResult = (JsonObject) room.updateMessage(originalSerial, updateParams);
+            String updateResultVersion = updateMessageResult.get("version").getAsString();
+            String updateResultTimestamp = updateMessageResult.get("timestamp").getAsString();
+
+            // Wait for the updated message to be received
+            err = new Helpers.ConditionalWaiter().wait(() -> receivedMsg.size() == 2, 10_000);
+            Assert.assertNull(err);
+
+            // Delete the message
+            ChatRoom.DeleteMessageParams deleteParams = new ChatRoom.DeleteMessageParams();
+            deleteParams.description = "message deleted by clientId1";
+
+            JsonObject deleteMessageResult = (JsonObject) room.deleteMessage(originalSerial, deleteParams);
+            String deleteResultVersion = deleteMessageResult.get("version").getAsString();
+            String deleteResultTimestamp = deleteMessageResult.get("timestamp").getAsString();
+
+            // Wait for the deleted message to be received
+            err = new Helpers.ConditionalWaiter().wait(() -> receivedMsg.size() == 3, 10_000);
+            Assert.assertNull(err);
+
+            // Verify the created message
+            Message createdMessage = receivedMsg.get(0);
+            Assert.assertEquals(MessageAction.MESSAGE_CREATE, createdMessage.action);
+            Assert.assertFalse("Message ID should not be empty", createdMessage.id.isEmpty());
+            Assert.assertEquals("chat.message", createdMessage.name);
+            Assert.assertEquals("clientId1", createdMessage.clientId);
+            JsonObject createdData = (JsonObject) createdMessage.data;
+            Assert.assertEquals("hello there", createdData.get("text").getAsString());
+
+            // Verify the updated message
+            Message updatedMessage = receivedMsg.get(1);
+            Assert.assertEquals(MessageAction.MESSAGE_UPDATE, updatedMessage.action);
+            Assert.assertFalse("Message ID should not be empty", updatedMessage.id.isEmpty());
+            Assert.assertEquals("chat.message", updatedMessage.name);
+            Assert.assertEquals("clientId1", updatedMessage.clientId);
+            JsonObject updatedData = (JsonObject) updatedMessage.data;
+            Assert.assertEquals("updated text", updatedData.get("text").getAsString());
+
+            Assert.assertEquals(updateResultVersion, updatedMessage.version);
+            Assert.assertEquals(updateResultTimestamp, String.valueOf(updatedMessage.timestamp));
+
+            // Verify the deleted message
+            Message deletedMessage = receivedMsg.get(2);
+            Assert.assertEquals(MessageAction.MESSAGE_DELETE, deletedMessage.action);
+            Assert.assertFalse("Message ID should not be empty", deletedMessage.id.isEmpty());
+            Assert.assertEquals("chat.message", deletedMessage.name);
+            Assert.assertEquals("clientId1", deletedMessage.clientId);
+
+            Assert.assertEquals(deleteResultVersion, deletedMessage.version);
+            Assert.assertEquals(deleteResultTimestamp, String.valueOf(deletedMessage.timestamp));
+
+            // Check original serials
+            Assert.assertEquals(originalSerial, createdMessage.serial);
+            Assert.assertEquals(originalSerial, updatedMessage.serial);
+            Assert.assertEquals(originalSerial, deletedMessage.serial);
+
+            // Check original message createdAt
+            Assert.assertEquals(originalCreatedAt, createdMessage.createdAt.toString());
+            Assert.assertEquals(originalCreatedAt, updatedMessage.createdAt.toString());
+            Assert.assertEquals(originalCreatedAt, deletedMessage.createdAt.toString());
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail("Unexpected exception instantiating library");
+        } finally {
+            if (ablyClient1 != null) ablyClient1.close();
+            if (ablyClient2 != null) ablyClient2.close();
+        }
+    }
+
+    /**
+     * Test that update/delete operations are allowed on a deleted message.
+     */
+    @Test
+    public void test_operations_allowed_on_deleted_message() {
+        String roomId = "1234";
+        String channelName = roomId + "::$chat::$chatMessages";
+        AblyRealtime ablyClient1 = null;
+        AblyRealtime ablyClient2 = null;
+        try {
+            ClientOptions opts1 = createOptions(testVars.keys[7].keyStr);
+            opts1.clientId = "clientId1";
+            ablyClient1 = new AblyRealtime(opts1);
+
+            ClientOptions opts2 = createOptions(testVars.keys[7].keyStr);
+            opts2.clientId = "clientId2";
+            ablyClient2 = new AblyRealtime(opts2);
+
+            ChatRoom room = new ChatRoom(roomId, ablyClient1);
+
+            // Create a channel and attach with client1
+            final Channel channel1 = ablyClient1.channels.get(channelName);
+            channel1.attach();
+            (new Helpers.ChannelWaiter(channel1)).waitFor(ChannelState.attached);
+
+            // Subscribe to messages with client2
+            final Channel channel2 = ablyClient2.channels.get(channelName);
+            channel2.attach();
+            (new Helpers.ChannelWaiter(channel2)).waitFor(ChannelState.attached);
+
+            List<Message> receivedMsg = new ArrayList<>();
+            channel2.subscribe(receivedMsg::add);
+
+            // Send message to room
+            ChatRoom.SendMessageParams sendParams = new ChatRoom.SendMessageParams();
+            sendParams.text = "hello there";
+
+            JsonObject sendMessageResult = (JsonObject) room.sendMessage(sendParams);
+            String originalSerial = sendMessageResult.get("serial").getAsString();
+
+            // Wait for the message to be received
+            Exception err = new Helpers.ConditionalWaiter().wait(() -> !receivedMsg.isEmpty(), 10_000);
+            Assert.assertNull(err);
+
+            // Delete the message
+            ChatRoom.DeleteMessageParams deleteParams = new ChatRoom.DeleteMessageParams();
+            deleteParams.description = "message deleted by clientId1";
+
+            room.deleteMessage(originalSerial, deleteParams);
+
+            // Wait for the deleted message to be received
+            err = new Helpers.ConditionalWaiter().wait(() -> receivedMsg.size() == 2, 10_000);
+            Assert.assertNull(err);
+
+            // Attempt to update the deleted message
+            ChatRoom.UpdateMessageParams updateParams = new ChatRoom.UpdateMessageParams();
+            updateParams.message = new ChatRoom.SendMessageParams();
+            updateParams.message.text = "updated text";
+            room.updateMessage(originalSerial, updateParams);
+
+            // wait for updated message to be received
+            err = new Helpers.ConditionalWaiter().wait(() -> receivedMsg.size() == 3, 10_000);
+            Assert.assertNull(err);
+
+            // Attempt to delete the already deleted message
+            room.deleteMessage(originalSerial, deleteParams);
+            // wait for delete message received
+            err = new Helpers.ConditionalWaiter().wait(() -> receivedMsg.size() == 4, 10_000);
+            Assert.assertNull(err);
+
+            Assert.assertEquals(4, receivedMsg.size());
+            for (Message msg : receivedMsg) {
+                Assert.assertEquals("Serial should match original serial", originalSerial, msg.serial);
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail("Unexpected exception instantiating library");
+        } finally {
+            if (ablyClient1 != null) ablyClient1.close();
+            if (ablyClient2 != null) ablyClient2.close();
+        }
+    }
 }

--- a/lib/src/test/java/io/ably/lib/chat/ChatRoom.java
+++ b/lib/src/test/java/io/ably/lib/chat/ChatRoom.java
@@ -47,12 +47,12 @@ public class ChatRoom {
     public static class UpdateMessageParams {
         public SendMessageParams message;
         public String description;
-        public JsonObject metadata;
+        public Map<String, String> metadata;
     }
 
     public static class DeleteMessageParams {
         public String description;
-        public JsonObject metadata;
+        public Map<String, String> metadata;
     }
 
     protected Optional<JsonElement> makeAuthorizedRequest(String url, String method, JsonElement body) throws AblyException {

--- a/lib/src/test/java/io/ably/lib/chat/ChatRoom.java
+++ b/lib/src/test/java/io/ably/lib/chat/ChatRoom.java
@@ -7,6 +7,7 @@ import io.ably.lib.http.HttpCore;
 import io.ably.lib.http.HttpUtils;
 import io.ably.lib.rest.AblyRest;
 import io.ably.lib.types.AblyException;
+import io.ably.lib.types.ErrorInfo;
 import io.ably.lib.types.HttpPaginatedResponse;
 import io.ably.lib.types.Param;
 
@@ -17,6 +18,7 @@ import java.util.Optional;
 public class ChatRoom {
     private final AblyRest ablyRest;
     private final String roomId;
+    private final Gson gson = new Gson();
 
     protected ChatRoom(String roomId, AblyRest ablyRest) {
         this.roomId = roomId;
@@ -24,18 +26,18 @@ public class ChatRoom {
     }
 
     public JsonElement sendMessage(SendMessageParams params) throws Exception {
-        return makeAuthorizedRequest("/chat/v2/rooms/" + roomId + "/messages", "POST", new Gson().toJsonTree(params))
-            .orElseThrow(() -> new Exception("Failed to send message"));
+        return makeAuthorizedRequest("/chat/v2/rooms/" + roomId + "/messages", "POST", gson.toJsonTree(params))
+            .orElseThrow(() -> AblyException.fromErrorInfo(new ErrorInfo("Failed to send message", 500)));
     }
 
     public JsonElement updateMessage(String serial, UpdateMessageParams params) throws Exception {
-        return makeAuthorizedRequest("/chat/v2/rooms/" + roomId + "/messages/" + serial, "PUT", new Gson().toJsonTree(params))
-            .orElseThrow(() -> new Exception("Failed to update message"));
+        return makeAuthorizedRequest("/chat/v2/rooms/" + roomId + "/messages/" + serial, "PUT", gson.toJsonTree(params))
+            .orElseThrow(() -> AblyException.fromErrorInfo(new ErrorInfo("Failed to update message", 500)));
     }
 
     public JsonElement deleteMessage(String serial, DeleteMessageParams params) throws Exception {
-        return makeAuthorizedRequest("/chat/v2/rooms/" + roomId + "/messages/" + serial + "/delete", "POST", new Gson().toJsonTree(params))
-            .orElseThrow(() -> new Exception("Failed to delete message"));
+        return makeAuthorizedRequest("/chat/v2/rooms/" + roomId + "/messages/" + serial + "/delete", "POST", gson.toJsonTree(params))
+            .orElseThrow(() -> AblyException.fromErrorInfo(new ErrorInfo("Failed to delete message", 500)));
     }
 
     public static class SendMessageParams {

--- a/lib/src/test/java/io/ably/lib/chat/ChatRoom.java
+++ b/lib/src/test/java/io/ably/lib/chat/ChatRoom.java
@@ -1,0 +1,62 @@
+package io.ably.lib.chat;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import io.ably.lib.http.HttpCore;
+import io.ably.lib.http.HttpUtils;
+import io.ably.lib.rest.AblyRest;
+import io.ably.lib.types.AblyException;
+import io.ably.lib.types.HttpPaginatedResponse;
+import io.ably.lib.types.Param;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+public class ChatRoom {
+    private final AblyRest ablyRest;
+    private final String roomId;
+
+    protected ChatRoom(String roomId, AblyRest ablyRest) {
+        this.roomId = roomId;
+        this.ablyRest = ablyRest;
+    }
+
+    public JsonElement sendMessage(SendMessageParams params) throws Exception {
+        return makeAuthorizedRequest("/chat/v2/rooms/" + roomId + "/messages", "POST", new Gson().toJsonTree(params))
+            .orElseThrow(() -> new Exception("Failed to send message"));
+    }
+
+    public JsonElement updateMessage(String serial, UpdateMessageParams params) throws Exception {
+        return makeAuthorizedRequest("/chat/v2/rooms/" + roomId + "/messages/" + serial, "PUT", new Gson().toJsonTree(params))
+            .orElseThrow(() -> new Exception("Failed to update message"));
+    }
+
+    public JsonElement deleteMessage(String serial, DeleteMessageParams params) throws Exception {
+        return makeAuthorizedRequest("/chat/v2/rooms/" + roomId + "/messages/" + serial + "/delete", "POST", new Gson().toJsonTree(params))
+            .orElseThrow(() -> new Exception("Failed to delete message"));
+    }
+
+    public static class SendMessageParams {
+        public String text;
+        public Map<String, Object> metadata;
+        public Map<String, String> headers;
+    }
+
+    public static class UpdateMessageParams {
+        public SendMessageParams message;
+        public String description;
+        public Map<String, Object> metadata;
+    }
+
+    public static class DeleteMessageParams {
+        public String description;
+        public Map<String, Object> metadata;
+    }
+
+    protected Optional<JsonElement> makeAuthorizedRequest(String url, String method, JsonElement body) throws AblyException {
+        HttpCore.RequestBody httpRequestBody = HttpUtils.requestBodyFromGson(body, ablyRest.options.useBinaryProtocol);
+        HttpPaginatedResponse response = ablyRest.request(method, url, new Param[] { new Param("v", 3) }, httpRequestBody, null);
+        return Arrays.stream(response.items()).findFirst();
+    }
+}

--- a/lib/src/test/java/io/ably/lib/chat/ChatRoom.java
+++ b/lib/src/test/java/io/ably/lib/chat/ChatRoom.java
@@ -2,6 +2,7 @@ package io.ably.lib.chat;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import io.ably.lib.http.HttpCore;
 import io.ably.lib.http.HttpUtils;
 import io.ably.lib.rest.AblyRest;
@@ -39,19 +40,19 @@ public class ChatRoom {
 
     public static class SendMessageParams {
         public String text;
-        public Map<String, Object> metadata;
+        public JsonObject metadata;
         public Map<String, String> headers;
     }
 
     public static class UpdateMessageParams {
         public SendMessageParams message;
         public String description;
-        public Map<String, Object> metadata;
+        public JsonObject metadata;
     }
 
     public static class DeleteMessageParams {
         public String description;
-        public Map<String, Object> metadata;
+        public JsonObject metadata;
     }
 
     protected Optional<JsonElement> makeAuthorizedRequest(String url, String method, JsonElement body) throws AblyException {

--- a/lib/src/test/java/io/ably/lib/types/MessageTest.java
+++ b/lib/src/test/java/io/ably/lib/types/MessageTest.java
@@ -12,7 +12,6 @@ import org.msgpack.core.MessagePacker;
 import org.msgpack.core.MessageUnpacker;
 
 import java.io.ByteArrayOutputStream;
-import java.util.HashMap;
 
 public class MessageTest {
 
@@ -107,9 +106,9 @@ public class MessageTest {
         Message.Operation operation = new Message.Operation();
         operation.clientId = "operation-client-id";
         operation.description = "operation-description";
-        operation.metadata = new HashMap<>();
-        operation.metadata.put("key1", "value1");
-        operation.metadata.put("key2", "value2");
+        operation.metadata = new JsonObject();
+        operation.metadata.addProperty("key1", "value1");
+        operation.metadata.addProperty("key2", "value2");
         message.operation = operation;
 
         // When
@@ -162,8 +161,8 @@ public class MessageTest {
         assertEquals("test-key", message.connectionKey);
         assertEquals("operation-client-id", message.operation.clientId);
         assertEquals("operation-description", message.operation.description);
-        assertEquals("value1", message.operation.metadata.get("key1"));
-        assertEquals("value2", message.operation.metadata.get("key2"));
+        assertEquals("value1", message.operation.metadata.get("key1").getAsString());
+        assertEquals("value2", message.operation.metadata.get("key2").getAsString());
     }
 
     @Test
@@ -200,9 +199,9 @@ public class MessageTest {
         Message.Operation operation = new Message.Operation();
         operation.clientId = "operation-client-id";
         operation.description = "operation-description";
-        operation.metadata = new HashMap<>();
-        operation.metadata.put("key1", "value1");
-        operation.metadata.put("key2", "value2");
+        operation.metadata = new JsonObject();
+        operation.metadata.addProperty("key1", "value1");
+        operation.metadata.addProperty("key2", "value2");
         message.operation = operation;
 
         // When Encode to MessagePack
@@ -227,7 +226,7 @@ public class MessageTest {
         assertEquals("01826232498871-001@abcdefghij:001", unpacked.serial);
         assertEquals("operation-client-id", unpacked.operation.clientId);
         assertEquals("operation-description", unpacked.operation.description);
-        assertEquals("value1", unpacked.operation.metadata.get("key1"));
-        assertEquals("value2", unpacked.operation.metadata.get("key2"));
+        assertEquals("value1", unpacked.operation.metadata.get("key1").getAsString());
+        assertEquals("value2", unpacked.operation.metadata.get("key2").getAsString());
     }
 }

--- a/lib/src/test/java/io/ably/lib/types/MessageTest.java
+++ b/lib/src/test/java/io/ably/lib/types/MessageTest.java
@@ -6,7 +6,13 @@ import static org.junit.Assert.assertNull;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.ably.lib.types.Message.Serializer;
+import io.ably.lib.util.Serialisation;
 import org.junit.Test;
+import org.msgpack.core.MessagePacker;
+import org.msgpack.core.MessageUnpacker;
+
+import java.io.ByteArrayOutputStream;
+import java.util.HashMap;
 
 public class MessageTest {
 
@@ -90,6 +96,75 @@ public class MessageTest {
         assertEquals("01826232498871-001@abcdefghij:001", message.serial);
     }
 
+    @Test
+    public void serialize_message_with_operation() {
+        // Given
+        Message message = new Message("test-name", "test-data");
+        message.clientId = "test-client-id";
+        message.connectionKey = "test-key";
+        message.refSerial = "test-ref-serial";
+        message.refType = "test-ref-type";
+        Message.Operation operation = new Message.Operation();
+        operation.clientId = "operation-client-id";
+        operation.description = "operation-description";
+        operation.metadata = new HashMap<>();
+        operation.metadata.put("key1", "value1");
+        operation.metadata.put("key2", "value2");
+        message.operation = operation;
+
+        // When
+        JsonElement serializedElement = serializer.serialize(message, null, null);
+
+        // Then
+        JsonObject serializedObject = serializedElement.getAsJsonObject();
+        assertEquals("test-client-id", serializedObject.get("clientId").getAsString());
+        assertEquals("test-key", serializedObject.get("connectionKey").getAsString());
+        assertEquals("test-data", serializedObject.get("data").getAsString());
+        assertEquals("test-name", serializedObject.get("name").getAsString());
+        assertEquals("test-ref-serial", serializedObject.get("refSerial").getAsString());
+        assertEquals("test-ref-type", serializedObject.get("refType").getAsString());
+        JsonObject operationObject = serializedObject.getAsJsonObject("operation");
+        assertEquals("operation-client-id", operationObject.get("clientId").getAsString());
+        assertEquals("operation-description", operationObject.get("description").getAsString());
+        JsonObject metadataObject = operationObject.getAsJsonObject("metadata");
+        assertEquals("value1", metadataObject.get("key1").getAsString());
+        assertEquals("value2", metadataObject.get("key2").getAsString());
+    }
+
+    @Test
+    public void deserialize_message_with_operation() throws Exception {
+        // Given
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("clientId", "test-client-id");
+        jsonObject.addProperty("data", "test-data");
+        jsonObject.addProperty("name", "test-name");
+        jsonObject.addProperty("refSerial", "test-ref-serial");
+        jsonObject.addProperty("refType", "test-ref-type");
+        jsonObject.addProperty("connectionKey", "test-key");
+        JsonObject operationObject = new JsonObject();
+        operationObject.addProperty("clientId", "operation-client-id");
+        operationObject.addProperty("description", "operation-description");
+        JsonObject metadataObject = new JsonObject();
+        metadataObject.addProperty("key1", "value1");
+        metadataObject.addProperty("key2", "value2");
+        operationObject.add("metadata", metadataObject);
+        jsonObject.add("operation", operationObject);
+
+        // When
+        Message message = Message.fromEncoded(jsonObject, new ChannelOptions());
+
+        // Then
+        assertEquals("test-client-id", message.clientId);
+        assertEquals("test-data", message.data);
+        assertEquals("test-name", message.name);
+        assertEquals("test-ref-serial", message.refSerial);
+        assertEquals("test-ref-type", message.refType);
+        assertEquals("test-key", message.connectionKey);
+        assertEquals("operation-client-id", message.operation.clientId);
+        assertEquals("operation-description", message.operation.description);
+        assertEquals("value1", message.operation.metadata.get("key1"));
+        assertEquals("value2", message.operation.metadata.get("key2"));
+    }
 
     @Test
     public void deserialize_message_with_unknown_action() throws Exception {
@@ -110,5 +185,49 @@ public class MessageTest {
         assertEquals("test-name", message.name);
         assertNull(message.action);
         assertEquals("01826232498871-001@abcdefghij:001", message.serial);
+    }
+
+    @Test
+    public void serialize_and_deserialize_with_msgpack() throws Exception {
+        // Given
+        Message message = new Message("test-name", "test-data");
+        message.clientId = "test-client-id";
+        message.connectionKey = "test-key";
+        message.refSerial = "test-ref-serial";
+        message.refType = "test-ref-type";
+        message.action = MessageAction.MESSAGE_CREATE;
+        message.serial = "01826232498871-001@abcdefghij:001";
+        Message.Operation operation = new Message.Operation();
+        operation.clientId = "operation-client-id";
+        operation.description = "operation-description";
+        operation.metadata = new HashMap<>();
+        operation.metadata.put("key1", "value1");
+        operation.metadata.put("key2", "value2");
+        message.operation = operation;
+
+        // When Encode to MessagePack
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        MessagePacker packer = Serialisation.msgpackPackerConfig.newPacker(out);
+        message.writeMsgpack(packer);
+        packer.close();
+
+        // Decode from MessagePack
+        MessageUnpacker unpacker = Serialisation.msgpackUnpackerConfig.newUnpacker(out.toByteArray());
+        Message unpacked = Message.fromMsgpack(unpacker);
+        unpacker.close();
+
+        // Then
+        assertEquals("test-client-id", unpacked.clientId);
+        assertEquals("test-key", unpacked.connectionKey);
+        assertEquals("test-data", unpacked.data);
+        assertEquals("test-name", unpacked.name);
+        assertEquals("test-ref-serial", unpacked.refSerial);
+        assertEquals("test-ref-type", unpacked.refType);
+        assertEquals(MessageAction.MESSAGE_CREATE, unpacked.action);
+        assertEquals("01826232498871-001@abcdefghij:001", unpacked.serial);
+        assertEquals("operation-client-id", unpacked.operation.clientId);
+        assertEquals("operation-description", unpacked.operation.description);
+        assertEquals("value1", unpacked.operation.metadata.get("key1"));
+        assertEquals("value2", unpacked.operation.metadata.get("key2"));
     }
 }

--- a/lib/src/test/java/io/ably/lib/types/MessageTest.java
+++ b/lib/src/test/java/io/ably/lib/types/MessageTest.java
@@ -12,6 +12,7 @@ import org.msgpack.core.MessagePacker;
 import org.msgpack.core.MessageUnpacker;
 
 import java.io.ByteArrayOutputStream;
+import java.util.HashMap;
 
 public class MessageTest {
 
@@ -77,12 +78,12 @@ public class MessageTest {
     @Test
     public void deserialize_message_with_serial() throws Exception {
         // Given
-       JsonObject jsonObject = new JsonObject();
-       jsonObject.addProperty("clientId", "test-client-id");
-       jsonObject.addProperty("data", "test-data");
-       jsonObject.addProperty("name", "test-name");
-       jsonObject.addProperty("action", 0);
-       jsonObject.addProperty("serial", "01826232498871-001@abcdefghij:001");
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("clientId", "test-client-id");
+        jsonObject.addProperty("data", "test-data");
+        jsonObject.addProperty("name", "test-name");
+        jsonObject.addProperty("action", 0);
+        jsonObject.addProperty("serial", "01826232498871-001@abcdefghij:001");
 
         // When
         Message message = Message.fromEncoded(jsonObject, new ChannelOptions());
@@ -106,9 +107,9 @@ public class MessageTest {
         Message.Operation operation = new Message.Operation();
         operation.clientId = "operation-client-id";
         operation.description = "operation-description";
-        operation.metadata = new JsonObject();
-        operation.metadata.addProperty("key1", "value1");
-        operation.metadata.addProperty("key2", "value2");
+        operation.metadata = new HashMap<>();
+        operation.metadata.put("key1", "value1");
+        operation.metadata.put("key2", "value2");
         message.operation = operation;
 
         // When
@@ -161,8 +162,8 @@ public class MessageTest {
         assertEquals("test-key", message.connectionKey);
         assertEquals("operation-client-id", message.operation.clientId);
         assertEquals("operation-description", message.operation.description);
-        assertEquals("value1", message.operation.metadata.get("key1").getAsString());
-        assertEquals("value2", message.operation.metadata.get("key2").getAsString());
+        assertEquals("value1", message.operation.metadata.get("key1"));
+        assertEquals("value2", message.operation.metadata.get("key2"));
     }
 
     @Test
@@ -199,9 +200,9 @@ public class MessageTest {
         Message.Operation operation = new Message.Operation();
         operation.clientId = "operation-client-id";
         operation.description = "operation-description";
-        operation.metadata = new JsonObject();
-        operation.metadata.addProperty("key1", "value1");
-        operation.metadata.addProperty("key2", "value2");
+        operation.metadata = new HashMap<>();
+        operation.metadata.put("key1", "value1");
+        operation.metadata.put("key2", "value2");
         message.operation = operation;
 
         // When Encode to MessagePack
@@ -226,7 +227,7 @@ public class MessageTest {
         assertEquals("01826232498871-001@abcdefghij:001", unpacked.serial);
         assertEquals("operation-client-id", unpacked.operation.clientId);
         assertEquals("operation-description", unpacked.operation.description);
-        assertEquals("value1", unpacked.operation.metadata.get("key1").getAsString());
-        assertEquals("value2", unpacked.operation.metadata.get("key2").getAsString());
+        assertEquals("value1", unpacked.operation.metadata.get("key1"));
+        assertEquals("value2", unpacked.operation.metadata.get("key2"));
     }
 }


### PR DESCRIPTION
- Fixed #1058 

TODO
- [x] TM2l = refSerial string – an opaque string that uniquely identifies some referenced message.
- [x] TM2m = refType string – an opaque string that identifies the type of this reference.
- [x] TM2n = operation – object that contain `clientId`, `description` and `metadata`.
- [x] Add integration tests for message create, update and delete to check if fields are being populated correctly.
- [x] Test for Update/ delete op for existing deleted message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for message operations with new fields like `refSerial`, `refType`, and `operation`.
	- Introduced enhanced message handling capabilities for chat rooms.
	- Implemented new serialization and deserialization methods for message operations.

- **Tests**
	- Added comprehensive test coverage for message creation, updating, and deletion.
	- Verified message serialization and deserialization processes, including the new operation details.
	- Created a test suite for chat message functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->