### PR TITLE
fix: update `testAppSpec.json` to the right format

### DIFF
--- a/lib/src/test/resources/local/testAppSpec.json
+++ b/lib/src/test/resources/local/testAppSpec.json
@@ -54,30 +54,15 @@
 				{
 					"clientId": "client_string_0",
 					"data": "This is a string data payload"
-				}
-			]
-		},
-		{
-			"name": "persisted:restpresence_persisted",
-			"presence": [
+				},
 				{
 					"clientId": "client_string_1",
 					"data": "This is a string data payload"
-				}
-			]
-		},
-		{
-			"name": "persisted:restpresence_persisted",
-			"presence": [
+				},
 				{
 					"clientId": "client_string_2",
 					"data": "This is a string data payload"
-				}
-			]
-		},
-		{
-			"name": "persisted:restpresence_persisted",
-			"presence": [
+				},
 				{
 					"clientId": "client_string_3",
 					"data": "This is a string data payload"


### PR DESCRIPTION
Right now ably-java has copy of common's test app spec with some modifications, but the format may change we shouldn't rely on it, and use actual format instead

for now as a quick fix we update format for presence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated duplicate test data entries to improve test resource efficiency and reduce redundancy in test configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->