### PR TITLE
[ECO-5065] feat: add support for managing message annotations

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -13,6 +13,7 @@ import io.ably.lib.http.BasePaginatedQuery;
 import io.ably.lib.http.Http;
 import io.ably.lib.http.HttpCore;
 import io.ably.lib.http.HttpUtils;
+import io.ably.lib.rest.RestAnnotation;
 import io.ably.lib.transport.ConnectionManager;
 import io.ably.lib.transport.ConnectionManager.QueuedMessage;
 import io.ably.lib.transport.Defaults;
@@ -90,6 +91,8 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
      * @see #markAsReleased()
      */
     private boolean released = false;
+
+    public final RealtimeAnnotation annotations;
 
     /***
      * internal
@@ -1295,6 +1298,10 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
         this.attachResume = false;
         state = ChannelState.initialized;
         this.decodingContext = new DecodingContext();
+        this.annotations = new RealtimeAnnotation(
+            this,
+            new RestAnnotation(name, ably.http, ably.options, options)
+        );
     }
 
     void onChannelMessage(ProtocolMessage msg) {
@@ -1361,6 +1368,9 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
         case error:
             setFailed(msg.error);
             break;
+        case annotation:
+            annotations.onAnnotation(msg);
+            break;
         default:
             Log.e(TAG, "onChannelMessage(): Unexpected message action (" + msg.action + ")");
         }
@@ -1385,6 +1395,17 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
 
     public void once(ChannelState state, ChannelStateListener listener) {
         super.once(state.getChannelEvent(), listener);
+    }
+
+    /**
+     * (Internal) Sends a protocol message and provides a callback for completion.
+     *
+     * @param protocolMessage the protocol message to be sent
+     * @param listener the listener to be notified upon completion of the message delivery
+     */
+    public void sendProtocolMessage(ProtocolMessage protocolMessage, CompletionListener listener) throws AblyException {
+        ConnectionManager connectionManager = ably.connection.connectionManager;
+        connectionManager.send(protocolMessage, ably.options.queueMessages, listener);
     }
 
     private static final String TAG = Channel.class.getName();

