### PR TITLE
fix: deadlock in `WebSocket.close()`

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -381,8 +381,7 @@ public class WebSocketTransport implements ITransport {
             }
         }
 
-        private synchronized void onActivityTimerExpiry() {
-            activityTimerTask = null;
+        private void onActivityTimerExpiry() {
             long timeSinceLastActivity = System.currentTimeMillis() - lastActivityTime;
             long timeRemaining = getActivityTimeout() - timeSinceLastActivity;
 
@@ -393,9 +392,12 @@ public class WebSocketTransport implements ITransport {
                 return;
             }
 
-            // Otherwise, we've had some activity, restart the timer for the next timeout
-            Log.v(TAG, "onActivityTimerExpiry: ok");
-            startActivityTimer(timeRemaining + 100);
+            synchronized (this) {
+                activityTimerTask = null;
+                // Otherwise, we've had some activity, restart the timer for the next timeout
+                Log.v(TAG, "onActivityTimerExpiry: ok");
+                startActivityTimer(timeRemaining + 100);
+            }
         }
 
         private long getActivityTimeout() {


### PR DESCRIPTION
Fixes https://github.com/ably/ably-java/issues/1079

The `Java-WebSocket` library holds a lock while invoking listeners, and when a connection is terminated ungracefully, it can cause a deadlock. Here’s an explanation:

- The **WebSocketLibrary**’s connection checker thread executes `WebSocket.close()`.
- The **WebSocketLibrary** acquires a lock and starts invoking listeners while holding the lock.
- The **WebSocketHandler** has an internal Timer that holds a lock on the handler. This Timer decides to close the connection as well and calls `WebSocket.close()` while holding the lock.
- The **WebSocketLibrary** tries to dispose of the **Timer**  but can’t because the **Timer**  holds the lock.
- The **Timer**  tries to close the connection but can’t because the  **WebSocketLibrary** still holds the lock.

There are two issues here:

1. The **WebSocketLibrary** shouldn’t hold a lock while calling listeners.
2. The **Timer** shouldn’t hold a lock while calling `close()`.

We can’t fix the first issue, which is why we need to address the second one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved connection handling to enhance overall stability and performance, ensuring a more robust and responsive experience during periods of activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->