### PR TITLE
[ECO-5514] fix: improve WebSocket transport lifecycle and activity management

### DIFF
--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -857,6 +857,16 @@ public class ConnectionManager implements ConnectListener {
         requestState(null, state);
     }
 
+    /**
+     * Determines if the given WebSocketTransport instance is the currently active transport.
+     *
+     * @param transport the WebSocketTransport instance to check against the active transport
+     * @return true if the provided transport is the currently active transport, false otherwise
+     */
+    boolean isActiveTransport(WebSocketTransport transport) {
+        return transport == this.transport;
+    }
+
     private synchronized void requestState(ITransport transport, StateIndication stateIndication) {
         Log.v(TAG, "requestState(): requesting " + stateIndication.state + "; id = " + connection.id);
         addAction(new AsynchronousStateChangeAction(transport, stateIndication));

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -2020,7 +2020,7 @@ public class ConnectionManager implements ConnectListener {
     private ErrorInfo stateError;
     private ConnectParams pendingConnect;
     private boolean suppressRetry; /* for tests only; modified via reflection */
-    private ITransport transport;
+    private volatile ITransport transport;
     private long suspendTime;
     public long msgSerial;
     private long lastActivity;

--- a/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
+++ b/lib/src/main/java/io/ably/lib/transport/ConnectionManager.java
@@ -31,6 +31,7 @@ import io.ably.lib.types.AblyException;
 import io.ably.lib.types.ClientOptions;
 import io.ably.lib.types.ConnectionDetails;
 import io.ably.lib.types.ErrorInfo;
+import io.ably.lib.types.Param;
 import io.ably.lib.types.ProtocolMessage;
 import io.ably.lib.types.ProtocolSerializer;
 import io.ably.lib.util.Log;
@@ -855,6 +856,13 @@ public class ConnectionManager implements ConnectListener {
 
     public void requestState(StateIndication state) {
         requestState(null, state);
+    }
+
+    /**
+     * Get query params representing the current authentication method and credentials.
+     */
+    Param[] getAuthParams() throws AblyException {
+        return ably.auth.getAuthParams();
     }
 
     /**

--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -252,8 +252,8 @@ public class WebSocketTransport implements ITransport {
          ***************************/
 
         private final Timer timer = new Timer();
-        private TimerTask activityTimerTask = null;
-        private long lastActivityTime;
+        private volatile TimerTask activityTimerTask = null;
+        private volatile long lastActivityTime;
 
         /**
          * Monitor for activity timer events
@@ -387,6 +387,9 @@ public class WebSocketTransport implements ITransport {
                 Log.v(TAG, "checkActivity: infinite timeout");
                 return;
             }
+
+            // prevent going to the synchronized block if the timer is active
+            if (activityTimerTask != null) return;
 
             synchronized (activityTimerMonitor) {
                 // Check if timer already running

--- a/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
+++ b/lib/src/main/java/io/ably/lib/transport/WebSocketTransport.java
@@ -109,7 +109,7 @@ public class WebSocketTransport implements ITransport {
             boolean isTls = params.options.tls;
             String wsScheme = isTls ? "wss://" : "ws://";
             wsUri = wsScheme + params.host + ':' + params.port + "/";
-            Param[] authParams = connectionManager.ably.auth.getAuthParams();
+            Param[] authParams = connectionManager.getAuthParams();
             Param[] connectParams = params.getConnectParams(authParams);
             if (connectParams.length > 0)
                 wsUri = HttpUtils.encodeParams(wsUri, connectParams);
@@ -415,7 +415,7 @@ public class WebSocketTransport implements ITransport {
             try {
                 timer.schedule(task, delay);
             } catch (IllegalStateException ise) {
-                Log.w(TAG, "Timer has already been canceled", ise);
+                Log.w(TAG, "Timer has already has been canceled", ise);
             }
         }
 
@@ -439,7 +439,7 @@ public class WebSocketTransport implements ITransport {
         }
 
         private long getActivityTimeout() {
-            return connectionManager.maxIdleInterval + connectionManager.ably.options.realtimeRequestTimeout;
+            return connectionManager.maxIdleInterval + params.options.realtimeRequestTimeout;
         }
     }
 

--- a/lib/src/test/java/io/ably/lib/test/common/Helpers.java
+++ b/lib/src/test/java/io/ably/lib/test/common/Helpers.java
@@ -969,6 +969,16 @@ public class Helpers {
         return (one == null) ? (two == null) : one.equals(two);
     }
 
+    public static void setPrivateField(Object object, String fieldName, Object value) {
+        try {
+            Field connectionStateField = object.getClass().getDeclaredField(fieldName);
+            connectionStateField.setAccessible(true);
+            connectionStateField.set(object, value);
+        } catch (Exception e) {
+            fail("Failed accessing " + fieldName + " with error " + e);
+        }
+    }
+
     public static class RawHttpRequest {
         public String id;
         public URL url;

--- a/lib/src/test/java/io/ably/lib/transport/WebSocketTransportTest.java
+++ b/lib/src/test/java/io/ably/lib/transport/WebSocketTransportTest.java
@@ -1,0 +1,153 @@
+package io.ably.lib.transport;
+
+import io.ably.lib.network.WebSocketClient;
+import io.ably.lib.network.WebSocketEngine;
+import io.ably.lib.network.WebSocketListener;
+import io.ably.lib.test.common.Helpers;
+import io.ably.lib.test.util.EmptyPlatformAgentProvider;
+import io.ably.lib.transport.ITransport.TransportParams;
+import io.ably.lib.types.ClientOptions;
+import io.ably.lib.types.Param;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for WebSocketTransport, specifically testing activity timer behavior
+ * when WebSocket close operations get stuck or fail to trigger onClose handlers.
+ */
+public class WebSocketTransportTest {
+
+    private ConnectionManager mockConnectionManager;
+
+    private WebSocketEngine mockEngine;
+
+    private WebSocketTransport transport;
+
+    private WebSocketClient mockWebSocketClient;
+
+    private TransportParams transportParams;
+
+    @Before
+    public void setUp() throws Exception {
+        mockConnectionManager = mock(ConnectionManager.class);
+        mockEngine = mock(WebSocketEngine.class);
+        mockWebSocketClient = mock(WebSocketClient.class);
+        when(mockEngine.isPingListenerSupported()).thenReturn(true);
+        when(mockEngine.create(any(), any())).thenReturn(mockWebSocketClient);
+        when(mockConnectionManager.getAuthParams()).thenReturn(new Param[]{});
+
+        mockConnectionManager.maxIdleInterval = 10;
+
+        // Setup transport params
+        transportParams = new TransportParams(new ClientOptions(), new EmptyPlatformAgentProvider());
+        transportParams.host = "realtime.ably.io";
+        transportParams.port = 443;
+        transportParams.options.realtimeRequestTimeout = 10;
+    }
+
+    private WebSocketTransport createWebSocketTransport() {
+        WebSocketTransport transport = new WebSocketTransport(transportParams, mockConnectionManager);
+        Helpers.setPrivateField(transport, "webSocketEngine", mockEngine);
+        return transport;
+    }
+
+    @Test
+    public void throwExceptionsIfConnectCalledTwice() {
+        final WebSocketTransport transport = createWebSocketTransport();
+        ITransport.ConnectListener connectListener = mock(ITransport.ConnectListener.class);
+        transport.connect(connectListener);
+        assertThrows(IllegalStateException.class, () ->
+                transport.connect(connectListener)
+        );
+    }
+
+    @Test
+    public void shouldCallCancelIfNotClosedGracefully() {
+        AtomicReference<WebSocketListener> webSocketListenerRef = new AtomicReference<>();
+
+        when(mockEngine.create(any(), any())).thenAnswer(invocation -> {
+            webSocketListenerRef.set(invocation.getArgumentAt(1, WebSocketListener.class));
+            return mockWebSocketClient;
+        });
+
+        doAnswer(invocation -> {
+            webSocketListenerRef.get().onClose(
+                    invocation.getArgumentAt(0, Integer.class),
+                    invocation.getArgumentAt(1, String.class)
+            );
+            return null;
+        }).when(mockWebSocketClient).cancel(anyInt(), anyString());
+
+        final WebSocketTransport transport = createWebSocketTransport();
+        ITransport.ConnectListener connectListener = mock(ITransport.ConnectListener.class);
+        transport.connect(connectListener);
+        transport.close();
+        // check that we tried to close gracefully
+        verify(mockWebSocketClient).close();
+        // check that we closed forcibly at the end
+        verify(mockWebSocketClient, timeout(1_000)).cancel(eq(1006), anyString());
+        // verify that we call listener at the end
+        verify(connectListener).onTransportUnavailable(eq(transport), any());
+    }
+
+    /**
+     * `onClose` can be called twice, e.g. from activity timer force close and from manual `close()`
+     * It shouldn't result in any exceptions
+     */
+    @Test
+    public void shouldNotThrowExceptionIfSeveralCloseEventsHappened() {
+        AtomicReference<WebSocketListener> listenerRef = new AtomicReference<>();
+
+        when(mockEngine.create(any(), any())).thenAnswer(invocation -> {
+            listenerRef.set(invocation.getArgumentAt(1, WebSocketListener.class));
+            return mockWebSocketClient;
+        });
+
+
+        final WebSocketTransport transport = createWebSocketTransport();
+        ITransport.ConnectListener connectListener = mock(ITransport.ConnectListener.class);
+        transport.connect(connectListener);
+
+        listenerRef.get().onClose(1000, "OK");
+        listenerRef.get().onClose(1006, "Abnormal close");
+
+        verify(connectListener, times(2)).onTransportUnavailable(eq(transport), any());
+    }
+
+    /**
+     * Calling `close()` on transport triggers the activity timer.
+     * Test checks that if it has been disposed it won't do anything.
+     */
+    @Test
+    public void shouldNotThrowExceptionIfCloseCalledOnAlreadyClosedTransport() {
+        AtomicReference<WebSocketListener> listenerRef = new AtomicReference<>();
+
+        when(mockEngine.create(any(), any())).thenAnswer(invocation -> {
+            listenerRef.set(invocation.getArgumentAt(1, WebSocketListener.class));
+            return mockWebSocketClient;
+        });
+
+
+        final WebSocketTransport transport = createWebSocketTransport();
+        ITransport.ConnectListener connectListener = mock(ITransport.ConnectListener.class);
+        transport.connect(connectListener);
+
+        listenerRef.get().onClose(1006, "Abnormal close");
+        transport.close();
+        verify(connectListener, timeout(1_000)).onTransportUnavailable(eq(transport), any());
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/ably/ably-java/issues/1144

* Force-cancel hanging socket connections
* Replace synchronized blocks with fine-grained locking using `activityTimerMonitor` to avoid deadlocks.
* Refactor `close()` for safer access to shared fields and handle uninitialized cases gracefully.
* Simplify activity timer logic and ensure consistent disposal of `WebSocketClient` and `WebSocketHandler`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fewer deadlocks/races during connect/close; improved cleanup and warnings for already-closed or uninitialized connections.
  * More robust activity/idle handling to prevent stray timers and improper cancels.

* **Refactor**
  * Enforced single-connect semantics and reduced synchronization hotspots for more reliable lifecycle and activity handling.

* **New Features**
  * Added ability to retrieve auth parameters and check whether a transport is active.

* **Tests**
  * Added unit tests for connect/close and activity-timer scenarios and a test helper to set private fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->