### PR TITLE
Rename action META_OCCUPANCY->META

### DIFF
--- a/lib/src/main/java/io/ably/lib/types/MessageAction.java
+++ b/lib/src/main/java/io/ably/lib/types/MessageAction.java
@@ -4,7 +4,7 @@ public enum MessageAction {
     MESSAGE_CREATE, // 0
     MESSAGE_UPDATE, // 1
     MESSAGE_DELETE, // 2
-    META_OCCUPANCY, // 3
+    META, // 3
     MESSAGE_SUMMARY; // 4
 
     static MessageAction tryFindByOrdinal(int ordinal) {


### PR DESCRIPTION
https://github.com/ably/specification/pull/292/commits/35bbeb7f8ed9f384fb7105eac8adab7430254f45

Technically a breaking change. We're not considering it such because `Message.action` was only introduced recently as part of the annotations/materialization work, which isn't yet part of a publicly released feature yet, and isn't added to our [main documentation](https://ably.com/docs/api/realtime-sdk/types#message). So it's just very unlikely that anyone is relying on the action yet. Our inband occupancy events docs still all say to use the message name, which is not changing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed an enum constant from "META_OCCUPANCY" to "META" in the user-facing API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->