### PR TITLE
chore[live-objects]: change `:java` dependency to `compileOnly` in `live-objects` module

### DIFF
--- a/live-objects/build.gradle.kts
+++ b/live-objects/build.gradle.kts
@@ -11,10 +11,11 @@ repositories {
 }
 
 dependencies {
-    implementation(project(":java"))
+    compileOnly(project(":java"))
     implementation(libs.bundles.common)
     implementation(libs.coroutine.core)
 
+    testImplementation(project(":java"))
     testImplementation(kotlin("test"))
     testImplementation(libs.bundles.kotlin.tests)
 }


### PR DESCRIPTION
live-objects can be used both with ably-java and ably-android, making dependency `compileOnly` we prevent adding specific module (ably-java or ably-android) to the classpath

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted an internal module to be compile-time only, reducing runtime dependencies and improving isolation.
  * Enabled that module on the test classpath so tests continue to run unchanged.
  * No changes to functionality, public APIs, or user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->