--- a/lib/src/main/java/io/ably/lib/realtime/RealtimeAnnotation.java
+++ b/lib/src/main/java/io/ably/lib/realtime/RealtimeAnnotation.java
@@ -1,0 +1,284 @@
+package io.ably.lib.realtime;
+
+import io.ably.lib.rest.RestAnnotation;
+import io.ably.lib.types.AblyException;
+import io.ably.lib.types.Annotation;
+import io.ably.lib.types.AnnotationAction;
+import io.ably.lib.types.AsyncPaginatedResult;
+import io.ably.lib.types.Callback;
+import io.ably.lib.types.ErrorInfo;
+import io.ably.lib.types.MessageDecodeException;
+import io.ably.lib.types.PaginatedResult;
+import io.ably.lib.types.Param;
+import io.ably.lib.types.ProtocolMessage;
+import io.ably.lib.util.Log;
+import io.ably.lib.util.Multicaster;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * RealtimeAnnotation provides subscription capabilities for annotations received on a channel.
+ * It allows adding or removing listeners to handle annotation events and facilitates broadcasting
+ * those events to the appropriate listeners.
+ * <p>
+ * Note: This is an experimental API. While the underlying functionality is stable,
+ * the public API may change in future releases.
+ */
+public class RealtimeAnnotation {
+
+    private static final String TAG = RealtimeAnnotation.class.getName();
+
+    private final ChannelBase channel;
+    private final RestAnnotation restAnnotation;
+    private final AnnotationMulticaster listeners = new AnnotationMulticaster();
+    private final Map<String, AnnotationMulticaster> typeListeners = new HashMap<>();
+
+    public RealtimeAnnotation(ChannelBase channel, RestAnnotation restAnnotation) {
+        this.channel = channel;
+        this.restAnnotation = restAnnotation;
+    }
+
+    public void publish(String messageSerial, Annotation annotation, CompletionListener listener) throws AblyException {
+        Log.v(TAG, String.format("publish(MsgSerial, Annotation); channel = %s", channel.name));
+
+        throwIfNotAbleToSendOrQueueAnnotation();
+
+        try {
+            annotation.encode(channel.options);
+        } catch (MessageDecodeException e) {
+            throw AblyException.fromThrowable(e);
+        }
+
+        Log.v(TAG, String.format("RealtimeAnnotations.publish(): channelName = %s, sending annotation with messageSerial = %s, type = %s",
+            channel.name, messageSerial, annotation.type));
+
+        ProtocolMessage protocolMessage = new ProtocolMessage();
+        protocolMessage.action = ProtocolMessage.Action.annotation;
+        protocolMessage.channel = channel.name;
+        protocolMessage.annotations = new Annotation[]{annotation};
+
+        channel.sendProtocolMessage(protocolMessage, listener);
+    }
+
+    public void publish(String messageSerial, Annotation annotation) throws AblyException {
+        publish(messageSerial, annotation, null);
+    }
+
+    private void throwIfNotAbleToSendOrQueueAnnotation() throws AblyException {
+        if (channel.state == ChannelState.detached || channel.state == ChannelState.detaching || channel.state == ChannelState.failed) {
+            throw AblyException.fromErrorInfo(new ErrorInfo("Unable to enter presence channel in detached or failed state", 400, 91001));
+        }
+    }
+
+    public void delete(String messageSerial, Annotation annotation, CompletionListener listener) throws AblyException {
+        Log.v(TAG, String.format("delete(MsgSerial, Annotation); channel = %s", channel.name));
+        annotation.action = AnnotationAction.ANNOTATION_DELETE;
+        publish(messageSerial, annotation, listener);
+    }
+
+    public void delete(String messageSerial, Annotation annotation) throws AblyException {
+        delete(messageSerial, annotation, null);
+    }
+
+    /**
+     * Retrieves a paginated list of annotations associated with the specified message serial.
+     * <p>
+     * Note: This is an experimental API. While the underlying functionality is stable,
+     * the public API may change in future releases.
+     *
+     * @param messageSerial the unique serial identifier for the message being annotated.
+     * @param params        an array of query parameters for filtering or modifying the request.
+     * @return a {@link PaginatedResult} containing the matching annotations.
+     * @throws AblyException if an error occurs during the retrieval process.
+     */
+    public PaginatedResult<Annotation> get(String messageSerial, Param[] params) throws AblyException {
+        return restAnnotation.get(messageSerial, params);
+    }
+
+    /**
+     * Retrieves a paginated list of annotations associated with the specified message serial.
+     * <p>
+     * Note: This is an experimental API. While the underlying functionality is stable,
+     * the public API may change in future releases.
+     *
+     * @param messageSerial the unique serial identifier for the message being annotated
+     * @return a PaginatedResult containing the matching annotations
+     * @throws AblyException if an error occurs during the retrieval process
+     */
+    public PaginatedResult<Annotation> get(String messageSerial) throws AblyException {
+        return restAnnotation.get(messageSerial, null);
+    }
+
+    /**
+     * Asynchronously retrieves a paginated list of annotations associated with the specified message serial.
+     * <p>
+     * Note: This is an experimental API. While the underlying functionality is stable,
+     * the public API may change in future releases.
+     *
+     * @param messageSerial the unique serial identifier for the message being annotated.
+     * @param params        an array of query parameters for filtering or modifying the request.
+     * @param callback      a callback to handle the result asynchronously, providing an {@link AsyncPaginatedResult} containing the matching annotations.
+     */
+    public void getAsync(String messageSerial, Param[] params, Callback<AsyncPaginatedResult<Annotation>> callback) {
+        restAnnotation.getAsync(messageSerial, params, callback);
+    }
+
+    /**
+     * Asynchronously retrieves a paginated list of annotations associated with the specified message serial.
+     * <p>
+     * Note: This is an experimental API. While the underlying functionality is stable,
+     * the public API may change in future releases.
+     *
+     * @param messageSerial the unique serial identifier for the message being annotated.
+     * @param callback      a callback to handle the result asynchronously, providing an {@link AsyncPaginatedResult} containing the matching annotations.
+     */
+    public void getAsync(String messageSerial, Callback<AsyncPaginatedResult<Annotation>> callback) {
+        restAnnotation.getAsync(messageSerial, null, callback);
+    }
+
+    /**
+     * Subscribes the given {@link AnnotationListener} to the channel, allowing it to receive annotations.
+     * If the channel's attach on subscribe option is enabled, the channel is attached automatically.
+     * <p>
+     * Note: This is an experimental API. While the underlying functionality is stable,
+     * the public API may change in future releases.
+     *
+     * @param listener the listener to be subscribed to the channel
+     * @throws AblyException if an error occurs during channel attachment
+     */
+    public synchronized void subscribe(AnnotationListener listener) throws AblyException {
+        Log.v(TAG, String.format("subscribe(); annotations in channel = %s", channel.name));
+        listeners.add(listener);
+        if (channel.attachOnSubscribeEnabled()) {
+            channel.attach();
+        }
+    }
+
+    /**
+     * Unsubscribes the specified {@link AnnotationListener} from the channel, stopping it
+     * from receiving further annotations. Any corresponding type-specific listeners
+     * associated with the listener are also removed.
+     * <p>
+     * Note: This is an experimental API. While the underlying functionality is stable,
+     * the public API may change in future releases.
+     *
+     * @param listener the {@link AnnotationListener} to be unsubscribed
+     */
+    public synchronized void unsubscribe(AnnotationListener listener) {
+        Log.v(TAG, String.format("unsubscribe(); annotations in channel = %s", channel.name));
+        listeners.remove(listener);
+        for (AnnotationMulticaster multicaster : typeListeners.values()) {
+            multicaster.remove(listener);
+        }
+    }
+
+    /**
+     * Subscribes the given {@link AnnotationListener} to the channel for a specific annotation type,
+     * allowing it to receive annotations of the specified type. If the channel's attach on subscribe
+     * option is enabled, the channel is attached automatically.
+     * <p>
+     * Note: This is an experimental API. While the underlying functionality is stable,
+     * the public API may change in future releases.
+     *
+     * @param type     the specific annotation type to subscribe to; if null, subscribes to all types
+     * @param listener the {@link AnnotationListener} to be subscribed
+     */
+    public synchronized void subscribe(String type, AnnotationListener listener) throws AblyException {
+        Log.v(TAG, String.format("subscribe(); annotations in channel = %s; single type = %s", channel.name, type));
+        subscribeImpl(type, listener);
+        if (channel.attachOnSubscribeEnabled()) {
+            channel.attach();
+        }
+    }
+
+    /**
+     * Unsubscribes the specified {@link AnnotationListener} from receiving annotations
+     * of a particular type within the channel. If there are no remaining listeners
+     * for the specified type, the type-specific listener collection is also removed.
+     * <p>
+     * Note: This is an experimental API. While the underlying functionality is stable,
+     * the public API may change in future releases.
+     *
+     * @param type     the specific annotation type to unsubscribe from; if null, unsubscribes
+     *                 from all annotations associated with the listener
+     * @param listener the {@link AnnotationListener} to be unsubscribed
+     */
+    public synchronized void unsubscribe(String type, AnnotationListener listener) {
+        Log.v(TAG, String.format("unsubscribe(); annotations in channel = %s; single type = %s", channel.name, type));
+        unsubscribeImpl(type, listener);
+    }
+
+    /**
+     * Internal method. Handles incoming annotation messages from the protocol layer.
+     *
+     * @param protocolMessage the protocol message containing annotation data
+     */
+    public void onAnnotation(ProtocolMessage protocolMessage) {
+        List<Annotation> annotations = new ArrayList<>();
+        for (int i = 0; i < protocolMessage.annotations.length; i++) {
+            Annotation annotation = protocolMessage.annotations[i];
+            try {
+                annotation.decode(channel.options);
+            } catch (MessageDecodeException e) {
+                Log.e(TAG, String.format(Locale.ROOT, "%s on channel %s", e.errorInfo.message, channel.name));
+            }
+            /* populate fields derived from protocol message */
+            if (annotation.connectionId == null) annotation.connectionId = protocolMessage.connectionId;
+            if (annotation.timestamp == 0) annotation.timestamp = protocolMessage.timestamp;
+            if (annotation.id == null) annotation.id = protocolMessage.id + ':' + i;
+            annotations.add(annotation);
+        }
+        broadcastAnnotation(annotations);
+    }
+
+    private void broadcastAnnotation(List<Annotation> annotations) {
+        for (Annotation annotation : annotations) {
+            listeners.onAnnotation(annotation);
+
+            String type = annotation.type != null ? annotation.type : "";
+            AnnotationMulticaster eventListener = typeListeners.get(type);
+            if (eventListener != null) eventListener.onAnnotation(annotation);
+        }
+    }
+
+    private void subscribeImpl(String type, AnnotationListener listener) {
+        String annotationType = type != null ? type : "";
+        AnnotationMulticaster typeSpecificListeners = typeListeners.get(annotationType);
+        if (typeSpecificListeners == null) {
+            typeSpecificListeners = new AnnotationMulticaster();
+            typeListeners.put(annotationType, typeSpecificListeners);
+        }
+        typeSpecificListeners.add(listener);
+    }
+
+    private void unsubscribeImpl(String type, AnnotationListener listener) {
+        AnnotationMulticaster listeners = typeListeners.get(type);
+        if (listeners != null) {
+            listeners.remove(listener);
+            if (listeners.isEmpty()) {
+                typeListeners.remove(type);
+            }
+        }
+    }
+
+    public interface AnnotationListener {
+        void onAnnotation(Annotation annotation);
+    }
+
+    private static class AnnotationMulticaster extends Multicaster<AnnotationListener> implements AnnotationListener {
+        @Override
+        public void onAnnotation(Annotation annotation) {
+            for (final AnnotationListener member : getMembers()) {
+                try {
+                    member.onAnnotation(annotation);
+                } catch (Exception e) {
+                    Log.e(TAG, e.getMessage(), e);
+                }
+            }
+        }
+    }
+}

