### PR TITLE
[CHAT-5063] feat: expose unwrapped java classes in the adapter

### DIFF
--- a/pubsub-adapter/src/main/kotlin/com/ably/annotations/Annotations.kt
+++ b/pubsub-adapter/src/main/kotlin/com/ably/annotations/Annotations.kt
@@ -1,0 +1,21 @@
+package com.ably.annotations
+
+/**
+ * API marked with this annotation is internal, and it is not intended to be used outside Ably.
+ * It could be modified or removed without any notice. Using it outside Ably could cause undefined behaviour and/or
+ * any unexpected effects.
+ */
+@RequiresOptIn(
+  level = RequiresOptIn.Level.ERROR,
+  message = "This API is internal in Ably and should not be used. It could be removed or changed without notice."
+)
+@Target(
+  AnnotationTarget.CLASS,
+  AnnotationTarget.TYPEALIAS,
+  AnnotationTarget.FUNCTION,
+  AnnotationTarget.PROPERTY,
+  AnnotationTarget.FIELD,
+  AnnotationTarget.CONSTRUCTOR,
+  AnnotationTarget.PROPERTY_SETTER,
+)
+public annotation class InternalAPI

--- a/pubsub-adapter/src/main/kotlin/com/ably/pubsub/RealtimeChannel.kt
+++ b/pubsub-adapter/src/main/kotlin/com/ably/pubsub/RealtimeChannel.kt
@@ -1,6 +1,7 @@
 package com.ably.pubsub
 
 import com.ably.Subscription
+import com.ably.annotations.InternalAPI
 import io.ably.lib.realtime.ChannelBase.MessageListener
 import io.ably.lib.realtime.ChannelState
 import io.ably.lib.realtime.CompletionListener
@@ -144,4 +145,10 @@ interface RealtimeChannel : Channel {
    * @param options A {@link ChannelOptions} object.
    */
   fun setOptions(options: ChannelOptions)
+
+  /**
+   * This property will be removed once public API for new version of ably-java is stable
+   */
+  @InternalAPI
+  val javaChannel: io.ably.lib.realtime.Channel
 }

--- a/pubsub-adapter/src/main/kotlin/com/ably/pubsub/RealtimeClient.kt
+++ b/pubsub-adapter/src/main/kotlin/com/ably/pubsub/RealtimeClient.kt
@@ -1,5 +1,7 @@
 package com.ably.pubsub
 
+import com.ably.annotations.InternalAPI
+import io.ably.lib.realtime.AblyRealtime
 import io.ably.lib.realtime.Connection
 
 /**
@@ -21,4 +23,10 @@ interface RealtimeClient : Client {
    * Collection of [RealtimeChannel] instances currently managed by Realtime client
    */
   override val channels: Channels<out RealtimeChannel>
+
+  /**
+   * This property will be removed once public API for new version of ably-java is stable
+   */
+  @InternalAPI
+  val javaClient: AblyRealtime
 }

--- a/pubsub-adapter/src/main/kotlin/com/ably/pubsub/RealtimePresence.kt
+++ b/pubsub-adapter/src/main/kotlin/com/ably/pubsub/RealtimePresence.kt
@@ -1,11 +1,9 @@
 package com.ably.pubsub
 
 import com.ably.Subscription
-import io.ably.lib.realtime.Channel
 import io.ably.lib.realtime.ChannelState
 import io.ably.lib.realtime.CompletionListener
 import io.ably.lib.realtime.Presence.PresenceListener
-import io.ably.lib.types.AblyException
 import io.ably.lib.types.PresenceMessage
 import java.util.*
 

--- a/pubsub-adapter/src/main/kotlin/io/ably/lib/realtime/RealtimeChannelAdapter.kt
+++ b/pubsub-adapter/src/main/kotlin/io/ably/lib/realtime/RealtimeChannelAdapter.kt
@@ -1,13 +1,16 @@
 package io.ably.lib.realtime
 
 import com.ably.Subscription
+import com.ably.annotations.InternalAPI
 import com.ably.pubsub.RealtimeChannel
 import com.ably.pubsub.RealtimePresence
 import com.ably.query.OrderBy
 import io.ably.lib.buildHistoryParams
 import io.ably.lib.types.*
 
-internal class RealtimeChannelAdapter(private val javaChannel: Channel) : RealtimeChannel {
+
+@OptIn(InternalAPI::class)
+internal class RealtimeChannelAdapter(override val javaChannel: Channel) : RealtimeChannel {
   override val name: String
     get() = javaChannel.name
   override val presence: RealtimePresence

--- a/pubsub-adapter/src/main/kotlin/io/ably/lib/realtime/RealtimeClientAdapter.kt
+++ b/pubsub-adapter/src/main/kotlin/io/ably/lib/realtime/RealtimeClientAdapter.kt
@@ -1,5 +1,6 @@
 package io.ably.lib.realtime
 
+import com.ably.annotations.InternalAPI
 import com.ably.http.HttpMethod
 import com.ably.pubsub.*
 import com.ably.query.OrderBy
@@ -15,7 +16,8 @@ import io.ably.lib.types.*
  */
 fun RealtimeClient(javaClient: AblyRealtime): RealtimeClient = RealtimeClientAdapter(javaClient)
 
-internal class RealtimeClientAdapter(private val javaClient: AblyRealtime) : RealtimeClient, SdkWrapperCompatible<RealtimeClient> {
+@OptIn(InternalAPI::class)
+internal class RealtimeClientAdapter(override val javaClient: AblyRealtime) : RealtimeClient, SdkWrapperCompatible<RealtimeClient> {
   override val channels: Channels<out RealtimeChannel>
     get() = RealtimeChannelsAdapter(javaClient.channels)
   override val connection: Connection

--- a/pubsub-adapter/src/main/kotlin/io/ably/lib/realtime/WrapperRealtimeClient.kt
+++ b/pubsub-adapter/src/main/kotlin/io/ably/lib/realtime/WrapperRealtimeClient.kt
@@ -1,5 +1,6 @@
 package io.ably.lib.realtime
 
+import com.ably.annotations.InternalAPI
 import com.ably.http.HttpMethod
 import com.ably.pubsub.*
 import com.ably.query.OrderBy
@@ -11,8 +12,9 @@ import io.ably.lib.http.HttpCore
 import io.ably.lib.rest.*
 import io.ably.lib.types.*
 
+@OptIn(InternalAPI::class)
 internal class WrapperRealtimeClient(
-  private val javaClient: AblyRealtime,
+  override val javaClient: AblyRealtime,
   private val adapter: RealtimeClientAdapter,
   private val httpModule: Http,
   private val agents: Map<String, String>,
@@ -93,7 +95,8 @@ internal class WrapperRealtimeChannels(
     WrapperRealtimeChannel(javaChannels.get(name, options.injectAgents(agents)), httpModule)
 }
 
-internal class WrapperRealtimeChannel(private val javaChannel: Channel, private val httpModule: Http) :
+@OptIn(InternalAPI::class)
+internal class WrapperRealtimeChannel(override val javaChannel: Channel, private val httpModule: Http) :
   RealtimeChannel by RealtimeChannelAdapter(javaChannel) {
 
   override val presence: RealtimePresence


### PR DESCRIPTION
Exposed unwrapped Java classes in the Kotlin wrapper; we’ll use them in the Chat SDK until the public API is stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced realtime messaging interfaces with new integration points that offer advanced access to underlying communication capabilities.

- **Refactor**
  - Updated adapter components to make key functionality more transparent while marking experimental features that may evolve over time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->