### PR TITLE
fix: wrap unhandled request exceptions into `AblyException`

### DIFF
--- a/lib/src/main/java/io/ably/lib/http/HttpCore.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpCore.java
@@ -285,6 +285,12 @@ public class HttpCore {
             response = executeRequest(request);
         } catch (FailedConnectionException exception) {
             throw AblyException.fromThrowable(exception);
+        } catch (Exception e) {
+            if (e.getCause() instanceof IOException) {
+                throw AblyException.fromThrowable(e.getCause());
+            } else {
+                throw AblyException.fromThrowable(e);
+            }
         }
 
         if (rawHttpListener != null) {


### PR DESCRIPTION
Fixes https://github.com/ably/ably-java/issues/1071

During the `HttpCore` refactoring, some exceptions that were previously wrapped in checked `AblyException` exceptions were instead wrapped in `RealtimeException`. As a result, code that handled these exceptions may behave differently, since checked exceptions ensure that an exception handler is in place. This commit restores the original behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for network connectivity issues, ensuring that users receive more specific and actionable error messages when problems occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->