--- a/lib/src/main/java/io/ably/lib/rest/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/rest/ChannelBase.java
@@ -39,6 +39,13 @@ public class ChannelBase {
     public final Presence presence;
 
     /**
+     * Represents the annotations associated with a channel message.
+     * This field provides functionality for managing annotations.
+     */
+    public final RestAnnotation annotations;
+
+
+    /**
      * Publish a message on this channel using the REST API.
      * Since the REST API is stateless, this request is made independently
      * of any other request on this or any other channel.
@@ -315,6 +322,7 @@ public class ChannelBase {
         this.options = options;
         this.basePath = "/channels/" + HttpUtils.encodeURIComponent(name);
         this.presence = new Presence();
+        this.annotations = new RestAnnotation(name, ably.http, ably.options, options);
     }
 
     private final AblyBase ably;

--- a/lib/src/main/java/io/ably/lib/rest/RestAnnotation.java
+++ b/lib/src/main/java/io/ably/lib/rest/RestAnnotation.java
@@ -1,0 +1,185 @@
+package io.ably.lib.rest;
+
+import io.ably.lib.http.BasePaginatedQuery;
+import io.ably.lib.http.Http;
+import io.ably.lib.http.HttpCore;
+import io.ably.lib.http.HttpUtils;
+import io.ably.lib.types.AblyException;
+import io.ably.lib.types.Annotation;
+import io.ably.lib.types.AnnotationAction;
+import io.ably.lib.types.AnnotationSerializer;
+import io.ably.lib.types.AsyncPaginatedResult;
+import io.ably.lib.types.Callback;
+import io.ably.lib.types.ChannelOptions;
+import io.ably.lib.types.ClientOptions;
+import io.ably.lib.types.PaginatedResult;
+import io.ably.lib.types.Param;
+import io.ably.lib.util.Crypto;
+import io.ably.lib.util.Log;
+
+import java.util.Arrays;
+
+/**
+ * The RestAnnotation class provides methods to manage and interact with annotations
+ * associated with messages in a specific channel.
+ * <p>
+ * Annotations can be retrieved, published, or deleted both synchronously and asynchronously.
+ * This class is intended as part of a client library for managing annotations via REST architecture.
+ * <p>
+ * Note: This is an experimental API. While the underlying functionality is stable,
+ * the public API may change in future releases.
+ */
+public class RestAnnotation {
+
+    private static final String TAG = RestAnnotation.class.getName();
+
+    private final String channelName;
+    private final Http http;
+    private final ClientOptions clientOptions;
+    private final ChannelOptions channelOptions;
+
+    public RestAnnotation(String channelName, Http http, ClientOptions clientOptions, ChannelOptions channelOptions) {
+        this.channelName = channelName;
+        this.http = http;
+        this.clientOptions = clientOptions;
+        this.channelOptions = channelOptions;
+    }
+
+    /**
+     * Retrieves a paginated list of annotations associated with the specified message serial.
+     * <p>
+     * Note: This is an experimental API. While the underlying functionality is stable,
+     * the public API may change in future releases.
+     *
+     * @param messageSerial the unique serial identifier for the message being annotated.
+     * @param params an array of query parameters for filtering or modifying the request.
+     * @return a {@link PaginatedResult} containing the matching annotations.
+     * @throws AblyException if an error occurs during the retrieval process.
+     */
+    public PaginatedResult<Annotation> get(String messageSerial, Param[] params) throws AblyException {
+        return getImpl(messageSerial, params).sync();
+    }
+
+    /**
+     * Asynchronously retrieves a paginated list of annotations associated with the specified message serial.
+     * <p>
+     * Note: This is an experimental API. While the underlying functionality is stable,
+     * the public API may change in future releases.
+     *
+     * @param messageSerial the unique serial identifier for the message being annotated.
+     * @param params an array of query parameters for filtering or modifying the request.
+     * @param callback a callback to handle the result asynchronously, providing an {@link AsyncPaginatedResult} containing the matching annotations.
+     */
+    public void getAsync(String messageSerial, Param[] params, Callback<AsyncPaginatedResult<Annotation>> callback) {
+        getImpl(messageSerial, params).async(callback);
+    }
+
+    /**
+     * Retrieves a paginated list of annotations associated with the specified message serial.
+     * <p>
+     * Note: This is an experimental API. While the underlying functionality is stable,
+     * the public API may change in future releases.
+     *
+     * @param messageSerial the unique serial identifier for the message being annotated
+     * @return a PaginatedResult containing the matching annotations
+     * @throws AblyException if an error occurs during the retrieval process
+     */
+    public PaginatedResult<Annotation> get(String messageSerial) throws AblyException {
+        return get(messageSerial, null);
+    }
+
+    /**
+     * Asynchronously retrieves a paginated list of annotations associated with the specified message serial.
+     * <p>
+     * Note: This is an experimental API. While the underlying functionality is stable,
+     * the public API may change in future releases.
+     *
+     * @param messageSerial the unique serial identifier for the message being annotated.
+     * @param callback a callback to handle the result asynchronously, providing an {@link AsyncPaginatedResult} containing the matching annotations.
+     */
+    public void getAsync(String messageSerial, Callback<AsyncPaginatedResult<Annotation>> callback) {
+        getImpl(messageSerial, null).async(callback);
+    }
+
+    /**
+     * Publishes an annotation associated with the specified message serial
+     * to the REST channel.
+     * <p>
+     * Note: This is an experimental API. While the underlying functionality is stable,
+     * the public API may change in future releases.
+     *
+     * @param messageSerial the unique serial identifier for the message being annotated.
+     * @param annotation the annotation to be published.
+     * @throws AblyException if an error occurs during the publishing process.
+     */
+    public void publish(String messageSerial, Annotation annotation) throws AblyException {
+        publishImpl(messageSerial, annotation).sync();
+    }
+
+    /**
+     * Asynchronously publishes an annotation associated with the specified message serial
+     * to the REST channel.
+     * <p>
+     * Note: This is an experimental API. While the underlying functionality is stable,
+     * the public API may change in future releases.
+     *
+     * @param messageSerial the unique serial identifier for the message being annotated.
+     * @param annotation the annotation to be published.
+     * @param callback a callback to handle the result asynchronously, providing a
+     *                 completion indication or error information.
+     */
+    public void publishAsync(String messageSerial, Annotation annotation, Callback<Void> callback) {
+        publishImpl(messageSerial, annotation).async(callback);
+    }
+
+    /**
+     * Deletes an annotation associated with the specified message serial.
+     * <p>
+     * Note: This is an experimental API. While the underlying functionality is stable,
+     * the public API may change in future releases.
+     *
+     * @param messageSerial the unique serial identifier for the message being annotated.
+     * @param annotation the annotation to be deleted.
+     * @throws AblyException if an error occurs during the deletion process.
+     */
+    public void delete(String messageSerial, Annotation annotation) throws AblyException {
+        annotation.action = AnnotationAction.ANNOTATION_DELETE;
+        publish(messageSerial, annotation);
+    }
+
+    /**
+     * Asynchronously deletes an annotation associated with the specified message serial.
+     * <p>
+     * Note: This is an experimental API. While the underlying functionality is stable,
+     * the public API may change in future releases.
+     *
+     * @param messageSerial the unique serial identifier for the message being annotated.
+     * @param annotation the annotation to be deleted.
+     * @param callback a callback to handle the result asynchronously, providing a completion
+     *                 indication or error information.
+     */
+    public void deleteAsync(String messageSerial, Annotation annotation, Callback<Void> callback) {
+        annotation.action = AnnotationAction.ANNOTATION_DELETE;
+        publishAsync(messageSerial, annotation, callback);
+    }
+
+    private String getBasePath(String messageSerial) {
+        return "/channels/" + HttpUtils.encodeURIComponent(channelName) + "/messages/" + HttpUtils.encodeURIComponent(messageSerial) + "/annotations";
+    }
+
+    private Http.Request<Void> publishImpl(String messageSerial, Annotation annotation) {
+        Log.v(TAG, "publishImpl(): annotation=" + annotation);
+        return http.request((http, callback) -> {
+            HttpCore.RequestBody requestBody = clientOptions.useBinaryProtocol ? AnnotationSerializer.asMsgpackRequest(annotation) : AnnotationSerializer.asJsonRequest(annotation);
+            final Param[] params = clientOptions.addRequestIds ? Param.array(Crypto.generateRandomRequestId()) : null; // RSC7c
+            http.post(getBasePath(messageSerial), HttpUtils.defaultAcceptHeaders(clientOptions.useBinaryProtocol), params, requestBody, null, true, callback);
+        });
+    }
+
+    private BasePaginatedQuery.ResultRequest<Annotation> getImpl(String messageSerial, Param[] initialParams) {
+        Log.v(TAG, "getImpl(): params=" + Arrays.toString(initialParams));
+        HttpCore.BodyHandler<Annotation> bodyHandler = AnnotationSerializer.getAnnotationResponseHandler(channelOptions);
+        final Param[] params = clientOptions.addRequestIds ? Param.set(initialParams, Crypto.generateRandomRequestId()) : initialParams; // RSC7c
+        return (new BasePaginatedQuery<>(http, getBasePath(messageSerial), HttpUtils.defaultAcceptHeaders(clientOptions.useBinaryProtocol), params, bodyHandler)).get();
+    }
+}

--- a/lib/src/main/java/io/ably/lib/types/Annotation.java
+++ b/lib/src/main/java/io/ably/lib/types/Annotation.java
@@ -1,0 +1,248 @@
+package io.ably.lib.types;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import io.ably.lib.util.Log;
+import io.ably.lib.util.Serialisation;
+import org.msgpack.core.MessageFormat;
+import org.msgpack.core.MessagePacker;
+import org.msgpack.core.MessageUnpacker;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+
+public class Annotation extends BaseMessage {
+
+    private static final String TAG = Annotation.class.getName();
+
+    private static final String ACTION = "action";
+    private static final String SERIAL = "serial";
+    private static final String MESSAGE_SERIAL = "messageSerial";
+    private static final String TYPE = "type";
+    private static final String NAME = "name";
+    private static final String COUNT = "count";
+    private static final String EXTRAS = "extras";
+
+    /**
+     * (TAN2b) The action, whether this is an annotation being added or removed,
+     * one of the AnnotationAction enum values.
+     */
+    public AnnotationAction action;
+
+    /**
+     * (TAN2i) This annotation's unique serial (lexicographically totally ordered).
+     */
+    public String serial;
+
+    /**
+     * (TAN2j) The serial of the message (of type `MESSAGE_CREATE`) that this annotation is annotating.
+     */
+    public String messageSerial;
+
+    /**
+     * (TAN2k) The type of annotation it is, typically some identifier together with an aggregation method;
+     * for example: "emoji:distinct.v1". Handled opaquely by the SDK and validated serverside. |
+     */
+    public String type;
+
+    /**
+     * (TAN2d) The name of this annotation. This is the field that most annotation aggregations will operate on.
+     * For example, using "distinct.v1" aggregation (specified in the type), the message summary will show a list
+     * of clients who have published an annotation with each distinct annotation.name.
+     */
+    public String name;
+
+    /**
+     * (TAN2e) An optional count, only relevant to certain aggregation methods,
+     * see aggregation methods documentation for more info.
+     */
+    public Integer count;
+
+    /**
+     * (TAN2l) A JSON object for metadata and/or ancillary payloads.
+     */
+    public MessageExtras extras;
+
+    public static Annotation fromMsgpack(MessageUnpacker unpacker) throws IOException {
+        return (new Annotation()).readMsgpack(unpacker);
+    }
+
+    void writeMsgpack(MessagePacker packer) throws IOException {
+        int fieldCount = super.countFields();
+        if (action != null) ++fieldCount;
+        if (serial != null) ++fieldCount;
+        if (messageSerial != null) ++fieldCount;
+        if (type != null) ++fieldCount;
+        if (name != null) ++fieldCount;
+        if (count != null) ++fieldCount;
+        if (extras != null) ++fieldCount;
+
+        packer.packMapHeader(fieldCount);
+        super.writeFields(packer);
+
+        if (action != null) {
+            packer.packString(ACTION);
+            packer.packInt(action.ordinal());
+        }
+
+        if (serial != null) {
+            packer.packString(SERIAL);
+            packer.packString(serial);
+        }
+
+        if (messageSerial != null) {
+            packer.packString(MESSAGE_SERIAL);
+            packer.packString(messageSerial);
+        }
+
+        if (type != null) {
+            packer.packString(TYPE);
+            packer.packString(type);
+        }
+
+        if (name != null) {
+            packer.packString(NAME);
+            packer.packString(name);
+        }
+
+        if (count != null) {
+            packer.packString(COUNT);
+            packer.packInt(count);
+        }
+
+        if (extras != null) {
+            packer.packString(EXTRAS);
+            extras.write(packer);
+        }
+    }
+
+    Annotation readMsgpack(MessageUnpacker unpacker) throws IOException {
+        int fieldCount = unpacker.unpackMapHeader();
+        for (int i = 0; i < fieldCount; i++) {
+            String fieldName = unpacker.unpackString().intern();
+            MessageFormat fieldFormat = unpacker.getNextFormat();
+            if (fieldFormat.equals(MessageFormat.NIL)) {
+                unpacker.unpackNil();
+                continue;
+            }
+
+            if (super.readField(unpacker, fieldName, fieldFormat)) {
+                continue;
+            }
+            if (fieldName.equals(ACTION)) {
+                action = AnnotationAction.tryFindByOrdinal(unpacker.unpackInt());
+            } else if (fieldName.equals(SERIAL)) {
+                serial = unpacker.unpackString();
+            } else if (fieldName.equals(MESSAGE_SERIAL)) {
+                messageSerial = unpacker.unpackString();
+            } else if (fieldName.equals(TYPE)) {
+                type = unpacker.unpackString();
+            } else if (fieldName.equals(NAME)) {
+                name = unpacker.unpackString();
+            } else if (fieldName.equals(COUNT)) {
+                count = unpacker.unpackInt();
+            } else if (fieldName.equals(EXTRAS)) {
+                extras = MessageExtras.read(unpacker);
+            } else {
+                Log.v(TAG, "Unexpected field: " + fieldName);
+                unpacker.skipValue();
+            }
+        }
+        return this;
+    }
+
+    @Override
+    protected void read(final JsonObject map) throws MessageDecodeException {
+        super.read(map);
+
+        Integer actionOrdinal = readInt(map, ACTION);
+        action = actionOrdinal == null ? null : AnnotationAction.tryFindByOrdinal(actionOrdinal);
+        serial = readString(map, SERIAL);
+        messageSerial = readString(map, MESSAGE_SERIAL);
+
+        type = readString(map, TYPE);
+        name = readString(map, NAME);
+        count = readInt(map, COUNT);
+
+        final JsonElement extrasElement = map.get(EXTRAS);
+        if (extrasElement != null) {
+            if (!extrasElement.isJsonObject()) {
+                throw MessageDecodeException.fromDescription("Message extras is of type \"" + extrasElement.getClass() + "\" when expected a JSON object.");
+            }
+            extras = MessageExtras.read((JsonObject) extrasElement);
+        }
+    }
+
+    public static class Serializer implements JsonSerializer<Annotation>, JsonDeserializer<Annotation> {
+        @Override
+        public JsonElement serialize(Annotation annotation, Type typeOfMessage, JsonSerializationContext ctx) {
+            final JsonObject json = BaseMessage.toJsonObject(annotation);
+            if (annotation.action != null) {
+                json.addProperty(ACTION, annotation.action.ordinal());
+            }
+
+            if (annotation.serial != null) {
+                json.addProperty(SERIAL, annotation.serial);
+            }
+
+            if (annotation.messageSerial != null) {
+                json.addProperty(MESSAGE_SERIAL, annotation.messageSerial);
+            }
+
+            if (annotation.type != null) {
+                json.addProperty(TYPE, annotation.type);
+            }
+
+            if (annotation.name != null) {
+                json.addProperty(NAME, annotation.name);
+            }
+
+            if (annotation.count != null) {
+                json.addProperty(COUNT, annotation.count);
+            }
+
+            if (annotation.extras != null) {
+                json.add(EXTRAS, Serialisation.gson.toJsonTree(annotation.extras));
+            }
+
+            return json;
+        }
+
+        @Override
+        public Annotation deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            if (!json.isJsonObject()) {
+                throw new JsonParseException("Expected an object but got \"" + json.getClass() + "\".");
+            }
+
+            final Annotation annotation = new Annotation();
+
+            try {
+                annotation.read((JsonObject) json);
+            } catch (MessageDecodeException e) {
+                Log.e(TAG, e.getMessage(), e);
+                throw new JsonParseException("Failed to deserialize Message from JSON.", e);
+            }
+
+            return annotation;
+        }
+    }
+
+    public static class ActionSerializer implements JsonSerializer<AnnotationAction>, JsonDeserializer<AnnotationAction> {
+        @Override
+        public AnnotationAction deserialize(JsonElement json, Type t, JsonDeserializationContext ctx)
+            throws JsonParseException {
+            return AnnotationAction.tryFindByOrdinal(json.getAsInt());
+        }
+
+        @Override
+        public JsonElement serialize(AnnotationAction action, Type t, JsonSerializationContext ctx) {
+            return new JsonPrimitive(action.ordinal());
+        }
+    }
+}

