### PR TITLE
chore: turn on `explicitApi` for kotlin module

### DIFF
--- a/pubsub-adapter/build.gradle.kts
+++ b/pubsub-adapter/build.gradle.kts
@@ -4,6 +4,10 @@ plugins {
     alias(libs.plugins.maven.publish)
 }
 
+kotlin {
+    explicitApi()
+}
+
 dependencies {
     compileOnly(project(":java"))
     testImplementation(kotlin("test"))

--- a/pubsub-adapter/src/main/kotlin/com/ably/Subscription.kt
+++ b/pubsub-adapter/src/main/kotlin/com/ably/Subscription.kt
@@ -4,9 +4,9 @@ package com.ably
  * An unsubscription handle, returned by various functions (mostly subscriptions)
  * where unsubscription is required.
  */
-fun interface Subscription {
+public fun interface Subscription {
   /**
    * Handle unsubscription (unsubscribe listeners, clean up)
    */
-  fun unsubscribe()
+  public fun unsubscribe()
 }

--- a/pubsub-adapter/src/main/kotlin/com/ably/http/HttpMethod.kt
+++ b/pubsub-adapter/src/main/kotlin/com/ably/http/HttpMethod.kt
@@ -1,6 +1,6 @@
 package com.ably.http
 
-enum class HttpMethod(private val method: String) {
+public enum class HttpMethod(private val method: String) {
   Get("GET"),
   Post("POST"),
   Put("PUT"),
@@ -8,5 +8,5 @@ enum class HttpMethod(private val method: String) {
   Patch("PATCH"),
   ;
 
-  override fun toString() = method
+  override fun toString(): String = method
 }

--- a/pubsub-adapter/src/main/kotlin/com/ably/pubsub/Channel.kt
+++ b/pubsub-adapter/src/main/kotlin/com/ably/pubsub/Channel.kt
@@ -13,7 +13,7 @@ import io.ably.lib.types.*
  *
  * @see <a href="https://ably.com/docs/realtime/channels">Ably Channels Documentation</a>
  */
-interface Channel {
+public interface Channel {
 
   /**
    * The channel name.
@@ -25,7 +25,7 @@ interface Channel {
    *
    * @see <a href="https://ably.com/docs/realtime/channels#channel-naming">Channel Naming Rules</a>
    */
-  val name: String
+  public val name: String
 
   /**
    * A [Presence] object.
@@ -41,7 +41,7 @@ interface Channel {
    *
    * Spec: RTL9
    */
-  val presence: Presence
+  public val presence: Presence
 
   /**
    * Obtain recent history for this channel using the REST API.
@@ -57,7 +57,7 @@ interface Channel {
    *
    * @return Paginated result of Messages for this Channel.
    */
-  fun history(
+  public fun history(
     start: Long? = null,
     end: Long? = null,
     limit: Int = 100,
@@ -76,7 +76,7 @@ interface Channel {
    * @param callback  A Callback returning [AsyncPaginatedResult] object containing an array of [Message] objects.
    * Note: This callback is invoked on a background thread.
    */
-  fun historyAsync(
+  public fun historyAsync(
     callback: Callback<AsyncPaginatedResult<Message>>,
     start: Long? = null,
     end: Long? = null,

--- a/pubsub-adapter/src/main/kotlin/com/ably/pubsub/Channels.kt
+++ b/pubsub-adapter/src/main/kotlin/com/ably/pubsub/Channels.kt
@@ -6,7 +6,7 @@ import io.ably.lib.types.ChannelOptions
 /**
  * Represents collection of managed Channel instances
  */
-interface Channels<ChannelType> : Iterable<ChannelType> {
+public interface Channels<ChannelType> : Iterable<ChannelType> {
 
   /**
    * Checks if channel with specified name exists
@@ -15,7 +15,7 @@ interface Channels<ChannelType> : Iterable<ChannelType> {
    * @param name The channel name.
    * @return `true` if it contains the specified [name].
    */
-  fun contains(name: String): Boolean
+  public fun contains(name: String): Boolean
 
   /**
    * Creates a new [Channel] object, or returns the existing channel object.
@@ -24,7 +24,7 @@ interface Channels<ChannelType> : Iterable<ChannelType> {
    * @param name The channel name.
    * @return A [Channel] object.
    */
-  fun get(name: String): ChannelType
+  public fun get(name: String): ChannelType
 
   /**
    * Creates a new [Channel] object, with the specified [ChannelOptions], or returns the existing channel object.
@@ -34,7 +34,7 @@ interface Channels<ChannelType> : Iterable<ChannelType> {
    * @param options A [ChannelOptions] object.
    * @return A [Channel] object.
    */
-  fun get(name: String, options: ChannelOptions): ChannelType
+  public fun get(name: String, options: ChannelOptions): ChannelType
 
   /**
    * Releases a [Channel] object, deleting it, and enabling it to be garbage collected.
@@ -44,5 +44,5 @@ interface Channels<ChannelType> : Iterable<ChannelType> {
    * Spec: RSN4, RTS4
    * @param name The channel name.
    */
-  fun release(name: String)
+  public fun release(name: String)
 }

--- a/pubsub-adapter/src/main/kotlin/com/ably/pubsub/Client.kt
+++ b/pubsub-adapter/src/main/kotlin/com/ably/pubsub/Client.kt
@@ -14,33 +14,33 @@ import io.ably.lib.types.*
  * This class implements {@link AutoCloseable} so you can use it in
  * try-with-resources constructs and have the JDK close it for you.
  */
-interface Client : AutoCloseable {
+public interface Client : AutoCloseable {
 
   /**
    * An [Auth] object.
    *
    * Spec: RSC5
    */
-  val auth: Auth
+  public val auth: Auth
 
   /**
    * A [Channels] object.
    *
    * Spec: RTC3, RTS1
    */
-  val channels: Channels<out Channel>
+  public val channels: Channels<out Channel>
 
   /**
    * Client options
    */
-  val options: ClientOptions
+  public val options: ClientOptions
 
   /**
    * An [Push] object.
    *
    * Spec: RSH7
    */
-  val push: Push
+  public val push: Push
 
   /**
    * Retrieves the time from the Ably service as milliseconds
@@ -53,7 +53,7 @@ interface Client : AutoCloseable {
    * Spec: RSC16
    * @return The time as milliseconds since the Unix epoch.
    */
-  fun time(): Long
+  public fun time(): Long
 
   /**
    * Asynchronously retrieves the time from the Ably service as milliseconds
@@ -68,7 +68,7 @@ interface Client : AutoCloseable {
    * @param callback Listener with the time as milliseconds since the Unix epoch.
    * This callback is invoked on a background thread
    */
-  fun timeAsync(callback: Callback<Long>)
+  public fun timeAsync(callback: Callback<Long>)
 
   /**
    * Queries the REST /stats API and retrieves your application's usage statistics.
@@ -83,7 +83,7 @@ interface Client : AutoCloseable {
    * @return A [PaginatedResult] object containing an array of [Stats] objects.
    * @throws AblyException
    */
-  fun stats(
+  public fun stats(
     start: Long? = null,
     end: Long? = null,
     limit: Int = 100,
@@ -105,7 +105,7 @@ interface Client : AutoCloseable {
    * @param callback Listener which returns a [AsyncPaginatedResult] object containing an array of [Stats] objects.
    * This callback is invoked on a background thread
    */
-  fun statsAsync(
+  public fun statsAsync(
     callback: Callback<AsyncPaginatedResult<Stats>>,
     start: Long? = null,
     end: Long? = null,
@@ -133,7 +133,7 @@ interface Client : AutoCloseable {
    * @param headers Additional HTTP headers to include in the request.
    * @return An [HttpPaginatedResponse] object returned by the HTTP request, containing an empty or JSON-encodable object.
    */
-  fun request(
+  public fun request(
     path: String,
     method: HttpMethod = HttpMethod.Get,
     params: List<Param> = emptyList(),
@@ -163,7 +163,7 @@ interface Client : AutoCloseable {
    * containing an empty or JSON-encodable object.
    * This callback is invoked on a background thread
    */
-  fun requestAsync(
+  public fun requestAsync(
     path: String,
     callback: AsyncHttpPaginatedResponse.Callback,
     method: HttpMethod = HttpMethod.Get,

--- a/pubsub-adapter/src/main/kotlin/com/ably/pubsub/Presence.kt
+++ b/pubsub-adapter/src/main/kotlin/com/ably/pubsub/Presence.kt
@@ -6,7 +6,7 @@ import io.ably.lib.types.*
 /**
  * Enables get historic presence set for a channel.
  */
-interface Presence {
+public interface Presence {
 
   /**
    * Retrieves a [PaginatedResult] object, containing an array of historical [PresenceMessage] objects for the channel.
@@ -23,7 +23,7 @@ interface Presence {
    *
    * @return A [PaginatedResult] object containing an array of [PresenceMessage] objects.
    */
-  fun history(
+  public fun history(
     start: Long? = null,
     end: Long? = null,
     limit: Int = 100,
@@ -45,7 +45,7 @@ interface Presence {
    * @param callback  A Callback returning [AsyncPaginatedResult] object containing an array of [PresenceMessage] objects.
    * Note: This callback is invoked on a background thread.
    */
-  fun historyAsync(
+  public fun historyAsync(
     callback: Callback<AsyncPaginatedResult<PresenceMessage>>,
     start: Long? = null,
     end: Long? = null,

--- a/pubsub-adapter/src/main/kotlin/com/ably/pubsub/RealtimeChannel.kt
+++ b/pubsub-adapter/src/main/kotlin/com/ably/pubsub/RealtimeChannel.kt
@@ -14,7 +14,7 @@ import io.ably.lib.types.Message
 /**
  * An interface representing a Realtime Channel.
  */
-interface RealtimeChannel : Channel {
+public interface RealtimeChannel : Channel {
   /**
    * Presence set for a channel.
    */
@@ -25,21 +25,21 @@ interface RealtimeChannel : Channel {
    *
    * Spec: RTL2b
    */
-  val state: ChannelState
+  public val state: ChannelState
 
   /**
    * An [ErrorInfo] object describing the last error which occurred on the channel, if any.
    *
    * Spec: RTL4e
    */
-  val reason: ErrorInfo?
+  public val reason: ErrorInfo?
 
   /**
    * A [ChannelProperties] object.
    *
    * Spec: CP1, RTL15
    */
-  val properties: ChannelProperties
+  public val properties: ChannelProperties
 
   /**
    * Attach to this channel ensuring the channel is created in the Ably system and all messages published
@@ -51,7 +51,7 @@ interface RealtimeChannel : Channel {
    *
    * Spec: RTL4d
    */
-  fun attach(listener: CompletionListener? = null)
+  public fun attach(listener: CompletionListener? = null)
 
   /**
    * Detach from this channel.
@@ -61,7 +61,7 @@ interface RealtimeChannel : Channel {
    *
    * Spec: RTL5e
    */
-  fun detach(listener: CompletionListener? = null)
+  public fun detach(listener: CompletionListener? = null)
 
   /**
    * Registers a listener for messages on this channel.
@@ -72,7 +72,7 @@ interface RealtimeChannel : Channel {
    * @param listener A listener may optionally be passed in to this call to be notified of success or failure
    * of the channel [RealtimeChannel.attach] operation. This listener is invoked on a background thread.
    */
-  fun subscribe(listener: MessageListener): Subscription
+  public fun subscribe(listener: MessageListener): Subscription
 
   /**
    * Registers a listener for messages with a given event name on this channel.
@@ -84,7 +84,7 @@ interface RealtimeChannel : Channel {
    * @param listener A listener may optionally be passed in to this call to be notified of success or failure
    * of the channel [RealtimeChannel.attach] operation. This listener is invoked on a background thread.
    */
-  fun subscribe(eventName: String, listener: MessageListener): Subscription
+  public fun subscribe(eventName: String, listener: MessageListener): Subscription
 
   /**
    * Registers a listener for messages on this channel for multiple event name values.
@@ -96,7 +96,7 @@ interface RealtimeChannel : Channel {
    * @param listener A listener may optionally be passed in to this call to be notified of success or failure
    * of the channel [RealtimeChannel.attach] operation. This listener is invoked on a background thread.
    */
-  fun subscribe(eventNames: List<String>, listener: MessageListener): Subscription
+  public fun subscribe(eventNames: List<String>, listener: MessageListener): Subscription
 
   /**
    * Publishes a single message to the channel with the given event name and payload.
@@ -111,7 +111,7 @@ interface RealtimeChannel : Channel {
    * @param listener A listener may optionally be passed in to this call to be notified of success or failure of the operation.
    * This listener is invoked on a background thread.
    */
-  fun publish(name: String? = null, data: Any? = null, listener: CompletionListener? = null)
+  public fun publish(name: String? = null, data: Any? = null, listener: CompletionListener? = null)
 
   /**
    * Publishes a message to the channel.
@@ -123,7 +123,7 @@ interface RealtimeChannel : Channel {
    * @param listener A listener may optionally be passed in to this call to be notified of success or failure of the operation.
    * This listener is invoked on a background thread.
    */
-  fun publish(message: Message, listener: CompletionListener? = null)
+  public fun publish(message: Message, listener: CompletionListener? = null)
 
   /**
    * Publishes an array of messages to the channel.
@@ -135,7 +135,7 @@ interface RealtimeChannel : Channel {
    * @param listener A listener may optionally be passed in to this call to be notified of success or failure of the operation.
    * This listener is invoked on a background thread.
    */
-  fun publish(messages: List<Message>, listener: CompletionListener? = null)
+  public fun publish(messages: List<Message>, listener: CompletionListener? = null)
 
   /**
    * Sets the [ChannelOptions] for the channel.
@@ -144,11 +144,11 @@ interface RealtimeChannel : Channel {
    *
    * @param options A {@link ChannelOptions} object.
    */
-  fun setOptions(options: ChannelOptions)
+  public fun setOptions(options: ChannelOptions)
 
   /**
    * This property will be removed once public API for new version of ably-java is stable
    */
   @InternalAPI
-  val javaChannel: io.ably.lib.realtime.Channel
+  public val javaChannel: io.ably.lib.realtime.Channel
 }

--- a/pubsub-adapter/src/main/kotlin/com/ably/pubsub/RealtimeClient.kt
+++ b/pubsub-adapter/src/main/kotlin/com/ably/pubsub/RealtimeClient.kt
@@ -10,14 +10,14 @@ import io.ably.lib.realtime.Connection
  * This class implements {@link AutoCloseable} so you can use it in
  * try-with-resources constructs and have the JDK close it for you.
  */
-interface RealtimeClient : Client {
+public interface RealtimeClient : Client {
 
   /**
    * The {@link Connection} object for this instance.
    * <p>
    * Spec: RTC2
    */
-  val connection: Connection
+  public val connection: Connection
 
   /**
    * Collection of [RealtimeChannel] instances currently managed by Realtime client
@@ -28,5 +28,5 @@ interface RealtimeClient : Client {
    * This property will be removed once public API for new version of ably-java is stable
    */
   @InternalAPI
-  val javaClient: AblyRealtime
+  public val javaClient: AblyRealtime
 }

--- a/pubsub-adapter/src/main/kotlin/com/ably/pubsub/RealtimePresence.kt
+++ b/pubsub-adapter/src/main/kotlin/com/ably/pubsub/RealtimePresence.kt
@@ -11,7 +11,7 @@ import java.util.*
 /**
  * Presence for a Realtime channel
  */
-interface RealtimePresence : Presence {
+public interface RealtimePresence : Presence {
 
   /**
    * Retrieves the current members present on the channel and the metadata for each member,
@@ -30,7 +30,7 @@ interface RealtimePresence : Presence {
    * @param connectionId (RTP11c3) - Filters the array of returned presence members by a specific connection using its ID.
    * @return A list of [PresenceMessage] objects.
    */
-  fun get(clientId: String? = null, connectionId: String? = null, waitForSync: Boolean = true): List<PresenceMessage>
+  public fun get(clientId: String? = null, connectionId: String? = null, waitForSync: Boolean = true): List<PresenceMessage>
 
   /**
    * Registers a listener that is called each time a [PresenceMessage] matching a given [PresenceMessage.Action],
@@ -42,7 +42,7 @@ interface RealtimePresence : Presence {
    * @param listener An event listener function.
    * The listener is invoked on a background thread.
    */
-  fun subscribe(listener: PresenceListener): Subscription
+  public fun subscribe(listener: PresenceListener): Subscription
 
   /**
    * Registers a listener that is called each time a [PresenceMessage] matching a given [PresenceMessage.Action],
@@ -55,7 +55,7 @@ interface RealtimePresence : Presence {
    * @param listener An event listener function.
    * The listener is invoked on a background thread.
    */
-  fun subscribe(action: PresenceMessage.Action, listener: PresenceListener): Subscription
+  public fun subscribe(action: PresenceMessage.Action, listener: PresenceListener): Subscription
 
   /**
    * Registers a listener that is called each time a [PresenceMessage] matching a given [PresenceMessage.Action],
@@ -68,7 +68,7 @@ interface RealtimePresence : Presence {
    * @param listener An event listener function.
    * The listener is invoked on a background thread.
    */
-  fun subscribe(actions: EnumSet<PresenceMessage.Action>, listener: PresenceListener): Subscription
+  public fun subscribe(actions: EnumSet<PresenceMessage.Action>, listener: PresenceListener): Subscription
 
   /**
    * Enters the presence set for the channel, optionally passing a data payload.
@@ -81,7 +81,7 @@ interface RealtimePresence : Presence {
    * @param listener A callback to notify of the success or failure of the operation.
    * This listener is invoked on a background thread.
    */
-  fun enter(data: Any? = null, listener: CompletionListener? = null)
+  public fun enter(data: Any? = null, listener: CompletionListener? = null)
 
   /**
    * Updates the data payload for a presence member.
@@ -94,7 +94,7 @@ interface RealtimePresence : Presence {
    * @param listener A callback to notify of the success or failure of the operation.
    * This listener is invoked on a background thread.
    */
-  fun update(data: Any? = null, listener: CompletionListener? = null)
+  public fun update(data: Any? = null, listener: CompletionListener? = null)
 
   /**
    * Leaves the presence set for the channel.
@@ -106,7 +106,7 @@ interface RealtimePresence : Presence {
    * @param listener a listener to notify of the success or failure of the operation.
    * This listener is invoked on a background thread.
    */
-  fun leave(data: Any? = null, listener: CompletionListener? = null)
+  public fun leave(data: Any? = null, listener: CompletionListener? = null)
 
   /**
    * Enters the presence set of the channel for a given clientId.
@@ -120,7 +120,7 @@ interface RealtimePresence : Presence {
    * @param listener A callback to notify of the success or failure of the operation.
    * This listener is invoked on a background thread.
    */
-  fun enterClient(clientId: String, data: Any? = null, listener: CompletionListener? = null)
+  public fun enterClient(clientId: String, data: Any? = null, listener: CompletionListener? = null)
 
   /**
    * Updates the data payload for a presence member using a given clientId.
@@ -135,7 +135,7 @@ interface RealtimePresence : Presence {
    * @param listener A callback to notify of the success or failure of the operation.
    * This listener is invoked on a background thread.
    */
-  fun updateClient(clientId: String, data: Any? = null, listener: CompletionListener? = null)
+  public fun updateClient(clientId: String, data: Any? = null, listener: CompletionListener? = null)
 
   /**
    * Leaves the presence set of the channel for a given clientId.
@@ -149,5 +149,5 @@ interface RealtimePresence : Presence {
    * @param listener A callback to notify of the success or failure of the operation.
    * This listener is invoked on a background thread.
    */
-  fun leaveClient(clientId: String?, data: Any? = null, listener: CompletionListener? = null)
+  public fun leaveClient(clientId: String?, data: Any? = null, listener: CompletionListener? = null)
 }

--- a/pubsub-adapter/src/main/kotlin/com/ably/pubsub/RestChannel.kt
+++ b/pubsub-adapter/src/main/kotlin/com/ably/pubsub/RestChannel.kt
@@ -3,7 +3,7 @@ package com.ably.pubsub
 import io.ably.lib.realtime.CompletionListener
 import io.ably.lib.types.Message
 
-interface RestChannel : Channel {
+public interface RestChannel : Channel {
 
   /**
    * Presence set for a channel.
@@ -16,7 +16,7 @@ interface RestChannel : Channel {
    * @param name the event name
    * @param data the message payload; see [io.ably.types.Data] for details of supported data types.
    */
-  fun publish(name: String? = null, data: Any? = null)
+  public fun publish(name: String? = null, data: Any? = null)
 
   /**
    * Publish list of messages on this channel. When there are
@@ -26,19 +26,19 @@ interface RestChannel : Channel {
    *
    * @param messages list of messages to publish.
    */
-  fun publish(messages: List<Message>)
+  public fun publish(messages: List<Message>)
 
   /**
    * Publish a message on this channel asynchronously
    *
    * @see [publish]
    */
-  fun publishAsync(name: String? = null, data: Any? = null, listener: CompletionListener)
+  public fun publishAsync(name: String? = null, data: Any? = null, listener: CompletionListener)
 
   /**
    * Publish list of messages on this channel asynchronously
    *
    * @see [publish]
    */
-  fun publishAsync(messages: List<Message>, listener: CompletionListener)
+  public fun publishAsync(messages: List<Message>, listener: CompletionListener)
 }

--- a/pubsub-adapter/src/main/kotlin/com/ably/pubsub/RestClient.kt
+++ b/pubsub-adapter/src/main/kotlin/com/ably/pubsub/RestClient.kt
@@ -1,6 +1,6 @@
 package com.ably.pubsub
 
-interface RestClient : Client {
+public interface RestClient : Client {
 
   /**
    * Collection of [RestChannel] instances currently managed by the client

--- a/pubsub-adapter/src/main/kotlin/com/ably/pubsub/RestPresence.kt
+++ b/pubsub-adapter/src/main/kotlin/com/ably/pubsub/RestPresence.kt
@@ -2,7 +2,7 @@ package com.ably.pubsub
 
 import io.ably.lib.types.*
 
-interface RestPresence : Presence {
+public interface RestPresence : Presence {
 
   /**
    * Retrieves the current members present on the channel and the metadata for each member,
@@ -16,7 +16,7 @@ interface RestPresence : Presence {
    *  @param connectionId (RSP3a3) - Filters the list of returned presence members by a specific connection using its ID.
    *  @return A [PaginatedResult] object containing an array of [PresenceMessage] objects.
    */
-  fun get(limit: Int = 100, clientId: String? = null, connectionId: String? = null): PaginatedResult<PresenceMessage>
+  public fun get(limit: Int = 100, clientId: String? = null, connectionId: String? = null): PaginatedResult<PresenceMessage>
 
   /**
    * Asynchronously retrieves the current members present on the channel and the metadata for each member,
@@ -31,6 +31,6 @@ interface RestPresence : Presence {
    * @param callback A Callback returning [AsyncPaginatedResult] object containing an array of [PresenceMessage] objects.
    * This callback is invoked on a background thread.
    */
-  fun getAsync(callback: Callback<AsyncPaginatedResult<PresenceMessage>>, limit: Int = 100, clientId: String? = null, connectionId: String? = null)
+  public fun getAsync(callback: Callback<AsyncPaginatedResult<PresenceMessage>>, limit: Int = 100, clientId: String? = null, connectionId: String? = null)
 
 }

--- a/pubsub-adapter/src/main/kotlin/com/ably/pubsub/WrapperSdkProxy.kt
+++ b/pubsub-adapter/src/main/kotlin/com/ably/pubsub/WrapperSdkProxy.kt
@@ -1,20 +1,20 @@
 package com.ably.pubsub
 
-data class WrapperSdkProxyOptions(val agents: Map<String, String>)
+public data class WrapperSdkProxyOptions(val agents: Map<String, String>)
 
-interface SdkWrapperCompatible<T> {
+public interface SdkWrapperCompatible<T> {
 
   /**
    * Creates a proxy client to be used to supply analytics information for Ably-authored SDKs.
    * The proxy client shares the state of the `RealtimeClient` or `RestClient` instance on which this method is called.
    * This method should only be called by Ably-authored SDKs.
    */
-  fun createWrapperSdkProxy(options: WrapperSdkProxyOptions): T
+  public fun createWrapperSdkProxy(options: WrapperSdkProxyOptions): T
 }
 
-fun RealtimeClient.createWrapperSdkProxy(options: WrapperSdkProxyOptions): RealtimeClient =
+public fun RealtimeClient.createWrapperSdkProxy(options: WrapperSdkProxyOptions): RealtimeClient =
   (this as SdkWrapperCompatible<*>).createWrapperSdkProxy(options) as RealtimeClient
 
-fun RestClient.createWrapperSdkProxy(options: WrapperSdkProxyOptions): RestClient =
+public fun RestClient.createWrapperSdkProxy(options: WrapperSdkProxyOptions): RestClient =
   (this as SdkWrapperCompatible<*>).createWrapperSdkProxy(options) as RestClient
 

--- a/pubsub-adapter/src/main/kotlin/com/ably/query/OrderBy.kt
+++ b/pubsub-adapter/src/main/kotlin/com/ably/query/OrderBy.kt
@@ -3,7 +3,7 @@ package com.ably.query
 /**
  * Represents direction to query messages in.
  */
-enum class OrderBy(val direction: String) {
+public enum class OrderBy(public val direction: String) {
 
   /**
    * The response will include messages from the end of the time window to the start.

--- a/pubsub-adapter/src/main/kotlin/com/ably/query/TimeUnit.kt
+++ b/pubsub-adapter/src/main/kotlin/com/ably/query/TimeUnit.kt
@@ -5,12 +5,12 @@ package com.ably.query
  * values supported are minute, hour, day or month; if omitted the unit defaults
  * to the REST API default (minute)
  */
-enum class TimeUnit(private val unit: String) {
+public enum class TimeUnit(private val unit: String) {
   Minute("minute"),
   Hour("hour"),
   Day("day"),
   Month("month"),
   ;
 
-  override fun toString() = unit
+  override fun toString(): String = unit
 }

--- a/pubsub-adapter/src/main/kotlin/io/ably/lib/Utils.kt
+++ b/pubsub-adapter/src/main/kotlin/io/ably/lib/Utils.kt
@@ -4,7 +4,7 @@ import com.ably.query.OrderBy
 import com.ably.query.TimeUnit
 import io.ably.lib.types.Param
 
-fun buildStatsParams(
+internal fun buildStatsParams(
   start: Long?,
   end: Long?,
   limit: Int,
@@ -15,7 +15,7 @@ fun buildStatsParams(
   add(Param("unit", unit.toString()))
 }
 
-fun buildHistoryParams(
+internal fun buildHistoryParams(
   start: Long?,
   end: Long?,
   limit: Int,
@@ -27,7 +27,7 @@ fun buildHistoryParams(
   add(Param("direction", orderBy.direction))
 }
 
-fun buildRestPresenceParams(
+internal fun buildRestPresenceParams(
   limit: Int,
   clientId: String?,
   connectionId: String?,

--- a/pubsub-adapter/src/main/kotlin/io/ably/lib/realtime/RealtimeClientAdapter.kt
+++ b/pubsub-adapter/src/main/kotlin/io/ably/lib/realtime/RealtimeClientAdapter.kt
@@ -14,7 +14,7 @@ import io.ably.lib.types.*
 /**
  * Wrapper for Realtime client
  */
-fun RealtimeClient(javaClient: AblyRealtime): RealtimeClient = RealtimeClientAdapter(javaClient)
+public fun RealtimeClient(javaClient: AblyRealtime): RealtimeClient = RealtimeClientAdapter(javaClient)
 
 @OptIn(InternalAPI::class)
 internal class RealtimeClientAdapter(override val javaClient: AblyRealtime) : RealtimeClient, SdkWrapperCompatible<RealtimeClient> {

--- a/pubsub-adapter/src/main/kotlin/io/ably/lib/rest/RestClientAdapter.kt
+++ b/pubsub-adapter/src/main/kotlin/io/ably/lib/rest/RestClientAdapter.kt
@@ -12,7 +12,7 @@ import io.ably.lib.types.*
 /**
  * Wrapper for Rest client
  */
-fun RestClient(javaClient: AblyRest): RestClient = RestClientAdapter(javaClient)
+public fun RestClient(javaClient: AblyRest): RestClient = RestClientAdapter(javaClient)
 
 internal class RestClientAdapter(private val javaClient: AblyRest) : RestClient, SdkWrapperCompatible<RestClient> {
   override val channels: Channels<out RestChannel>

--- a/pubsub-adapter/src/main/kotlin/io/ably/lib/rest/RestClientUtils.kt
+++ b/pubsub-adapter/src/main/kotlin/io/ably/lib/rest/RestClientUtils.kt
@@ -1,15 +1,30 @@
 package io.ably.lib.rest
 
+import com.ably.annotations.InternalAPI
 import io.ably.lib.http.Http
 import io.ably.lib.http.HttpCore
 import io.ably.lib.types.*
 
-fun AblyBase.time(http: Http): Long = time(http)
-fun AblyBase.timeAsync(http: Http, callback: Callback<Long>): Unit = timeAsync(http, callback)
-fun AblyBase.stats(http: Http, params: Array<Param>): PaginatedResult<Stats> = stats(http, params)
-fun AblyBase.statsAsync(http: Http, params: Array<Param>, callback: Callback<AsyncPaginatedResult<Stats>>): Unit =
+@InternalAPI
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+public fun AblyBase.time(http: Http): Long = time(http)
+
+@InternalAPI
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+public fun AblyBase.timeAsync(http: Http, callback: Callback<Long>): Unit = timeAsync(http, callback)
+
+@InternalAPI
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+public fun AblyBase.stats(http: Http, params: Array<Param>): PaginatedResult<Stats> = stats(http, params)
+
+@InternalAPI
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+public fun AblyBase.statsAsync(http: Http, params: Array<Param>, callback: Callback<AsyncPaginatedResult<Stats>>): Unit =
   this.statsAsync(http, params, callback)
-fun AblyBase.request(
+
+@InternalAPI
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+public fun AblyBase.request(
   http: Http,
   method: String,
   path: String,
@@ -17,7 +32,10 @@ fun AblyBase.request(
   body: HttpCore.RequestBody?,
   headers: Array<Param>?
 ): HttpPaginatedResponse = this.request(http, method, path, params, body, headers)
-fun AblyBase.requestAsync(
+
+@InternalAPI
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+public fun AblyBase.requestAsync(
   http: Http,
   method: String?,
   path: String?,


### PR DESCRIPTION
Although the `pubsub-adapter` module is currently completely internal and not ready to be exposed, we expect this to change. That’s why we plan to provide a well-designed public API while ensuring that unnecessary details remain hidden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enabled explicit API declarations to enforce consistent and clear public interface definitions.

- **Refactor**
  - Updated visibility modifiers across various interfaces and methods to enhance accessibility and clarity.
  - Adjusted internal utility function scopes to restrict access where necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->