### PR TITLE
[ECO-5447][LiveObjects] Use server-provided timestamp to sweep old tombstones

### DIFF
--- a/live-objects/src/main/kotlin/io/ably/lib/objects/ObjectMessage.kt
+++ b/live-objects/src/main/kotlin/io/ably/lib/objects/ObjectMessage.kt
@@ -126,6 +126,12 @@ internal data class ObjectMapEntry(
   val timeserial: String? = null,
 
   /**
+   * A timestamp from the [timeserial] field. Only present if [tombstone] is `true`
+   * Spec: OME2d
+   */
+  val serialTimestamp: Long? = null,
+
+  /**
    * The data that represents the value of the map entry.
    * Spec: OME2c
    */
@@ -335,6 +341,12 @@ internal data class ObjectMessage(
    * Spec: OM2h
    */
   val serial: String? = null,
+
+  /**
+   * A timestamp from the [serial] field.
+   * Spec: OM2j
+   */
+  val serialTimestamp: Long? = null,
 
   /**
    * An opaque string used as a key to update the map of serial values on an object.

--- a/live-objects/src/main/kotlin/io/ably/lib/objects/serialization/MsgpackSerialization.kt
+++ b/live-objects/src/main/kotlin/io/ably/lib/objects/serialization/MsgpackSerialization.kt
@@ -38,6 +38,7 @@ internal fun ObjectMessage.writeMsgpack(packer: MessagePacker) {
   if (operation != null) fieldCount++
   if (objectState != null) fieldCount++
   if (serial != null) fieldCount++
+  if (serialTimestamp != null) fieldCount++
   if (siteCode != null) fieldCount++
 
   packer.packMapHeader(fieldCount)
@@ -82,6 +83,11 @@ internal fun ObjectMessage.writeMsgpack(packer: MessagePacker) {
     packer.packString(serial)
   }
 
+  if (serialTimestamp != null) {
+    packer.packString("serialTimestamp")
+    packer.packLong(serialTimestamp)
+  }
+
   if (siteCode != null) {
     packer.packString("siteCode")
     packer.packString(siteCode)
@@ -107,6 +113,7 @@ internal fun readObjectMessage(unpacker: MessageUnpacker): ObjectMessage {
   var operation: ObjectOperation? = null
   var objectState: ObjectState? = null
   var serial: String? = null
+  var serialTimestamp: Long? = null
   var siteCode: String? = null
 
   for (i in 0 until fieldCount) {
@@ -127,6 +134,7 @@ internal fun readObjectMessage(unpacker: MessageUnpacker): ObjectMessage {
       "operation" -> operation = readObjectOperation(unpacker)
       "object" -> objectState = readObjectState(unpacker)
       "serial" -> serial = unpacker.unpackString()
+      "serialTimestamp" -> serialTimestamp = unpacker.unpackLong()
       "siteCode" -> siteCode = unpacker.unpackString()
       else -> unpacker.skipValue()
     }
@@ -141,6 +149,7 @@ internal fun readObjectMessage(unpacker: MessageUnpacker): ObjectMessage {
     operation = operation,
     objectState = objectState,
     serial = serial,
+    serialTimestamp = serialTimestamp,
     siteCode = siteCode
   )
 }
@@ -558,6 +567,7 @@ private fun ObjectMapEntry.writeMsgpack(packer: MessagePacker) {
 
   if (tombstone != null) fieldCount++
   if (timeserial != null) fieldCount++
+  if (serialTimestamp != null) fieldCount++
   if (data != null) fieldCount++
 
   packer.packMapHeader(fieldCount)
@@ -570,6 +580,11 @@ private fun ObjectMapEntry.writeMsgpack(packer: MessagePacker) {
   if (timeserial != null) {
     packer.packString("timeserial")
     packer.packString(timeserial)
+  }
+
+  if (serialTimestamp != null) {
+    packer.packString("serialTimestamp")
+    packer.packLong(serialTimestamp)
   }
 
   if (data != null) {
@@ -586,6 +601,7 @@ private fun readObjectMapEntry(unpacker: MessageUnpacker): ObjectMapEntry {
 
   var tombstone: Boolean? = null
   var timeserial: String? = null
+  var serialTimestamp: Long? = null
   var data: ObjectData? = null
 
   for (i in 0 until fieldCount) {
@@ -600,12 +616,13 @@ private fun readObjectMapEntry(unpacker: MessageUnpacker): ObjectMapEntry {
     when (fieldName) {
       "tombstone" -> tombstone = unpacker.unpackBoolean()
       "timeserial" -> timeserial = unpacker.unpackString()
+      "serialTimestamp" -> serialTimestamp = unpacker.unpackLong()
       "data" -> data = readObjectData(unpacker)
       else -> unpacker.skipValue()
     }
   }
 
-  return ObjectMapEntry(tombstone = tombstone, timeserial = timeserial, data = data)
+  return ObjectMapEntry(tombstone = tombstone, timeserial = timeserial, serialTimestamp = serialTimestamp, data = data)
 }
 
 /**

--- a/live-objects/src/main/kotlin/io/ably/lib/objects/type/livecounter/DefaultLiveCounter.kt
+++ b/live-objects/src/main/kotlin/io/ably/lib/objects/type/livecounter/DefaultLiveCounter.kt
@@ -80,7 +80,7 @@ internal class DefaultLiveCounter private constructor(
   }
 
   override fun clearData(): LiveCounterUpdate {
-    return LiveCounterUpdate(data.get()).apply { data.set(0.0) }
+    return liveCounterManager.calculateUpdateFromDataDiff(data.get(), 0.0).apply { data.set(0.0) }
   }
 
   override fun notifyUpdated(update: LiveObjectUpdate) {

--- a/live-objects/src/main/kotlin/io/ably/lib/objects/type/livecounter/DefaultLiveCounter.kt
+++ b/live-objects/src/main/kotlin/io/ably/lib/objects/type/livecounter/DefaultLiveCounter.kt
@@ -72,12 +72,12 @@ internal class DefaultLiveCounter private constructor(
 
   override fun validate(state: ObjectState) = liveCounterManager.validate(state)
 
-  override fun applyObjectState(objectState: ObjectState): LiveCounterUpdate {
-    return liveCounterManager.applyState(objectState)
+  override fun applyObjectState(objectState: ObjectState, message: ObjectMessage): LiveCounterUpdate {
+    return liveCounterManager.applyState(objectState, message.serialTimestamp)
   }
 
   override fun applyObjectOperation(operation: ObjectOperation, message: ObjectMessage) {
-    liveCounterManager.applyOperation(operation)
+    liveCounterManager.applyOperation(operation, message.serialTimestamp)
   }
 
   override fun clearData(): LiveCounterUpdate {

--- a/live-objects/src/main/kotlin/io/ably/lib/objects/type/livecounter/LiveCounterManager.kt
+++ b/live-objects/src/main/kotlin/io/ably/lib/objects/type/livecounter/LiveCounterManager.kt
@@ -17,11 +17,11 @@ internal class LiveCounterManager(private val liveCounter: DefaultLiveCounter): 
   /**
    * @spec RTLC6 - Overrides counter data with state from sync
    */
-  internal fun applyState(objectState: ObjectState): LiveCounterUpdate {
+  internal fun applyState(objectState: ObjectState, serialTimestamp: Long?): LiveCounterUpdate {
     val previousData = liveCounter.data.get()
 
     if (objectState.tombstone) {
-      liveCounter.tombstone()
+      liveCounter.tombstone(serialTimestamp)
     } else {
       // override data for this object with data from the object state
       liveCounter.createOperationIsMerged = false // RTLC6b
@@ -39,7 +39,7 @@ internal class LiveCounterManager(private val liveCounter: DefaultLiveCounter): 
   /**
    * @spec RTLC7 - Applies operations to LiveCounter
    */
-  internal fun applyOperation(operation: ObjectOperation) {
+  internal fun applyOperation(operation: ObjectOperation, serialTimestamp: Long?) {
     val update = when (operation.action) {
       ObjectOperationAction.CounterCreate -> applyCounterCreate(operation) // RTLC7d1
       ObjectOperationAction.CounterInc -> {
@@ -49,7 +49,7 @@ internal class LiveCounterManager(private val liveCounter: DefaultLiveCounter): 
           throw objectError("No payload found for ${operation.action} op for LiveCounter objectId=${objectId}")
         }
       }
-      ObjectOperationAction.ObjectDelete -> liveCounter.tombstone()
+      ObjectOperationAction.ObjectDelete -> liveCounter.tombstone(serialTimestamp)
       else -> throw objectError("Invalid ${operation.action} op for LiveCounter objectId=${objectId}") // RTLC7d3
     }
 

--- a/live-objects/src/main/kotlin/io/ably/lib/objects/type/livecounter/LiveCounterManager.kt
+++ b/live-objects/src/main/kotlin/io/ably/lib/objects/type/livecounter/LiveCounterManager.kt
@@ -33,7 +33,7 @@ internal class LiveCounterManager(private val liveCounter: DefaultLiveCounter): 
       }
     }
 
-    return LiveCounterUpdate(liveCounter.data.get() - previousData)
+    return calculateUpdateFromDataDiff(previousData, liveCounter.data.get())
   }
 
   /**
@@ -83,6 +83,10 @@ internal class LiveCounterManager(private val liveCounter: DefaultLiveCounter): 
     val previousValue = liveCounter.data.get()
     liveCounter.data.set(previousValue + amount) // RTLC9b
     return LiveCounterUpdate(amount)
+  }
+
+  internal fun calculateUpdateFromDataDiff(prevData: Double, newData: Double): LiveCounterUpdate {
+    return LiveCounterUpdate(newData - prevData)
   }
 
   /**

--- a/live-objects/src/main/kotlin/io/ably/lib/objects/type/livemap/DefaultLiveMap.kt
+++ b/live-objects/src/main/kotlin/io/ably/lib/objects/type/livemap/DefaultLiveMap.kt
@@ -124,7 +124,7 @@ internal class DefaultLiveMap private constructor(
   }
 
   override fun applyObjectOperation(operation: ObjectOperation, message: ObjectMessage) {
-    liveMapManager.applyOperation(operation, message.serial)
+    liveMapManager.applyOperation(operation, message.serial, message.serialTimestamp)
   }
 
   override fun clearData(): LiveMapUpdate {

--- a/live-objects/src/main/kotlin/io/ably/lib/objects/type/livemap/DefaultLiveMap.kt
+++ b/live-objects/src/main/kotlin/io/ably/lib/objects/type/livemap/DefaultLiveMap.kt
@@ -119,8 +119,8 @@ internal class DefaultLiveMap private constructor(
 
   override fun unsubscribeAll() = liveMapManager.unsubscribeAll()
 
-  override fun applyObjectState(objectState: ObjectState): LiveMapUpdate {
-    return liveMapManager.applyState(objectState)
+  override fun applyObjectState(objectState: ObjectState, message: ObjectMessage): LiveMapUpdate {
+    return liveMapManager.applyState(objectState, message.serialTimestamp)
   }
 
   override fun applyObjectOperation(operation: ObjectOperation, message: ObjectMessage) {

--- a/live-objects/src/main/kotlin/io/ably/lib/objects/type/livemap/LiveMapManager.kt
+++ b/live-objects/src/main/kotlin/io/ably/lib/objects/type/livemap/LiveMapManager.kt
@@ -33,7 +33,7 @@ internal class LiveMapManager(private val liveMap: DefaultLiveMap): LiveMapChang
       objectState.map?.entries?.forEach { (key, entry) ->
         liveMap.data[key] = LiveMapEntry(
           isTombstoned = entry.tombstone ?: false,
-          tombstonedAt = if (entry.tombstone == true) System.currentTimeMillis() else null,
+          tombstonedAt = if (entry.tombstone == true) entry.serialTimestamp ?: System.currentTimeMillis() else null,
           timeserial = entry.timeserial,
           data = entry.data
         )
@@ -51,19 +51,19 @@ internal class LiveMapManager(private val liveMap: DefaultLiveMap): LiveMapChang
   /**
    * @spec RTLM15 - Applies operations to LiveMap
    */
-  internal fun applyOperation(operation: ObjectOperation, messageTimeserial: String?) {
+  internal fun applyOperation(operation: ObjectOperation, serial: String?, serialTimestamp: Long?) {
     val update = when (operation.action) {
       ObjectOperationAction.MapCreate -> applyMapCreate(operation) // RTLM15d1
       ObjectOperationAction.MapSet -> {
         if (operation.mapOp != null) {
-          applyMapSet(operation.mapOp, messageTimeserial) // RTLM15d2
+          applyMapSet(operation.mapOp, serial) // RTLM15d2
         } else {
           throw objectError("No payload found for ${operation.action} op for LiveMap objectId=${objectId}")
         }
       }
       ObjectOperationAction.MapRemove -> {
         if (operation.mapOp != null) {
-          applyMapRemove(operation.mapOp, messageTimeserial) // RTLM15d3
+          applyMapRemove(operation.mapOp, serial, serialTimestamp) // RTLM15d3
         } else {
           throw objectError("No payload found for ${operation.action} op for LiveMap objectId=${objectId}")
         }
@@ -132,7 +132,6 @@ internal class LiveMapManager(private val liveMap: DefaultLiveMap): LiveMapChang
       // RTLM7a2 - Replace existing entry with new one instead of mutating
       liveMap.data[mapOp.key] = LiveMapEntry(
         isTombstoned = false, // RTLM7a2c
-        tombstonedAt = null,
         timeserial = timeSerial, // RTLM7a2b
         data = mapOp.data // RTLM7a2a
       )
@@ -154,6 +153,7 @@ internal class LiveMapManager(private val liveMap: DefaultLiveMap): LiveMapChang
   private fun applyMapRemove(
     mapOp: ObjectMapOp, // RTLM8c1
     timeSerial: String?, // RTLM8c2
+    timeStamp: Long?, // RTLM8c3
   ): LiveMapUpdate {
     val existingEntry = liveMap.data[mapOp.key]
 
@@ -168,11 +168,20 @@ internal class LiveMapManager(private val liveMap: DefaultLiveMap): LiveMapChang
       return noOpMapUpdate
     }
 
+    val tombstonedAt = if (timeStamp != null) timeStamp else {
+      Log.w(
+        tag,
+        "No timestamp provided for MAP_REMOVE op on key=\"${mapOp.key}\"; using current time as tombstone time; " +
+          "objectId=${objectId}"
+      )
+      System.currentTimeMillis()
+    }
+
     if (existingEntry != null) {
       // RTLM8a2 - Replace existing entry with new one instead of mutating
       liveMap.data[mapOp.key] = LiveMapEntry(
         isTombstoned = true, // RTLM8a2c
-        tombstonedAt = System.currentTimeMillis(),
+        tombstonedAt = tombstonedAt,
         timeserial = timeSerial, // RTLM8a2b
         data = null // RTLM8a2a
       )
@@ -180,7 +189,7 @@ internal class LiveMapManager(private val liveMap: DefaultLiveMap): LiveMapChang
       // RTLM8b, RTLM8b1
       liveMap.data[mapOp.key] = LiveMapEntry(
         isTombstoned = true, // RTLM8b2
-        tombstonedAt = System.currentTimeMillis(),
+        tombstonedAt = tombstonedAt,
         timeserial = timeSerial
       )
     }
@@ -224,7 +233,7 @@ internal class LiveMapManager(private val liveMap: DefaultLiveMap): LiveMapChang
       val opTimeserial = entry.timeserial
       val update = if (entry.tombstone == true) {
         // RTLM17a2 - entry in MAP_CREATE op is removed, try to apply MAP_REMOVE op
-        applyMapRemove(ObjectMapOp(key), opTimeserial)
+        applyMapRemove(ObjectMapOp(key), opTimeserial, entry.serialTimestamp)
       } else {
         // RTLM17a1 - entry in MAP_CREATE op is not removed, try to set it via MAP_SET op
         applyMapSet(ObjectMapOp(key, entry.data), opTimeserial)

--- a/live-objects/src/main/kotlin/io/ably/lib/objects/type/livemap/LiveMapManager.kt
+++ b/live-objects/src/main/kotlin/io/ably/lib/objects/type/livemap/LiveMapManager.kt
@@ -20,11 +20,11 @@ internal class LiveMapManager(private val liveMap: DefaultLiveMap): LiveMapChang
   /**
    * @spec RTLM6 - Overrides object data with state from sync
    */
-  internal fun applyState(objectState: ObjectState): LiveMapUpdate {
+  internal fun applyState(objectState: ObjectState, serialTimestamp: Long?): LiveMapUpdate {
     val previousData = liveMap.data.toMap()
 
     if (objectState.tombstone) {
-      liveMap.tombstone()
+      liveMap.tombstone(serialTimestamp)
     } else {
       // override data for this object with data from the object state
       liveMap.createOperationIsMerged = false // RTLM6b
@@ -68,7 +68,7 @@ internal class LiveMapManager(private val liveMap: DefaultLiveMap): LiveMapChang
           throw objectError("No payload found for ${operation.action} op for LiveMap objectId=${objectId}")
         }
       }
-      ObjectOperationAction.ObjectDelete -> liveMap.tombstone()
+      ObjectOperationAction.ObjectDelete -> liveMap.tombstone(serialTimestamp)
       else -> throw objectError("Invalid ${operation.action} op for LiveMap objectId=${objectId}") // RTLM15d4
     }
 

--- a/live-objects/src/test/kotlin/io/ably/lib/objects/integration/DefaultLiveObjectsTest.kt
+++ b/live-objects/src/test/kotlin/io/ably/lib/objects/integration/DefaultLiveObjectsTest.kt
@@ -6,11 +6,15 @@ import io.ably.lib.objects.*
 import io.ably.lib.objects.Binary
 import io.ably.lib.objects.integration.helpers.State
 import io.ably.lib.objects.integration.helpers.fixtures.initializeRootMap
+import io.ably.lib.objects.integration.helpers.simulateObjectDelete
 import io.ably.lib.objects.integration.setup.IntegrationTest
 import io.ably.lib.objects.size
 import io.ably.lib.objects.state.ObjectsStateEvent
 import io.ably.lib.objects.type.counter.LiveCounter
+import io.ably.lib.objects.type.livecounter.DefaultLiveCounter
+import io.ably.lib.objects.type.livemap.DefaultLiveMap
 import io.ably.lib.objects.type.map.LiveMap
+import io.ably.lib.objects.type.map.LiveMapUpdate
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -155,13 +159,14 @@ class DefaultLiveObjectsTest : IntegrationTest() {
   }
 
   /**
-   * Spec: RTLO4e - Tests the removal of objects from the root map.
    * Server runs periodic garbage collection (GC) to remove orphaned objects and will send
    * OBJECT_DELETE events for objects that are no longer referenced.
-   * `OBJECT_DELETE` event is not covered in the test and we only check if map entries are removed
+   * So, we simulate the deletion of an object by sending an object delete ProtocolMessage.
+   * This does not actually delete the object from the server, only simulates the deletion locally.
+   * Spec: RTLO4e
    */
   @Test
-  fun testObjectRemovalFromRoot() = runTest {
+  fun testObjectDelete() = runTest {
     val channelName = generateChannelName()
     // Initialize the root map on the channel with initial data
     restObjects.initializeRootMap(channelName)
@@ -171,19 +176,41 @@ class DefaultLiveObjectsTest : IntegrationTest() {
     assertEquals(6L, rootMap.size()) // Should have 6 entries initially
 
     // Remove the "referencedCounter" from the root map
-    assertNotNull(rootMap.get("referencedCounter")) // Access to ensure it exists before removal
+    val refCounter = rootMap.get("referencedCounter") as LiveCounter
+    assertNotNull(refCounter)
+    // Subscribe to counter updates to verify removal
+    val counterUpdates = mutableListOf<Double>()
+    refCounter.subscribe { event ->
+      counterUpdates.add(event.update.amount)
+    }
 
-    restObjects.removeMapValue(channelName, "root", "referencedCounter")
+    // Simulate the deletion of the referencedCounter object
+    channel.objects.simulateObjectDelete(refCounter as DefaultLiveCounter)
 
     assertWaiter { rootMap.size() == 5L } // Wait for the removal to complete
     assertNull(rootMap.get("referencedCounter")) // Should be null after removal
+    assertEquals(1, counterUpdates.size) // Should have received one update for deletion
+    assertEquals(20.0, counterUpdates[0]) // The update should indicate the counter was removed
 
     // Remove the "referencedMap" from the root map
-    assertNotNull(rootMap.get("referencedMap")) // Access to ensure it exists before removal
+    val referencedMap = rootMap.get("referencedMap") as LiveMap
+    assertNotNull(referencedMap)
+    // Subscribe to map updates to verify removal
+    val mapUpdates = mutableListOf<Map<String, LiveMapUpdate.Change>>()
+    referencedMap.subscribe { event ->
+      mapUpdates.add(event.update)
+    }
 
-    restObjects.removeMapValue(channelName, "root", "referencedMap")
+    // Simulate the deletion of the referencedMap object
+    channel.objects.simulateObjectDelete(referencedMap as DefaultLiveMap)
 
     assertWaiter { rootMap.size() == 4L } // Wait for the removal to complete
     assertNull(rootMap.get("referencedMap")) // Should be null after removal
+    assertEquals(1, mapUpdates.size) // Should have received one update for deletion
+
+    val updatedMap = mapUpdates.first()
+    assertEquals(1, updatedMap.size) // Should have one change
+    assertEquals("counterKey", updatedMap.keys.first()) // The change should be for the "counterKey"
+    assertEquals(LiveMapUpdate.Change.REMOVED, updatedMap.values.first()) // Should indicate removal
   }
 }

--- a/live-objects/src/test/kotlin/io/ably/lib/objects/integration/helpers/Utils.kt
+++ b/live-objects/src/test/kotlin/io/ably/lib/objects/integration/helpers/Utils.kt
@@ -1,14 +1,40 @@
 package io.ably.lib.objects.integration.helpers
 
+import io.ably.lib.objects.*
 import io.ably.lib.objects.DefaultLiveObjects
+import io.ably.lib.objects.ObjectMessage
+import io.ably.lib.objects.ObjectOperation
+import io.ably.lib.objects.type.BaseLiveObject
 import io.ably.lib.objects.type.counter.LiveCounter
 import io.ably.lib.objects.type.map.LiveMap
-import io.ably.lib.objects.LiveObjects
 import io.ably.lib.objects.type.livecounter.DefaultLiveCounter
 import io.ably.lib.objects.type.livemap.DefaultLiveMap
+import io.ably.lib.types.ProtocolMessage
 
 internal val LiveMap.ObjectId get() = (this as DefaultLiveMap).objectId
 
 internal val LiveCounter.ObjectId get() = (this as DefaultLiveCounter).objectId
 
 internal val LiveObjects.State get() = (this as DefaultLiveObjects).state
+
+/**
+ * Server runs periodic garbage collection (GC) to remove orphaned objects and will send
+ * OBJECT_DELETE events for objects that are no longer referenced.
+ * So, we simulate the deletion of an object by sending a ProtocolMessage.
+ */
+internal fun LiveObjects.simulateObjectDelete(baseObject: BaseLiveObject) {
+  val defaultLiveObjects = this as DefaultLiveObjects
+  val existingSiteCode = baseObject.siteTimeserials.keys.first()
+  val existingSiteSerial = baseObject.siteTimeserials[existingSiteCode]!!
+
+  val deleteObjectProtoMsg = ProtocolMessage(ProtocolMessage.Action.`object`, channelName)
+  deleteObjectProtoMsg.state = arrayOf(ObjectMessage(
+    siteCode = existingSiteCode,
+    serial = existingSiteSerial + "1", // Increment serial to accept new operation
+    operation = ObjectOperation(
+      action = ObjectOperationAction.ObjectDelete,
+      objectId = baseObject.objectId,
+    )
+  ))
+  defaultLiveObjects.handle(deleteObjectProtoMsg)
+}

--- a/live-objects/src/test/kotlin/io/ably/lib/objects/unit/TestHelpers.kt
+++ b/live-objects/src/test/kotlin/io/ably/lib/objects/unit/TestHelpers.kt
@@ -57,6 +57,9 @@ internal fun ObjectsPool.size(): Int {
   return pool.size
 }
 
+internal val BaseLiveObject.TombstonedAt: Long?
+  get() = this.getPrivateField("tombstonedAt")
+
 /**
  * ======================================
  * START - DefaultLiveObjects dep mocks

--- a/live-objects/src/test/kotlin/io/ably/lib/objects/unit/objects/ObjectsManagerTest.kt
+++ b/live-objects/src/test/kotlin/io/ably/lib/objects/unit/objects/ObjectsManagerTest.kt
@@ -80,17 +80,17 @@ class ObjectsManagerTest {
     val testObject1 = objectsPool.get("map:testObject@1")
     assertNotNull(testObject1, "map:testObject@1 should exist in pool after sync")
     verify(exactly = 1) {
-      testObject1.applyObjectSync(any<ObjectState>())
+      testObject1.applyObjectSync(any<ObjectMessage>())
     }
     val testObject2 = objectsPool.get("counter:testObject@2")
     assertNotNull(testObject2, "counter:testObject@2 should exist in pool after sync")
     verify(exactly = 1) {
-      testObject2.applyObjectSync(any<ObjectState>())
+      testObject2.applyObjectSync(any<ObjectMessage>())
     }
     val testObject3 = objectsPool.get("map:testObject@3")
     assertNotNull(testObject3, "map:testObject@3 should exist in pool after sync")
     verify(exactly = 1) {
-      testObject3.applyObjectSync(any<ObjectState>())
+      testObject3.applyObjectSync(any<ObjectMessage>())
     }
   }
 

--- a/live-objects/src/test/kotlin/io/ably/lib/objects/unit/type/livecounter/DefaultLiveCounterTest.kt
+++ b/live-objects/src/test/kotlin/io/ably/lib/objects/unit/type/livecounter/DefaultLiveCounterTest.kt
@@ -26,7 +26,15 @@ class DefaultLiveCounterTest {
       siteTimeserials = mapOf("site3" to "serial3", "site4" to "serial4"),
       tombstone = false,
     )
-    liveCounter.applyObjectSync(objectState)
+    
+    val objectMessage = ObjectMessage(
+      id = "testId",
+      objectState = objectState,
+      serial = "serial1",
+      siteCode = "site1"
+    )
+    
+    liveCounter.applyObjectSync(objectMessage)
     assertEquals(mapOf("site3" to "serial3", "site4" to "serial4"), liveCounter.siteTimeserials) // RTLC6a
   }
 

--- a/live-objects/src/test/kotlin/io/ably/lib/objects/unit/type/livemap/DefaultLiveMapTest.kt
+++ b/live-objects/src/test/kotlin/io/ably/lib/objects/unit/type/livemap/DefaultLiveMapTest.kt
@@ -30,7 +30,15 @@ class DefaultLiveMapTest {
         semantics = MapSemantics.LWW,
       )
     )
-    liveMap.applyObjectSync(objectState)
+    
+    val objectMessage = ObjectMessage(
+      id = "testId",
+      objectState = objectState,
+      serial = "serial1",
+      siteCode = "site1"
+    )
+    
+    liveMap.applyObjectSync(objectMessage)
     assertEquals(mapOf("site3" to "serial3", "site4" to "serial4"), liveMap.siteTimeserials) // RTLM6a
   }
 

--- a/live-objects/src/test/kotlin/io/ably/lib/objects/unit/type/livemap/LiveMapManagerTest.kt
+++ b/live-objects/src/test/kotlin/io/ably/lib/objects/unit/type/livemap/LiveMapManagerTest.kt
@@ -194,7 +194,7 @@ class LiveMapManagerTest {
     liveMap.data["key1"] = LiveMapEntry(
       isTombstoned = false,
       timeserial = "1",
-      data = ObjectData(value = ObjectValue("oldValue"))
+      data = ObjectData(value = ObjectValue.String("oldValue"))
     )
 
     val expectedTimestamp = 1234567890L
@@ -204,13 +204,13 @@ class LiveMapManagerTest {
         semantics = MapSemantics.LWW,
         entries = mapOf(
           "key1" to ObjectMapEntry(
-            data = ObjectData(value = ObjectValue("newValue")),
+            data = ObjectData(value = ObjectValue.String("newValue")),
             timeserial = "serial1",
             tombstone = true,
             serialTimestamp = expectedTimestamp
           ),
           "key2" to ObjectMapEntry(
-            data = ObjectData(value = ObjectValue("value2")),
+            data = ObjectData(value = ObjectValue.String("value2")),
             timeserial = "serial2"
           )
         )
@@ -244,7 +244,7 @@ class LiveMapManagerTest {
     liveMap.data["key1"] = LiveMapEntry(
       isTombstoned = false,
       timeserial = "1",
-      data = ObjectData(value = ObjectValue("oldValue"))
+      data = ObjectData(value = ObjectValue.String("oldValue"))
     )
 
     val objectState = ObjectState(
@@ -253,13 +253,13 @@ class LiveMapManagerTest {
         semantics = MapSemantics.LWW,
         entries = mapOf(
           "key1" to ObjectMapEntry(
-            data = ObjectData(value = ObjectValue("newValue")),
+            data = ObjectData(value = ObjectValue.String("newValue")),
             timeserial = "serial1",
             tombstone = true,
             serialTimestamp = null // No timestamp provided
           ),
           "key2" to ObjectMapEntry(
-            data = ObjectData(value = ObjectValue("value2")),
+            data = ObjectData(value = ObjectValue.String("value2")),
             timeserial = "serial2"
           )
         )
@@ -330,7 +330,7 @@ class LiveMapManagerTest {
     liveMap.data["key1"] = LiveMapEntry(
       isTombstoned = false,
       timeserial = "serial1",
-      data = ObjectData(value = ObjectValue("existingValue"))
+      data = ObjectData(value = ObjectValue.String("existingValue"))
     )
 
     val expectedTimestamp = 1234567890L
@@ -341,13 +341,13 @@ class LiveMapManagerTest {
         semantics = MapSemantics.LWW,
         entries = mapOf(
           "key1" to ObjectMapEntry(
-            data = ObjectData(value = ObjectValue("createValue")),
+            data = ObjectData(value = ObjectValue.String("createValue")),
             timeserial = "serial2",
             tombstone = true,
             serialTimestamp = expectedTimestamp
           ),
           "key2" to ObjectMapEntry(
-            data = ObjectData(value = ObjectValue("newValue")),
+            data = ObjectData(value = ObjectValue.String("newValue")),
             timeserial = "serial3"
           ),
           "key3" to ObjectMapEntry(
@@ -436,7 +436,7 @@ class LiveMapManagerTest {
     liveMap.data["key1"] = LiveMapEntry(
       isTombstoned = false,
       timeserial = "serial1",
-      data = ObjectData(value = ObjectValue("value1"))
+      data = ObjectData(value = ObjectValue.String("value1"))
     )
 
     val operation = ObjectOperation(
@@ -1013,7 +1013,7 @@ class LiveMapManagerTest {
     liveMap.data["key1"] = LiveMapEntry(
       isTombstoned = false,
       timeserial = "1",
-      data = ObjectData(value = ObjectValue("oldValue"))
+      data = ObjectData(value = ObjectValue.String("oldValue"))
     )
 
     val expectedTimestamp = 1234567890L
@@ -1044,7 +1044,7 @@ class LiveMapManagerTest {
     liveMap.data["key1"] = LiveMapEntry(
       isTombstoned = false,
       timeserial = "1",
-      data = ObjectData(value = ObjectValue("oldValue"))
+      data = ObjectData(value = ObjectValue.String("oldValue"))
     )
 
     val objectState = ObjectState(


### PR DESCRIPTION
- Fixed #1117 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking and utilizing tombstone timestamps for live objects and map entries, allowing more precise recording of when objects are removed or marked inactive.
  * Serialization and deserialization now include an optional timestamp field for enhanced data consistency.
  * Introduced simulation of object deletion via protocol messages to better mimic server-side deletion events.

* **Bug Fixes**
  * Improved handling of tombstone operations to ensure correct timestamp assignment, defaulting to the current time if not provided.

* **Tests**
  * Expanded test coverage to verify correct handling and propagation of tombstone timestamps in live objects and map entries.
  * Updated existing tests to use enhanced message structures and added new tests for tombstone timestamp scenarios.
  * Enhanced integration tests to validate object deletion events and update notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->