### PR TITLE
[ECO-5430] fix: npe in the connectivity check

### DIFF
--- a/lib/src/main/java/io/ably/lib/http/HttpHelpers.java
+++ b/lib/src/main/java/io/ably/lib/http/HttpHelpers.java
@@ -1,6 +1,5 @@
 package io.ably.lib.http;
 
-import java.io.IOException;
 import java.net.URL;
 
 import io.ably.lib.types.AblyException;
@@ -42,7 +41,11 @@ public class HttpHelpers {
      * @throws AblyException
      */
     public static String getUrlString(HttpCore httpCore, String url) throws AblyException {
-        return new String(getUrl(httpCore, url));
+        byte[] bytes = getUrl(httpCore, url);
+        if (bytes == null) {
+            throw AblyException.fromErrorInfo(new ErrorInfo("Empty response body", 500, 50000));
+        }
+        return new String(bytes);
     }
 
     /**
@@ -62,8 +65,8 @@ public class HttpHelpers {
                     }
                     return response.body;
                 }});
-        } catch(IOException ioe) {
-            throw AblyException.fromThrowable(ioe);
+        } catch (Exception e) {
+            throw AblyException.fromThrowable(e);
         }
     }
 

--- a/lib/src/test/java/io/ably/lib/http/HttpHelpersTest.java
+++ b/lib/src/test/java/io/ably/lib/http/HttpHelpersTest.java
@@ -1,0 +1,61 @@
+package io.ably.lib.http;
+
+import io.ably.lib.types.AblyException;
+import org.junit.Test;
+
+import java.net.URL;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertEquals;
+
+public class HttpHelpersTest {
+
+    @Test
+    public void getUrlString_validResponse_returnsString() throws Exception {
+        HttpCore mockHttpCore = mock(HttpCore.class);
+        HttpCore.Response mockResponse = new HttpCore.Response();
+        mockResponse.body = "Test Response".getBytes();
+
+        when(mockHttpCore.httpExecuteWithRetry(
+            eq(new URL("http://example.com")),
+            eq("GET"),
+            eq(null),
+            eq(null),
+            any(HttpCore.ResponseHandler.class),
+            eq(false)
+        )).thenAnswer(invocation -> {
+            HttpCore.ResponseHandler<byte[]> responseHandler = invocation.getArgumentAt(4, HttpCore.ResponseHandler.class);
+            return responseHandler.handleResponse(mockResponse, null);
+        });
+
+        String result = HttpHelpers.getUrlString(mockHttpCore, "http://example.com");
+        assertEquals("Test Response", result);
+    }
+
+    @Test
+    public void getUrlString_emptyResponse_throwsAblyException() throws Exception {
+        HttpCore mockHttpCore = mock(HttpCore.class);
+        HttpCore.Response mockResponse = new HttpCore.Response();
+
+        when(mockHttpCore.httpExecuteWithRetry(
+            eq(new URL("http://example.com")),
+            eq("GET"),
+            eq(null),
+            eq(null),
+            any(HttpCore.ResponseHandler.class),
+            eq(false)
+        )).thenAnswer(invocation -> {
+            HttpCore.ResponseHandler<byte[]> responseHandler = invocation.getArgumentAt(4, HttpCore.ResponseHandler.class);
+            return responseHandler.handleResponse(mockResponse, null);
+        });
+
+        AblyException e = assertThrows(AblyException.class, () -> HttpHelpers.getUrlString(mockHttpCore, "http://example.com"));
+        assertEquals(500, e.errorInfo.statusCode);
+        assertEquals(50000, e.errorInfo.code);
+        assertEquals("Empty response body", e.errorInfo.message);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/ably/ably-java/issues/1110

handle empty response in `HttpHelpers.getUrlString`

- Throw `AblyException` for empty response bodies.
- Added corresponding unit tests to validate behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for empty HTTP responses, ensuring a clear error message is provided if the response body is empty.
  * Enhanced exception handling to better manage unexpected errors during HTTP requests.

* **Tests**
  * Added new tests to verify correct behavior for both successful and empty HTTP response scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->