### PR TITLE
fix: move serializer initialization inside methods

### DIFF
--- a/lib/src/main/java/io/ably/lib/objects/LiveObjectsHelper.java
+++ b/lib/src/main/java/io/ably/lib/objects/LiveObjectsHelper.java
@@ -34,7 +34,7 @@ public class LiveObjectsHelper {
                     } catch (ClassNotFoundException | InstantiationException | IllegalAccessException |
                              NoSuchMethodException |
                              InvocationTargetException e) {
-                        Log.e(TAG, "Failed to init LiveObjectSerializer, LiveObjects plugin not included in the classpath", e);
+                        Log.w(TAG, "Failed to init LiveObjectSerializer, LiveObjects plugin not included in the classpath", e);
                         return null;
                     }
                 }

--- a/lib/src/main/java/io/ably/lib/objects/LiveObjectsJsonSerializer.java
+++ b/lib/src/main/java/io/ably/lib/objects/LiveObjectsJsonSerializer.java
@@ -13,10 +13,10 @@ import java.lang.reflect.Type;
 
 public class LiveObjectsJsonSerializer implements JsonSerializer<Object[]>, JsonDeserializer<Object[]> {
     private static final String TAG = LiveObjectsJsonSerializer.class.getName();
-    private final LiveObjectSerializer serializer = LiveObjectsHelper.getLiveObjectSerializer();
 
     @Override
     public Object[] deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        LiveObjectSerializer serializer = LiveObjectsHelper.getLiveObjectSerializer();
         if (serializer == null) {
             Log.w(TAG, "Skipping 'state' field json deserialization because LiveObjectsSerializer not found.");
             return null;
@@ -29,6 +29,7 @@ public class LiveObjectsJsonSerializer implements JsonSerializer<Object[]>, Json
 
     @Override
     public JsonElement serialize(Object[] src, Type typeOfSrc, JsonSerializationContext context) {
+        LiveObjectSerializer serializer = LiveObjectsHelper.getLiveObjectSerializer();
         if (serializer == null) {
             Log.w(TAG, "Skipping 'state' field json serialization because LiveObjectsSerializer not found.");
             return JsonNull.INSTANCE;


### PR DESCRIPTION
it prevents SDK from immediately posting an error log message about not having LiveObject installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how serializers are managed during serialization and deserialization processes, ensuring a fresh instance is used for each operation.
  * Adjusted logging to provide clearer warnings instead of errors during serializer initialization issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->