--- a/lib/src/main/java/io/ably/lib/types/AnnotationAction.java
+++ b/lib/src/main/java/io/ably/lib/types/AnnotationAction.java
@@ -1,0 +1,19 @@
+package io.ably.lib.types;
+
+/**
+ * Enumerates the possible values of the {@link Annotation#action} field of an {@link Annotation}
+ */
+public enum AnnotationAction {
+    /**
+     * (TAN2b) A created annotation
+     */
+    ANNOTATION_CREATE,
+    /**
+     * (TAN2b) A deleted annotation
+     */
+    ANNOTATION_DELETE;
+
+    static AnnotationAction tryFindByOrdinal(int ordinal) {
+        return values().length <= ordinal ? null: values()[ordinal];
+    }
+}

--- a/lib/src/main/java/io/ably/lib/types/AnnotationSerializer.java
+++ b/lib/src/main/java/io/ably/lib/types/AnnotationSerializer.java
@@ -1,0 +1,101 @@
+package io.ably.lib.types;
+
+import io.ably.lib.http.HttpCore;
+import io.ably.lib.http.HttpUtils;
+import io.ably.lib.util.Log;
+import io.ably.lib.util.Serialisation;
+import org.msgpack.core.MessagePacker;
+import org.msgpack.core.MessageUnpacker;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class AnnotationSerializer {
+
+    private static final String TAG = AnnotationSerializer.class.getName();
+
+    public static void writeMsgpackArray(Annotation[] annotations, MessagePacker packer) {
+        try {
+            int count = annotations.length;
+            packer.packArrayHeader(count);
+            for (Annotation annotation : annotations) {
+                annotation.writeMsgpack(packer);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    public static Annotation[] readMsgpackArray(MessageUnpacker unpacker) throws IOException {
+        int count = unpacker.unpackArrayHeader();
+        Annotation[] result = new Annotation[count];
+        for (int i = 0; i < count; i++)
+            result[i] = Annotation.fromMsgpack(unpacker);
+        return result;
+    }
+
+    public static HttpCore.RequestBody asMsgpackRequest(Annotation annotation) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            MessagePacker packer = Serialisation.msgpackPackerConfig.newPacker(out);
+            annotation.writeMsgpack(packer);
+            packer.flush();
+        } catch (IOException e) {
+            Log.e(TAG, e.getMessage(), e);
+        }
+        return new HttpUtils.ByteArrayRequestBody(out.toByteArray(), "application/x-msgpack");
+    }
+
+    public static HttpCore.RequestBody asJsonRequest(Annotation annotation) {
+        return new HttpUtils.JsonRequestBody(Serialisation.gson.toJson(annotation));
+    }
+
+    public static HttpCore.BodyHandler<Annotation> getAnnotationResponseHandler(ChannelOptions channelOptions) {
+        return new AnnotationBodyHandler(channelOptions);
+    }
+
+    public static Annotation[] readMsgpack(byte[] packed) throws AblyException {
+        try {
+            MessageUnpacker unpacker = Serialisation.msgpackUnpackerConfig.newUnpacker(packed);
+            return readMsgpackArray(unpacker);
+        } catch (IOException ioe) {
+            throw AblyException.fromThrowable(ioe);
+        }
+    }
+
+    public static Annotation[] readMessagesFromJson(byte[] packed) throws MessageDecodeException {
+        return Serialisation.gson.fromJson(new String(packed), Annotation[].class);
+    }
+
+    private static class AnnotationBodyHandler implements HttpCore.BodyHandler<Annotation> {
+
+        private final ChannelOptions channelOptions;
+
+        AnnotationBodyHandler(ChannelOptions channelOptions) {
+            this.channelOptions = channelOptions;
+        }
+
+        @Override
+        public Annotation[] handleResponseBody(String contentType, byte[] body) throws AblyException {
+            try {
+                Annotation[] annotations = null;
+                if ("application/json".equals(contentType))
+                    annotations = readMessagesFromJson(body);
+                else if ("application/x-msgpack".equals(contentType))
+                    annotations = readMsgpack(body);
+                if (annotations != null) {
+                    for (Annotation annotation : annotations) {
+                        try {
+                            annotation.decode(channelOptions);
+                        } catch (MessageDecodeException e) {
+                            Log.e(TAG, e.errorInfo.message);
+                        }
+                    }
+                }
+                return annotations;
+            } catch (MessageDecodeException e) {
+                throw AblyException.fromThrowable(e);
+            }
+        }
+    }
+}

--- a/lib/src/main/java/io/ably/lib/types/ChannelMode.java
+++ b/lib/src/main/java/io/ably/lib/types/ChannelMode.java
@@ -24,7 +24,15 @@ public enum ChannelMode {
     /**
      * The client can receive presence messages.
      */
-    presence_subscribe(Flag.presence_subscribe);
+    presence_subscribe(Flag.presence_subscribe),
+    /**
+     * The client can publish annotation.
+     */
+    annotation_publish(Flag.annotation_publish),
+    /**
+     * The client can subscribe to annotations.
+     */
+    annotation_subscribe(Flag.annotation_subscribe);
 
     private final int mask;
 

--- a/lib/src/main/java/io/ably/lib/types/MessageAction.java
+++ b/lib/src/main/java/io/ably/lib/types/MessageAction.java
@@ -4,7 +4,7 @@ public enum MessageAction {
     MESSAGE_CREATE, // 0
     MESSAGE_UPDATE, // 1
     MESSAGE_DELETE, // 2
-    META_OCCUPANCY, // 3
+    META, // 3
     MESSAGE_SUMMARY; // 4
 
     static MessageAction tryFindByOrdinal(int ordinal) {

--- a/lib/src/main/java/io/ably/lib/types/ProtocolMessage.java
+++ b/lib/src/main/java/io/ably/lib/types/ProtocolMessage.java
@@ -28,24 +28,28 @@ import io.ably.lib.util.Log;
  */
 public class ProtocolMessage {
     public enum Action {
-        heartbeat,
-        ack,
-        nack,
-        connect,
-        connected,
-        disconnect,
-        disconnected,
-        close,
-        closed,
-        error,
-        attach,
-        attached,
-        detach,
-        detached,
-        presence,
-        message,
-        sync,
-        auth;
+        heartbeat, // 0
+        ack, // 1
+        nack, // 2
+        connect, // 3
+        connected, // 4
+        disconnect, // 5
+        disconnected, // 6
+        close, // 7
+        closed, // 8
+        error, // 9
+        attach, // 10
+        attached, // 11
+        detach, // 12
+        detached, // 13
+        presence, // 14
+        message, // 15
+        sync, // 16
+        auth, // 17
+        activate, // 18
+        object, // 19
+        object_sync, // 20
+        annotation; // 21
 
         public int getValue() { return ordinal(); }
         public static Action findByValue(int value) { return values()[value]; }
@@ -62,7 +66,13 @@ public class ProtocolMessage {
         presence(16),
         publish(17),
         subscribe(18),
-        presence_subscribe(19);
+        presence_subscribe(19),
+        // 20 reserved (TR3v)
+        annotation_publish(21), // (TR3w)
+        annotation_subscribe(22), // (TR3x)
+        // 23 reserved (TR3v)
+        object_subscribe(24), // (TR3y)
+        object_publish(25); // (TR3z)
 
         private final int mask;
 
@@ -75,8 +85,12 @@ public class ProtocolMessage {
         }
     }
 
+    /**
+     * (RTN7a)
+     */
     public static boolean ackRequired(ProtocolMessage msg) {
-        return (msg.action == Action.message || msg.action == Action.presence);
+        return (msg.action == Action.message || msg.action == Action.presence
+            || msg.action == Action.object || msg.action == Action.annotation);
     }
 
     public ProtocolMessage() {}
@@ -105,6 +119,7 @@ public class ProtocolMessage {
     public ConnectionDetails connectionDetails;
     public AuthDetails auth;
     public Map<String, String> params;
+    public Annotation[] annotations;
 
     public boolean hasFlag(final Flag flag) {
         return (flags & flag.getMask()) == flag.getMask();
@@ -162,6 +177,10 @@ public class ProtocolMessage {
         if(channelSerial != null) {
             packer.packString("channelSerial");
             packer.packString(channelSerial);
+        }
+        if(annotations != null) {
+            packer.packString("annotations");
+            AnnotationSerializer.writeMsgpackArray(annotations, packer);
         }
     }
 
@@ -221,6 +240,9 @@ public class ProtocolMessage {
                     break;
                 case "params":
                     params = MessageSerializer.readStringMap(unpacker);
+                    break;
+                case "annotations":
+                    annotations = AnnotationSerializer.readMsgpackArray(unpacker);
                     break;
                 default:
                     Log.v(TAG, "Unexpected field: " + fieldName);

--- a/lib/src/main/java/io/ably/lib/types/Summary.java
+++ b/lib/src/main/java/io/ably/lib/types/Summary.java
@@ -1,0 +1,145 @@
+package io.ably.lib.types;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import io.ably.lib.util.Log;
+import io.ably.lib.util.Serialisation;
+import org.msgpack.core.MessagePacker;
+import org.msgpack.core.MessageUnpacker;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A summary of all the annotations that have been made to the message. Will always be
+ * populated for a message.summary, and may be populated for any other type (in
+ * particular a message retrieved from REST history will have its latest summary
+ * included).
+ * The keys of the map are the annotation types. The exact structure of the value of
+ * each key depends on the aggregation part of the annotation type, e.g. for a type of
+ * reaction:distinct.v1, the value will be a DistinctValues object. New aggregation
+ * methods might be added serverside, hence the 'unknown' part of the sum type.
+ */
+public class Summary {
+
+    private static final String TAG = Summary.class.getName();
+
+    /**
+     * (TM2q1) The sdk MUST be able to cope with structures and aggregation types that have it does not yet know about
+     * or have explicit support for, hence the loose (JsonObject) type.
+     */
+    private final JsonObject summaryJsonRepresentation;
+
+    public Summary(JsonObject summaryJsonRepresentation) {
+        this.summaryJsonRepresentation = summaryJsonRepresentation;
+    }
+
+    public static Map<String, SummaryClientIdList> asSummaryDistinctV1(JsonObject jsonObject) {
+        Map<String, SummaryClientIdList> summary = new HashMap<>();
+        jsonObject.entrySet().forEach(entry -> {
+            String key = entry.getKey();
+            summary.put(key, asSummaryFlagV1(entry.getValue().getAsJsonObject()));
+        });
+        return summary;
+    }
+
+    public static Map<String, SummaryClientIdList> asSummaryUniqueV1(JsonObject jsonObject) {
+        return asSummaryDistinctV1(jsonObject);
+    }
+
+    public static Map<String, SummaryClientIdCounts> asSummaryMultipleV1(JsonObject jsonObject) {
+        Map<String, SummaryClientIdCounts> summary = new HashMap<>();
+        jsonObject.entrySet().forEach(entry -> {
+            String key = entry.getKey();
+            JsonObject value = entry.getValue().getAsJsonObject();
+            int total = value.get("total").getAsInt();
+            Map<String, Integer> clientIds = Serialisation.gson.fromJson(value.get("clientIds"), Map.class);
+            summary.put(key, new SummaryClientIdCounts(total, clientIds));
+        });
+        return summary;
+    }
+
+    public static SummaryClientIdList asSummaryFlagV1(JsonObject jsonObject) {
+        int total = jsonObject.get("total").getAsInt();
+        List<String> clientIds = Serialisation.gson.fromJson(jsonObject.get("clientIds"), List.class);
+        return new SummaryClientIdList(total, clientIds);
+    }
+
+    public static SummaryTotal asSummaryTotalV1(JsonObject jsonObject) {
+        int total = jsonObject.get("total").getAsInt();
+        return new SummaryTotal(total);
+    }
+
+    static Summary read(MessageUnpacker unpacker) {
+        try {
+            return new Summary(Serialisation.msgpackToGson(unpacker.unpackValue()).getAsJsonObject());
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to read summary from MessagePack", e);
+            return null;
+        }
+    }
+
+    static Summary read(JsonObject jsonObject) {
+        return new Summary(jsonObject);
+    }
+
+    void write(MessagePacker packer) {
+        Serialisation.gsonToMsgpack(summaryJsonRepresentation, packer);
+    }
+
+    JsonElement toJsonTree() {
+        return Serialisation.gson.toJsonTree(this);
+    }
+
+    public static class SummaryClientIdList {
+        private final int total; // TM7c1a
+        private final List<String> clientIds; // TM7c1b
+
+        public SummaryClientIdList(int total, List<String> clientIds) {
+            this.total = total;
+            this.clientIds = clientIds;
+        }
+    }
+
+    public static class SummaryClientIdCounts {
+        private final int total; // TM7d1a
+        private final Map<String, Integer> clientIds; // TM7d1b
+
+        public SummaryClientIdCounts(int total, Map<String, Integer> clientIds) {
+            this.total = total;
+            this.clientIds = clientIds;
+        }
+    }
+
+    public static class SummaryTotal {
+        private final int total; // TM7e1a
+
+        SummaryTotal(int total) {
+            this.total = total;
+        }
+    }
+
+    public static class Serializer implements JsonSerializer<Summary>, JsonDeserializer<Summary> {
+
+        @Override
+        public JsonElement serialize(Summary summary, Type typeOfMessage, JsonSerializationContext ctx) {
+            return summary.summaryJsonRepresentation;
+        }
+
+        @Override
+        public Summary deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            if (!json.isJsonObject()) {
+                throw new JsonParseException("Expected an object but got \"" + json.getClass() + "\".");
+            }
+            return new Summary(json.getAsJsonObject());
+        }
+
+    }
+}

--- a/lib/src/main/java/io/ably/lib/util/Serialisation.java
+++ b/lib/src/main/java/io/ably/lib/util/Serialisation.java
@@ -11,11 +11,14 @@ import com.google.gson.JsonPrimitive;
 import io.ably.lib.http.HttpCore;
 import io.ably.lib.platform.Platform;
 import io.ably.lib.types.AblyException;
+import io.ably.lib.types.Annotation;
+import io.ably.lib.types.AnnotationAction;
 import io.ably.lib.types.ErrorInfo;
 import io.ably.lib.types.Message;
 import io.ably.lib.types.MessageExtras;
 import io.ably.lib.types.PresenceMessage;
 import io.ably.lib.types.ProtocolMessage;
+import io.ably.lib.types.Summary;
 import org.msgpack.core.MessagePack;
 import org.msgpack.core.MessagePack.PackerConfig;
 import org.msgpack.core.MessagePack.UnpackerConfig;
@@ -48,6 +51,9 @@ public class Serialisation {
         gsonBuilder.registerTypeAdapter(PresenceMessage.class, new PresenceMessage.Serializer());
         gsonBuilder.registerTypeAdapter(PresenceMessage.Action.class, new PresenceMessage.ActionSerializer());
         gsonBuilder.registerTypeAdapter(ProtocolMessage.Action.class, new ProtocolMessage.ActionSerializer());
+        gsonBuilder.registerTypeAdapter(Annotation.class, new Annotation.Serializer());
+        gsonBuilder.registerTypeAdapter(AnnotationAction.class, new Annotation.ActionSerializer());
+        gsonBuilder.registerTypeAdapter(Summary.class, new Summary.Serializer());
         gson = gsonBuilder.create();
 
         msgpackPackerConfig = Platform.name.equals("android") ?

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAnnotationsTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeAnnotationsTest.java
@@ -1,0 +1,149 @@
+package io.ably.lib.test.realtime;
+
+import io.ably.lib.realtime.AblyRealtime;
+import io.ably.lib.realtime.Channel;
+import io.ably.lib.realtime.ChannelState;
+import io.ably.lib.realtime.ConnectionState;
+import io.ably.lib.rest.AblyRest;
+import io.ably.lib.rest.Auth;
+import io.ably.lib.test.common.Helpers;
+import io.ably.lib.test.common.ParameterizedTest;
+import io.ably.lib.types.AblyException;
+import io.ably.lib.types.Annotation;
+import io.ably.lib.types.AnnotationAction;
+import io.ably.lib.types.ClientOptions;
+import io.ably.lib.types.Message;
+import io.ably.lib.types.MessageAction;
+import io.ably.lib.types.MessageExtras;
+import io.ably.lib.types.Param;
+import io.ably.lib.types.PaginatedResult;
+import io.ably.lib.types.PresenceMessage;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class RealtimeAnnotationsTest extends ParameterizedTest {
+
+    @Rule
+    public Timeout testTimeout = Timeout.seconds(300);
+
+    @Test
+    public void publish_and_subscribe_annotations() throws AblyException, InterruptedException {
+        ClientOptions opts = createOptions();
+        AblyRealtime realtime = new AblyRealtime(opts);
+        AblyRest rest = new AblyRest(opts);
+
+        Channel channel = realtime.channels.get("mutable:publish_subscribe_annotation",
+            new Channel.ChannelOptions("publish", "subscribe", "annotation_publish", "annotation_subscribe"));
+        Channel restChannel = rest.channels.get("mutable:publish_subscribe_annotation");
+
+        channel.attach();
+        Helpers.CompletionWaiter waiter = new Helpers.CompletionWaiter();
+        channel.once(ChannelState.attached, waiter);
+        waiter.waitFor();
+
+        final Message[] receivedMessage = new Message[1];
+        channel.subscribe(message -> receivedMessage[0] = message);
+
+        final Annotation[] receivedAnnotation = new Annotation[1];
+        channel.annotations.subscribe(annotation -> receivedAnnotation[0] = annotation);
+
+        channel.publish("message", "foobar");
+        Thread.sleep(1000);
+
+        assertNotNull("Message should be received", receivedMessage[0]);
+
+        channel.annotations.publish(receivedMessage[0], "reaction:distinct.v1", "👍");
+        Thread.sleep(1000);
+
+        assertNotNull("Annotation should be received", receivedAnnotation[0]);
+        assertEquals(AnnotationAction.ANNOTATION_CREATE, receivedAnnotation[0].action);
+        assertEquals(receivedMessage[0].serial, receivedAnnotation[0].messageSerial);
+        assertEquals("reaction:distinct.v1", receivedAnnotation[0].type);
+        assertEquals("👍", receivedAnnotation[0].name);
+        assertTrue(Long.parseLong(receivedAnnotation[0].serial) > Long.parseLong(receivedAnnotation[0].messageSerial));
+
+        receivedAnnotation[0] = null;
+        restChannel.annotations.publish(receivedMessage[0], "reaction:distinct.v1", "😕");
+        Thread.sleep(1000);
+
+        assertNotNull("Rest annotation should be received", receivedAnnotation[0]);
+        assertEquals(AnnotationAction.ANNOTATION_CREATE, receivedAnnotation[0].action);
+        assertEquals(receivedMessage[0].serial, receivedAnnotation[0].messageSerial);
+        assertEquals("reaction:distinct.v1", receivedAnnotation[0].type);
+        assertEquals("😕", receivedAnnotation[0].name);
+        assertTrue(Long.parseLong(receivedAnnotation[0].serial) > Long.parseLong(receivedAnnotation[0].messageSerial));
+
+        realtime.close();
+        rest.close();
+    }
+
+    @Test
+    public void get_all_annotations() throws AblyException, InterruptedException {
+        ClientOptions opts = createOptions();
+        AblyRealtime realtime = new AblyRealtime(opts);
+
+        Channel channel = realtime.channels.get("mutable:get_all_annotations_for_a_message",
+            new Channel.ChannelOptions("publish", "subscribe", "annotation_publish", "annotation_subscribe"));
+
+        channel.attach();
+        Helpers.CompletionWaiter waiter = new Helpers.CompletionWaiter();
+        channel.once(ChannelState.attached, waiter);
+        waiter.waitFor();
+
+        final Message[] receivedMessage = new Message[1];
+        channel.subscribe(message -> receivedMessage[0] = message);
+
+        channel.publish("message", "foobar");
+        Thread.sleep(1000);
+
+        String[] emojis = new String[]{"👍", "😕", "👎", "👍👍", "😕😕", "👎👎"};
+        for (String emoji : emojis) {
+            channel.annotations.publish(receivedMessage[0].serial, "reaction:distinct.v1", emoji);
+            Thread.sleep(100);
+        }
+
+        Thread.sleep(1000);
+        PaginatedResult<Annotation> result = channel.annotations.get(receivedMessage[0].serial);
+        assertEquals(6, result.items.length);
+
+        assertEquals(AnnotationAction.ANNOTATION_CREATE, result.items[0].action);
+        assertEquals(receivedMessage[0].serial, result.items[0].messageSerial);
+        assertEquals("reaction:distinct.v1", result.items[0].type);
+        assertEquals("👍", result.items[0].name);
+        assertEquals("😕", result.items[1].name);
+        assertEquals("👎", result.items[2].name);
+        assertTrue(Long.parseLong(result.items[1].serial) > Long.parseLong(result.items[0].serial));
+        assertTrue(Long.parseLong(result.items[2].serial) > Long.parseLong(result.items[1].serial));
+
+        result = channel.annotations.get(receivedMessage[0].serial, new Param[]{new Param("limit", "2")});
+        assertEquals(2, result.items.length);
+        assertEquals("👍", result.items[0].name);
+        assertEquals("😕", result.items[1].name);
+        assertTrue(result.hasNext());
+
+        result = result.next();
+        assertNotNull(result);
+        assertEquals(2, result.items.length);
+        assertEquals("👎", result.items[0].name);
+        assertEquals("👍👍", result.items[1].name);
+        assertTrue(result.hasNext());
+
+        result = result.next();
+        assertNotNull(result);
+        assertEquals(2, result.items.length);
+        assertEquals("😕😕", result.items[0].name);
+        assertEquals("👎👎", result.items[1].name);
+        assertTrue(!result.hasNext());
+
+        realtime.close();
+    }
+
+
+}

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeSuite.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeSuite.java
@@ -1,5 +1,6 @@
 package io.ably.lib.test.realtime;
 
+import io.ably.lib.realtime.RealtimeAnnotation;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.JUnitCore;
@@ -15,6 +16,7 @@ import io.ably.lib.test.common.Setup;
 @SuiteClasses({
     ConnectionManagerTest.class,
     RealtimeHttpHeaderTest.class,
+    RealtimeAnnotation.class,
     RealtimeAuthTest.class,
     RealtimeJWTTest.class,
     RealtimeReauthTest.class,


### PR DESCRIPTION
Add support for managing message annotations via Rest and Realtime APIs

Introduced new classes and functionality to enable creating, retrieving, and deleting annotations on messages, both synchronously and asynchronously. Extended protocol support to handle annotation operations and added serialization/deserialization logic for annotations and summaries.