### PR TITLE
Implement TM2p change (no message version populating from channelmessage)

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -856,10 +856,8 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
             if(msg.connectionId == null) msg.connectionId = protocolMessage.connectionId;
             if(msg.timestamp == 0) msg.timestamp = protocolMessage.timestamp;
             if(msg.id == null) msg.id = protocolMessage.id + ':' + i;
-            // (TM2p)
-            if(msg.version == null) msg.version = String.format("%s:%03d", protocolMessage.channelSerial, i);
             // (TM2k)
-            if(msg.serial == null && msg.action == MessageAction.MESSAGE_CREATE) msg.serial = msg.version;
+            if(msg.serial == null && msg.version != null && msg.action == MessageAction.MESSAGE_CREATE) msg.serial = msg.version;
             // (TM2o)
             if(msg.createdAt == null && msg.action == MessageAction.MESSAGE_CREATE) msg.createdAt = msg.timestamp;
 

--- a/lib/src/main/java/io/ably/lib/types/Message.java
+++ b/lib/src/main/java/io/ably/lib/types/Message.java
@@ -58,10 +58,7 @@ public class Message extends BaseMessage {
 
     /**
      * (TM2p) version string – an opaque string that uniquely identifies the message, and is different for different versions.
-     * If a message received from Ably over a realtime transport does not contain a version,
-     * the SDK must set it to <channelSerial>:<padded_index> from the channelSerial field of the enclosing ProtocolMessage,
-     * and padded_index is the index of the message inside the messages array of the ProtocolMessage,
-     * left-padded with 0s to three digits (for example, the second entry might be foo:001)
+     * (May not be populated depending on app & channel namespace settings)
      */
     public String version;
 


### PR DESCRIPTION
Implements https://github.com/ably/specification/pull/275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refined the logic for assigning message identifiers to ensure they are set only under valid conditions, improving message consistency.
- **Documentation**
  - Updated the messaging version field guidance to more clearly reflect behavior based on configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->