### PR TITLE
fix: add missing ProGuard rules for LiveObjects plugin

### DIFF
--- a/android/proguard.txt
+++ b/android/proguard.txt
@@ -1,5 +1,9 @@
 -keep public class io.ably.lib.transport.WebSocketTransport$Factory {*;}
 -keep class io.ably.lib.types.** {*;}
+-keep class io.ably.lib.objects.*ObjectsPlugin {*;}
+-keep class io.ably.lib.objects.serialization.*Serializer {*;}
+-keep class io.ably.lib.objects.ObjectsJsonSerializer {*;}
+
 -keep class org.msgpack.core.** {*;}
 -keepclasseswithmembers class io.ably.lib.rest.Auth** {*;}
 -keep class com.google.gson.** {*;}


### PR DESCRIPTION
Add rules for Gson serializers and reflection used during plugin initialization.