### PR TITLE
[ECO-5553] Fixed omitted tests responsible for handling vcdiff encoding

### DIFF
--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -174,7 +174,7 @@ public class RealtimeChannelTest extends ParameterizedTest {
             channel.attach();
             (new ChannelWaiter(channel)).waitFor(ChannelState.attached);
             assertEquals("Verify attached state reached", ChannelState.attached, channel.state);
-            assertEquals("Verify channel params", channel.getParams(), options.params);
+            assertEquals("Verify channel params", options.params, channel.getParams());
             assertArrayEquals("Verify channel modes", new ChannelMode[] { ChannelMode.subscribe }, channel.getModes());
         } catch (AblyException e) {
             e.printStackTrace();
@@ -208,7 +208,7 @@ public class RealtimeChannelTest extends ParameterizedTest {
             channel.attach();
             (new ChannelWaiter(channel)).waitFor(ChannelState.attached);
             assertEquals("Verify attached state reached", ChannelState.attached, channel.state);
-            assertEquals("Verify channel params", channel.getParams(), options.params);
+            assertEquals("Verify channel params", options.params, channel.getParams());
             assertArrayEquals("Verify channel modes", new ChannelMode[] { ChannelMode.subscribe }, channel.getModes());
         } catch (AblyException e) {
             e.printStackTrace();
@@ -285,7 +285,10 @@ public class RealtimeChannelTest extends ParameterizedTest {
             (new ChannelWaiter(channel)).waitFor(ChannelState.attached);
             assertEquals("Verify attached state reached", ChannelState.attached, channel.state);
             assertEquals("Verify channel params", channel.getParams(), options.params);
-            assertArrayEquals("Verify channel modes", new ChannelMode[] { ChannelMode.subscribe, ChannelMode.presence }, channel.getModes());
+            // modes in params overrides individual modes in options
+            assertThat("Verify channel modes", Arrays.asList(channel.getModes()),
+                Matchers.containsInAnyOrder(ChannelMode.presence, ChannelMode.subscribe));
+
         } catch (AblyException e) {
             e.printStackTrace();
             fail("init0: Unexpected exception instantiating library");

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeChannelTest.java
@@ -2561,7 +2561,7 @@ public class RealtimeChannelTest extends ParameterizedTest {
             new ConnectionWaiter(ably.connection).waitFor(ConnectionState.closing);
             new ConnectionWaiter(ably.connection).waitFor(ConnectionState.connected);
 
-            assertEquals(List.of(ConnectionState.closing, ConnectionState.connecting, ConnectionState.connected), observedConnectionStates);
+            assertEquals(Arrays.asList(ConnectionState.closing, ConnectionState.connecting, ConnectionState.connected), observedConnectionStates);
             assertEquals(ChannelState.initialized, channel.state);
 
             channel.attach();
@@ -2569,7 +2569,7 @@ public class RealtimeChannelTest extends ParameterizedTest {
 
             assertNull(channel.reason);
             assertEquals(0, ably.connection.connectionManager.msgSerial);
-            assertEquals(List.of(ChannelState.detached, ChannelState.initialized, ChannelState.attaching, ChannelState.attached), observedChannelStates);
+            assertEquals(Arrays.asList(ChannelState.detached, ChannelState.initialized, ChannelState.attaching, ChannelState.attached), observedChannelStates);
         }
     }
 

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeDeltaDecoderTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeDeltaDecoderTest.java
@@ -11,6 +11,7 @@ import io.ably.lib.test.common.ParameterizedTest;
 import io.ably.lib.transport.ConnectionManager;
 import io.ably.lib.transport.ITransport;
 import io.ably.lib.transport.WebSocketTransport;
+import io.ably.lib.types.ChannelOptions;
 import io.ably.lib.types.ClientOptions;
 import io.ably.lib.types.Message;
 import io.ably.lib.types.MessageExtras;
@@ -20,6 +21,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
+import java.util.Map;
 import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
@@ -51,6 +53,8 @@ public class RealtimeDeltaDecoderTest extends ParameterizedTest {
             MessageWaiter messageWaiter = new MessageWaiter(channel);
 
             (new ChannelWaiter(channel)).waitFor(ChannelState.attached);
+
+            assertEquals("Verify channel params", Map.of("delta", "vcdiff"), channel.getParams());
 
             for (int i = 0; i < testData.length; i++) {
                 channel.publish(Integer.toString(i), testData[i]);
@@ -90,13 +94,17 @@ public class RealtimeDeltaDecoderTest extends ParameterizedTest {
             opts.transportFactory = websocketFactory;
             ably = new AblyRealtime(opts);
 
-            /* create a channel */
-            final Channel channel = ably.channels.get("[?delta=vcdiff]" + testName);
+            ChannelOptions options = new ChannelOptions();
+            options.params = Map.of("delta", "vcdiff");
+            /* create a channel with channelOptions set to vcdiff*/
+            final Channel channel = ably.channels.get(testName, options);
 
             /* attach */
             channel.attach();
             (new ChannelWaiter(channel)).waitFor(ChannelState.attached);
             assertEquals("Verify attached state reached", channel.state, ChannelState.attached);
+
+            assertEquals("Verify channel params", Map.of("delta", "vcdiff"), channel.getParams());
 
             /* subscribe */
             MessageWaiter messageWaiter = new MessageWaiter(channel);

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeDeltaDecoderTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeDeltaDecoderTest.java
@@ -21,7 +21,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
-import java.util.Map;
+import java.util.Collections;
 import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
@@ -54,7 +54,7 @@ public class RealtimeDeltaDecoderTest extends ParameterizedTest {
 
             (new ChannelWaiter(channel)).waitFor(ChannelState.attached);
 
-            assertEquals("Verify channel params", Map.of("delta", "vcdiff"), channel.getParams());
+            assertEquals("Verify channel params", Collections.singletonMap("delta", "vcdiff"), channel.getParams());
 
             for (int i = 0; i < testData.length; i++) {
                 channel.publish(Integer.toString(i), testData[i]);
@@ -95,7 +95,7 @@ public class RealtimeDeltaDecoderTest extends ParameterizedTest {
             ably = new AblyRealtime(opts);
 
             ChannelOptions options = new ChannelOptions();
-            options.params = Map.of("delta", "vcdiff");
+            options.params = Collections.singletonMap("delta", "vcdiff");
             /* create a channel with channelOptions set to vcdiff*/
             final Channel channel = ably.channels.get(testName, options);
 
@@ -104,7 +104,7 @@ public class RealtimeDeltaDecoderTest extends ParameterizedTest {
             (new ChannelWaiter(channel)).waitFor(ChannelState.attached);
             assertEquals("Verify attached state reached", channel.state, ChannelState.attached);
 
-            assertEquals("Verify channel params", Map.of("delta", "vcdiff"), channel.getParams());
+            assertEquals("Verify channel params", Collections.singletonMap("delta", "vcdiff"), channel.getParams());
 
             /* subscribe */
             MessageWaiter messageWaiter = new MessageWaiter(channel);

--- a/lib/src/test/java/io/ably/lib/test/rest/RestPresenceTest.java
+++ b/lib/src/test/java/io/ably/lib/test/rest/RestPresenceTest.java
@@ -87,7 +87,7 @@ public class RestPresenceTest extends ParameterizedTest {
      * Get presence history data in the forward direction and check order
      * DISABLED: See issue https://github.com/ably/ably-java/issues/159
      */
-    /*@Test*/
+    @Test
     public void rest_presencehistory_order_f() {
         String channelName = "persisted:restpresence_persisted";
         /* get channel */
@@ -114,7 +114,7 @@ public class RestPresenceTest extends ParameterizedTest {
      * Get presence history data in the backwards direction using text protocol and check order
      * DISABLED: See issue https://github.com/ably/ably-java/issues/159
      */
-    /*@Test*/
+    @Test
     public void rest_presencehistory_order_b() {
         String channelName = "persisted:restpresence_persisted";
         /* get channel */
@@ -141,7 +141,7 @@ public class RestPresenceTest extends ParameterizedTest {
      * Get limited presence history data in the forward direction using text protocol and check order
      * DISABLED: See issue https://github.com/ably/ably-java/issues/159
      */
-    /*@Test*/
+    @Test
     public void rest_presencehistory_limit_f() {
         String channelName = "persisted:restpresence_persisted";
         /* get channel */
@@ -168,7 +168,7 @@ public class RestPresenceTest extends ParameterizedTest {
      * Get limited presence history data in the backwards direction using text protocol and check order
      * DISABLED: See issue https://github.com/ably/ably-java/issues/159
      */
-    /*@Test*/
+    @Test
     public void rest_presencehistory_limit_b() {
         String channelName = "persisted:restpresence_persisted";
         /* get channel */
@@ -195,7 +195,7 @@ public class RestPresenceTest extends ParameterizedTest {
      * Get paginated presence history data in the forward direction using text protocol
      * DISABLED: See issue https://github.com/ably/ably-java/issues/159
      */
-    /*@Test*/
+    @Test
     public void rest_presencehistory_paginate_f() {
         /* get channel */
         String channelName = "persisted:restpresence_persisted";
@@ -263,7 +263,7 @@ public class RestPresenceTest extends ParameterizedTest {
      * Get paginated presence history data in the backwards direction using text protocol
      * DISABLED: See issue https://github.com/ably/ably-java/issues/159
      */
-    /*@Test*/
+    @Test
     public void rest_presencehistory_paginate_text_b() {
         /* get channel */
         String channelName = "persisted:restpresence_persisted";


### PR DESCRIPTION
- Fixed #1160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reactivated multiple previously disabled tests for realtime channels, delta decoding, and REST presence history, improving coverage and reliability.
  * Modernized assertions and exception handling; channel mode checks are now order-insensitive.
  * Added verifications for channel parameters (e.g., delta) after attach and simplified test setup via options.
  * One internal test helper signature was updated; no user-facing runtime behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->