### PR TITLE
fix[live-objects]: replace unsafe array cast with `.map`

### DIFF
--- a/live-objects/src/main/kotlin/io/ably/lib/objects/serialization/DefaultSerialization.kt
+++ b/live-objects/src/main/kotlin/io/ably/lib/objects/serialization/DefaultSerialization.kt
@@ -1,5 +1,3 @@
-@file:Suppress("UNCHECKED_CAST")
-
 package io.ably.lib.objects.serialization
 
 import com.google.gson.*
@@ -23,7 +21,7 @@ internal class DefaultObjectsSerializer : ObjectsSerializer {
   }
 
   override fun writeMsgpackArray(objects: Array<out Any>, packer: MessagePacker) {
-    val objectMessages: Array<ObjectMessage> = objects as Array<ObjectMessage>
+    val objectMessages = objects.map { it as ObjectMessage }
     packer.packArrayHeader(objectMessages.size)
     objectMessages.forEach { it.writeMsgpack(packer) }
   }
@@ -36,7 +34,7 @@ internal class DefaultObjectsSerializer : ObjectsSerializer {
   }
 
   override fun asJsonArray(objects: Array<out Any>): JsonArray {
-    val objectMessages: Array<ObjectMessage> = objects as Array<ObjectMessage>
+    val objectMessages = objects.map { it as ObjectMessage }
     val jsonArray = JsonArray()
     for (objectMessage in objectMessages) {
       jsonArray.add(objectMessage.toJsonObject())


### PR DESCRIPTION
`Array<Object>` can't be cast to `Array<ObjectMessages>` even if every element is an instance of `ObjectMessages`, so it's safer to use `map`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved serialization safety by replacing unchecked array casts with per-element casting and safe iteration.
  * Removed suppression of unchecked-cast warnings for clearer type safety.
  * No changes to public APIs or user-visible behavior; improves internal robustness and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->