### PR TITLE
feat: add support for clipped client ID lists and enhance aggregation handling

### DIFF
--- a/lib/src/main/java/io/ably/lib/types/SummaryClientIdCounts.java
+++ b/lib/src/main/java/io/ably/lib/types/SummaryClientIdCounts.java
@@ -2,12 +2,45 @@ package io.ably.lib.types;
 
 import java.util.Map;
 
+/**
+ * The per-name value for the multiple.v1 aggregation method.
+ */
 public class SummaryClientIdCounts {
+    /**
+     * The sum of the counts from all clients who have published an annotation with this name
+     */
     public final int total; // TM7d1a
+    /**
+     * A list of the clientIds of all clients who have published an annotation with this
+     * name, and the count each of them have contributed.
+     */
     public final Map<String, Integer> clientIds; // TM7d1b
+    /**
+     * The sum of the counts from all unidentified clients who have published an annotation with this
+     * name, and so who are not included in the clientIds list
+     */
+    public final int totalUnidentified; // TM7d1d
+    /**
+     * Whether the list of clientIds has been clipped due to exceeding the maximum number of
+     * clients.
+     */
+    public final boolean clipped; // TM7d1c
+    /**
+     * The total number of distinct clientIds in the map (equal to length of map if clipped is false).
+     */
+    public final int totalClientIds; // TM7d1e
 
-    public SummaryClientIdCounts(int total, Map<String, Integer> clientIds) {
+    public SummaryClientIdCounts(
+        int total,
+        Map<String, Integer> clientIds,
+        int totalUnidentified,
+        boolean clipped,
+        int totalClientIds
+    ) {
         this.total = total;
         this.clientIds = clientIds;
+        this.totalUnidentified = totalUnidentified;
+        this.clipped = clipped;
+        this.totalClientIds = totalClientIds;
     }
 }

--- a/lib/src/main/java/io/ably/lib/types/SummaryClientIdList.java
+++ b/lib/src/main/java/io/ably/lib/types/SummaryClientIdList.java
@@ -2,12 +2,29 @@ package io.ably.lib.types;
 
 import java.util.List;
 
+/**
+ * The summary entry for aggregated annotations that use the flag.v1
+ * aggregation method; also the per-name value for some other aggregation methods.
+ */
 public class SummaryClientIdList {
+    /**
+     * The sum of the counts from all clients who have published an annotation with this name
+     */
     public final int total; // TM7c1a
-    public final List<String> clientIds; // TM7c1b
+    /**
+     * A list of the clientIds of all clients who have published an annotation with this name (or
+     * type, depending on context).
+     */
+    public final List<String> clientIds; // TM7
+    /**
+     * Whether the list of clientIds has been clipped due to exceeding the maximum number of
+     * clients.
+     */
+    public final boolean clipped; // TM7c1c
 
-    public SummaryClientIdList(int total, List<String> clientIds) {
+    public SummaryClientIdList(int total, List<String> clientIds, boolean clipped) {
         this.total = total;
         this.clientIds = clientIds;
+        this.clipped = clipped;
     }
 }

--- a/lib/src/test/java/io/ably/lib/types/SummaryTest.java
+++ b/lib/src/test/java/io/ably/lib/types/SummaryTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -126,6 +127,25 @@ public class SummaryTest {
         assertTrue(result.clientIds.contains("client1"));
         assertTrue(result.clientIds.contains("client2"));
         assertTrue(result.clientIds.contains("client3"));
+        assertFalse(result.clipped);
+    }
+
+    @Test
+    public void testAsSummaryFlagV1_clippedTrue() {
+        JsonObject entryValue = new JsonObject();
+        entryValue.addProperty("total", 100);
+        JsonArray clientIds = new JsonArray();
+        clientIds.add("client1");
+        entryValue.add("clientIds", clientIds);
+        entryValue.addProperty("clipped", true);
+
+        SummaryClientIdList result = Summary.asSummaryFlagV1(entryValue);
+
+        assertNotNull(result);
+        assertEquals(100, result.total);
+        assertEquals(1, result.clientIds.size());
+        assertTrue(result.clientIds.contains("client1"));
+        assertTrue(result.clipped);
     }
 
     @Test
@@ -196,6 +216,9 @@ public class SummaryTest {
         assertEquals(2, summaryA.clientIds.size());
         assertEquals(3, (int) summaryA.clientIds.get("clientA"));
         assertEquals(2, (int) summaryA.clientIds.get("clientB"));
+        assertEquals(0, summaryA.totalUnidentified);
+        assertEquals(5, summaryA.totalClientIds);
+        assertFalse(summaryA.clipped);
 
         SummaryClientIdCounts summaryB = result.get("👍️️️️️️");
         assertNotNull(summaryB);
@@ -203,6 +226,30 @@ public class SummaryTest {
         assertEquals(2, summaryB.clientIds.size());
         assertEquals(1, (int) summaryB.clientIds.get("clientX"));
         assertEquals(1, (int) summaryB.clientIds.get("clientY"));
+        assertEquals(0, summaryB.totalUnidentified);
+        assertEquals(2, summaryB.totalClientIds);
+        assertFalse(summaryA.clipped);
+    }
+
+    @Test
+    public void testAsSummaryMultipleV1_ClippedTrue() {
+        JsonObject jsonObject = new JsonObject();
+
+        JsonObject entryValue1 = new JsonObject();
+        entryValue1.addProperty("total", 5);
+        JsonObject clientIds1 = new JsonObject();
+        clientIds1.addProperty("clientA", 1);
+        entryValue1.add("clientIds", clientIds1);
+        entryValue1.addProperty("clipped", true);
+        entryValue1.addProperty("totalClientIds", 1);
+        jsonObject.add("😄️️️", entryValue1);
+
+        Map<String, SummaryClientIdCounts> result = Summary.asSummaryMultipleV1(jsonObject);
+        SummaryClientIdCounts summary = result.get("😄️️️");
+        assertEquals(5, summary.total);
+        assertEquals(1, summary.totalClientIds);
+        assertEquals(0, summary.totalUnidentified);
+        assertTrue(summary.clipped);
     }
 
     @Test


### PR DESCRIPTION
Introduce `clipped` field in `SummaryClientIdList` and `SummaryClientIdCounts` for managing truncated client ID lists. Update relevant methods to read this field and handle additional aggregation metadata (`totalClientIds`, `totalUnidentified`). Add comprehensive test cases for new functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Summary responses now include clipped status for clientId lists and additional totals: totalClientIds and totalUnidentified.
  - More robust handling of optional/missing fields in summary data.
  - Public summary models updated to expose these new fields; constructors adjusted accordingly.

- Documentation
  - Expanded model documentation to explain new fields and aggregation semantics.

- Tests
  - Added tests covering clipped behavior and validation of totalClientIds and totalUnidentified across single and multiple-entry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->