### PR TITLE
[ECO-5613] fix: resolve presence re-entry on channel re-attach

### DIFF
--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -461,13 +461,13 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
         if(state == ChannelState.attached) {
             Log.v(TAG, String.format(Locale.ROOT, "Server initiated attach for channel %s", name));
             if (!message.hasFlag(Flag.resumed)) { // RTL12
-                presence.onAttached(message.hasFlag(Flag.has_presence));
                 emitUpdate(message.error, false);
+                presence.onAttached(message.hasFlag(Flag.has_presence));
             }
         }
         else {
-            presence.onAttached(message.hasFlag(Flag.has_presence));
             setState(ChannelState.attached, message.error, message.hasFlag(Flag.resumed));
+            presence.onAttached(message.hasFlag(Flag.has_presence));
         }
     }
 

--- a/lib/src/main/java/io/ably/lib/realtime/Presence.java
+++ b/lib/src/main/java/io/ably/lib/realtime/Presence.java
@@ -755,9 +755,11 @@ public class Presence {
             case initialized:
                 channel.attach();
             case attaching:
+                Log.v(TAG, "updatePresence(); put message in pending presence queue");
                 pendingPresence.add(new QueuedPresence(msg, listener));
                 break;
             case attached:
+                Log.v(TAG, "updatePresence(); send message to connection manager");
                 ProtocolMessage message = new ProtocolMessage(ProtocolMessage.Action.presence, channel.name);
                 message.presence = new PresenceMessage[] { msg };
                 ConnectionManager connectionManager = ably.connection.connectionManager;
@@ -938,7 +940,7 @@ public class Presence {
                     @Override
                     public void onError(ErrorInfo reason) {
                         String errorString = String.format(Locale.ROOT, "Cannot automatically re-enter %s on channel %s (%s)",
-                            item.clientId, channel.name, reason.message);
+                            item.clientId, channel.name, reason == null ? "" : reason.message);
                         Log.e(TAG, errorString);
                         channel.emitUpdate(new ErrorInfo(errorString, 91004), true);
                     }

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeResumeTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeResumeTest.java
@@ -28,6 +28,8 @@ import org.junit.rules.Timeout;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -988,15 +990,21 @@ public class RealtimeResumeTest extends ParameterizedTest {
                 System.out.println("presence_resume_test: sent message with client: "+presenceMessage.clientId +" " +
                     " action:"+presenceMessage.action);
             }
-            assertEquals("Second round of messages has incorrect size", 6, transport.getSentPresenceMessages().size());
+
+            Set<String> sentClientIds = transport.getSentPresenceMessages().stream()
+                .map(it -> it.clientId).collect(Collectors.toSet());
+
+            assertEquals("Second round of messages has incorrect size",
+                9,
+                sentClientIds.size()
+            );
             //make sure they were sent with correct client ids
             final Map<String,PresenceMessage> sentPresenceMap = new HashMap<>();
             for (PresenceMessage presenceMessage: transport.getSentPresenceMessages()){
                 sentPresenceMap.put(presenceMessage.clientId, presenceMessage);
             }
-
-            for (int i = 3; i < 9; i++) {
-                assertTrue("Client id isn't there:" + clients[i], sentPresenceMap.containsKey(clients[i]));
+            for (String client: clients) {
+                assertTrue("Client id isn't there:" + client, sentPresenceMap.containsKey(client));
             }
         }
     }


### PR DESCRIPTION
- Ensure presence update messages are correctly sent.
- Add logging for presence updates in `Presence`, improving debuggability.
- Update presence re-entry tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Presence callbacks now run after state updates and update emissions to ensure consistent attach/resume behavior.

* **Improvements**
  * Added diagnostic logging to indicate when presence messages are queued vs sent.

* **Tests**
  * Reworked suspend/resume presence tests: restored full lifecycle handling, removed ignored tests, strengthened presence and leave validations, and updated expected presence message counts and client coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->