### PR TITLE
Release/1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [1.7.0](https://github.com/ably/ably-java/tree/v1.7.0)
+
+[Full Changelog](https://github.com/ably/ably-java/compare/v1.6.1...v1.7.0)
+
+### What's Changed
+
+- Introduce version 6 of the Ably protocol; add operation-specific payload fields to `ObjectOperation` and typed value fields to `ObjectData` [#1195](https://github.com/ably/ably-java/pull/1195) 
+- Add support for partial sync of LiveObjects state [#1197](https://github.com/ably/ably-java/pull/1197) 
+- Introduce ACK-based local application of LiveObjects ops [#1194](https://github.com/ably/ably-java/pull/1194)
+- Add support for server-initiated MAP_CLEAR object operation [#1198](https://github.com/ably/ably-java/pull/1198)
+
 ## [1.6.1](https://github.com/ably/ably-java/tree/v1.6.1)
 
 [Full Changelog](https://github.com/ably/ably-java/compare/v1.6.0...v1.6.1)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,7 +235,7 @@ You may wish to make changes to Ably Java or Ably Android, and test it immediate
 - Open the directory printed from the output of that command. Inside that folder, get the `ably-android-x.y.z.aar`, and place it your Android project's `libs/` directory. Create this directory if it doesn't exist.
 - Add an `implementation` dependency on the `.aar`:
 ```groovy
-implementation files('libs/ably-android-1.6.1.aar')
+implementation files('libs/ably-android-1.7.0.aar')
 ```
 - Add the `implementation` (not `testImplementation`) dependencies found in `dependencies.gradle` to your project. This is because the `.aar` does not contain dependencies.
 - Build/run your application.

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ The Java SDK is available as a [Maven dependency](https://mvnrepository.com/arti
 <dependency>
     <groupId>io.ably</groupId>
     <artifactId>ably-java</artifactId>
-    <version>1.6.1</version>
+    <version>1.7.0</version>
 </dependency>
 ```
 
 ### Install for Gradle:
 
 ```gradle
-implementation 'io.ably:ably-java:1.6.1'
+implementation 'io.ably:ably-java:1.7.0'
 implementation 'org.slf4j:slf4j-simple:2.0.7'
 ```
 
@@ -113,7 +113,7 @@ Add the following dependency to your `build.gradle` file:
 
 ```groovy
 dependencies {
-    runtimeOnly("io.ably:liveobjects:1.6.1")
+    runtimeOnly("io.ably:liveobjects:1.7.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=io.ably
-VERSION_NAME=1.6.1
+VERSION_NAME=1.7.0
 POM_INCEPTION_YEAR=2015
 POM_URL=https://github.com/ably/ably-java
 POM_SCM_URL=https://github.com/ably/ably-java/

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeHttpHeaderTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeHttpHeaderTest.java
@@ -88,7 +88,7 @@ public class RealtimeHttpHeaderTest extends ParameterizedTest {
              * Defaults.ABLY_AGENT_PARAM, as ultimately the request param has been derived from those values.
              */
             assertEquals("Verify correct lib version", requestParameters.get("agent"),
-                    Collections.singletonList("ably-java/1.6.1 jre/" + System.getProperty("java.version")));
+                    Collections.singletonList("ably-java/1.7.0 jre/" + System.getProperty("java.version")));
 
             /* Spec RTN2a */
             assertEquals("Verify correct format", requestParameters.get("format"),


### PR DESCRIPTION
### What's Changed

- Introduce version 6 of the Ably protocol; add operation-specific payload fields to `ObjectOperation` and typed value fields to `ObjectData` [#1195](https://github.com/ably/ably-java/pull/1195) 
- Add support for partial sync of LiveObjects state [#1197](https://github.com/ably/ably-java/pull/1197) 
- Introduce ACK-based local application of LiveObjects ops [#1194](https://github.com/ably/ably-java/pull/1194)
- Add support for server-initiated MAP_CLEAR object operation [#1198](https://github.com/ably/ably-java/pull/1198)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation and README examples to reference version 1.7.0.
  * Added a 1.7.0 release entry with changelog and "What's Changed" details.

* **Chores**
  * Bumped project version to 1.7.0 in configuration.

* **Tests**
  * Updated tests to expect the updated client/version identifier (1.7.0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->