### PR TITLE
[ECO-5246] fix: Realtime Client Reconnection Logic

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
+++ b/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
@@ -64,14 +64,6 @@ public class AblyRealtime extends AblyRest {
         this.channels = channels;
         connection = new Connection(this, channels, platformAgentProvider);
 
-        /* remove all channels when the connection is closed, to avoid stalled state */
-        connection.on(ConnectionEvent.closed, new ConnectionStateListener() {
-            @Override
-            public void onConnectionStateChanged(ConnectionStateListener.ConnectionStateChange state) {
-                channels.clear();
-            }
-        });
-
         if (!StringUtils.isNullOrEmpty(options.recover)) {
             RecoveryKeyContext recoveryKeyContext = RecoveryKeyContext.decode(options.recover);
             if (recoveryKeyContext != null) {

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -681,6 +681,16 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
         }
     }
 
+    /**
+     * Internal
+     * <p>
+     * (RTN11d) Resets channels back to initialized and clears error reason
+     */
+    public synchronized void setReinitialized() {
+        clearAttachTimers();
+        setState(ChannelState.initialized, null);
+    }
+
     @Override
     protected void apply(ChannelStateListener listener, ChannelEvent event, Object... args) {
         try {


### PR DESCRIPTION
Resolves https://github.com/ably/ably-java/issues/1074

Previously, we cleared all channels on the close event, causing all previously acquired channels to become orphaned. We have now removed this logic and fixed the reconnection behavior to align with the spec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Modified channel management to prevent automatic clearing of channels upon connection closure, allowing for persistent channel states.

- **New Features**
  - Introduced a mechanism to reinitialize channels, resetting their states and error conditions during reconnection for smoother recovery.

- **Tests**
  - Added tests to validate that channels properly reset when reconnecting from closed or closing states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->