### PR TITLE
[CHAT-5228] fix: add lombok to ProGuard rules

### DIFF
--- a/android/proguard.txt
+++ b/android/proguard.txt
@@ -5,3 +5,4 @@
 -keep class com.google.gson.** {*;}
 -dontwarn org.msgpack.core.buffer.**
 -dontwarn org.slf4j.**
+-dontwarn lombok.**


### PR DESCRIPTION
Fixes https://github.com/ably/ably-java/issues/1067

We use Lombok deep down internally for code generation but Lombok itself should not be included in the final APK.

Effect of `-dontwarn lombok.**`:
- It tells ProGuard to ignore missing Lombok classes, preventing unnecessary warnings.
- This avoids potential build failures when ProGuard is set to treat warnings as errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration settings to suppress non-critical warnings from an external utility library, helping to streamline the build process and improve overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->