### PR TITLE
fix: reconnect breaks async requests

### DIFF
--- a/lib/src/main/java/io/ably/lib/http/Http.java
+++ b/lib/src/main/java/io/ably/lib/http/Http.java
@@ -21,6 +21,10 @@ public class Http implements AutoCloseable {
         asyncHttp.close();
     }
 
+    public void connect() {
+        asyncHttp.connect();
+    }
+
     /**
      * [Internal Method]
      * <p>

--- a/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
+++ b/lib/src/main/java/io/ably/lib/realtime/AblyRealtime.java
@@ -96,7 +96,9 @@ public class AblyRealtime extends AblyRest {
      * <p>
      * Spec: RTN11
      */
+    @Override
     public void connect() {
+        super.connect(); // resets thread pool for async requests
         connection.connect();
     }
 

--- a/lib/src/main/java/io/ably/lib/rest/AblyBase.java
+++ b/lib/src/main/java/io/ably/lib/rest/AblyBase.java
@@ -139,6 +139,13 @@ public abstract class AblyBase implements AutoCloseable {
     }
 
     /**
+     * Internal method, used for `RealtimeClient` only
+     */
+    protected void connect() {
+        http.connect();
+    }
+
+    /**
      * A collection of Channels associated with an Ably instance.
      */
     public interface Channels extends ReadOnlyMap<String, Channel> {


### PR DESCRIPTION
Resolves https://github.com/ably/ably-java/issues/1175

Introduced `connect()` in `AblyBase` to reset thread pools when `AblyRealtime.connect()` is called after `close()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit connect() capability allowing direct initiation and recovery of networking components so clients can reconnect after closure.

* **Tests**
  * Added a test that closes a realtime client, reopens it, performs an async time request, and verifies the server time is reasonable, validating reconnection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->