### PR TITLE
[AIT-996] feat(liveobjects): add path-based RealtimeObject and channel.object accessor

### DIFF
--- a/lib/src/main/java/io/ably/lib/object/RealtimeObject.java
+++ b/lib/src/main/java/io/ably/lib/object/RealtimeObject.java
@@ -3,11 +3,11 @@ package io.ably.lib.object;
 import io.ably.lib.object.path.types.LiveMapPathObject;
 import io.ably.lib.object.state.ObjectStateChange;
 import io.ably.lib.object.state.ObjectStateEvent;
-import io.ably.lib.objects.ObjectsSubscription;
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.ErrorInfo;
-import org.jetbrains.annotations.Blocking;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
  * The RealtimeObject interface is the entry point to the strongly-typed, path-based
@@ -33,16 +33,17 @@ public interface RealtimeObject extends ObjectStateChange {
      * when working with multiple channels with different underlying data structures.
      *
      * <p>This operation requires the {@code OBJECT_SUBSCRIBE} channel mode. It implicitly
-     * attaches the channel if it is not already attached, and waits for the objects
-     * synchronization state to transition to {@code SYNCED} before returning.
+     * attaches the channel if it is not already attached; the returned future completes once
+     * the objects synchronization state has transitioned to {@code SYNCED}, and completes
+     * exceptionally with an {@code AblyException} if synchronization fails.
      *
      * <p>Spec: RTO23, RTO23f (typed SDKs return a {@link LiveMapPathObject})
      *
-     * @return the root {@link LiveMapPathObject} for this channel's objects graph.
+     * @return a future that completes with the root {@link LiveMapPathObject} for this
+     *         channel's objects graph.
      */
-    @Blocking
     @NotNull
-    LiveMapPathObject get();
+    CompletableFuture<LiveMapPathObject> get();
 
     /**
      * Null-Object guard for {@link RealtimeObject}, used as the value of {@code channel.object}
@@ -64,12 +65,12 @@ public interface RealtimeObject extends ObjectStateChange {
         private Unavailable() {}
 
         @Override
-        public @NotNull LiveMapPathObject get() {
+        public @NotNull CompletableFuture<LiveMapPathObject> get() {
             throw missing();
         }
 
         @Override
-        public ObjectsSubscription on(@NotNull ObjectStateEvent event, ObjectStateChange.@NotNull Listener listener) {
+        public Subscription on(@NotNull ObjectStateEvent event, ObjectStateChange.@NotNull Listener listener) {
             throw missing();
         }
 

--- a/lib/src/main/java/io/ably/lib/object/RealtimeObject.java
+++ b/lib/src/main/java/io/ably/lib/object/RealtimeObject.java
@@ -1,0 +1,92 @@
+package io.ably.lib.object;
+
+import io.ably.lib.object.path.types.LiveMapPathObject;
+import io.ably.lib.object.state.ObjectStateChange;
+import io.ably.lib.object.state.ObjectStateEvent;
+import io.ably.lib.objects.ObjectsSubscription;
+import io.ably.lib.types.AblyException;
+import io.ably.lib.types.ErrorInfo;
+import org.jetbrains.annotations.Blocking;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The RealtimeObject interface is the entry point to the strongly-typed, path-based
+ * LiveObjects API on a channel. It exposes the root of the objects graph as a
+ * {@link LiveMapPathObject} and, via {@link ObjectStateChange}, lets callers observe
+ * synchronization state transitions for the channel's objects.
+ *
+ * <p>Implementations of this interface must be thread-safe as they may be accessed
+ * from multiple threads concurrently.
+ *
+ * <p>Spec: RTO23
+ */
+public interface RealtimeObject extends ObjectStateChange {
+
+    /**
+     * Retrieves a {@link LiveMapPathObject} rooted at the channel's root {@code LiveMap}.
+     * The returned object has an empty path and resolves to the root {@code LiveMap}; use
+     * its navigation methods to address nested values within the objects graph.
+     *
+     * <p>When called without a type variable, we return a default root type which is based
+     * on the globally defined interface for the Objects feature. A user can provide an
+     * explicit type to set the type structure on this particular channel. This is useful
+     * when working with multiple channels with different underlying data structures.
+     *
+     * <p>This operation requires the {@code OBJECT_SUBSCRIBE} channel mode. It implicitly
+     * attaches the channel if it is not already attached, and waits for the objects
+     * synchronization state to transition to {@code SYNCED} before returning.
+     *
+     * <p>Spec: RTO23, RTO23f (typed SDKs return a {@link LiveMapPathObject})
+     *
+     * @return the root {@link LiveMapPathObject} for this channel's objects graph.
+     */
+    @Blocking
+    @NotNull
+    LiveMapPathObject get();
+
+    /**
+     * Null-Object guard for {@link RealtimeObject}, used as the value of {@code channel.object}
+     * when the LiveObjects plugin is not installed.
+     *
+     * <p>Because {@code channel.object} is a field, dereferencing it can never throw; instead
+     * every method here fails fast with the plugin-missing error, so {@code get()}, {@code on()},
+     * {@code off()} and {@code offAll()} surface a clear, consistent error rather than a
+     * {@link NullPointerException}.
+     *
+     * <p>A stateless singleton ({@link #INSTANCE}) shared across all channels that lack the
+     * plugin. Adding a method to {@link RealtimeObject} will fail compilation here until it is
+     * guarded, which is the intended safety net.
+     */
+    final class Unavailable implements RealtimeObject {
+
+        public static final Unavailable INSTANCE = new Unavailable();
+
+        private Unavailable() {}
+
+        @Override
+        public @NotNull LiveMapPathObject get() {
+            throw missing();
+        }
+
+        @Override
+        public ObjectsSubscription on(@NotNull ObjectStateEvent event, ObjectStateChange.@NotNull Listener listener) {
+            throw missing();
+        }
+
+        @Override
+        public void off(ObjectStateChange.@NotNull Listener listener) {
+            throw missing();
+        }
+
+        @Override
+        public void offAll() {
+            throw missing();
+        }
+
+        private static RuntimeException missing() {
+            return new IllegalStateException("LiveObjects plugin hasn't been installed", AblyException.fromErrorInfo(
+                new ErrorInfo("add runtimeOnly('io.ably:liveobjects:<ably-version>') to your dependency tree", 400, 40019)
+            ));
+        }
+    }
+}

--- a/lib/src/main/java/io/ably/lib/object/state/ObjectStateChange.java
+++ b/lib/src/main/java/io/ably/lib/object/state/ObjectStateChange.java
@@ -1,6 +1,6 @@
 package io.ably.lib.object.state;
 
-import io.ably.lib.objects.ObjectsSubscription;
+import io.ably.lib.object.Subscription;
 import org.jetbrains.annotations.NonBlocking;
 import org.jetbrains.annotations.NotNull;
 
@@ -17,7 +17,7 @@ public interface ObjectStateChange {
      * @return a subscription object that can be used to unsubscribe from the event
      */
     @NonBlocking
-    ObjectsSubscription on(@NotNull ObjectStateEvent event, @NotNull ObjectStateChange.Listener listener);
+    Subscription on(@NotNull ObjectStateEvent event, @NotNull ObjectStateChange.Listener listener);
 
     /**
      * Unsubscribes the specified listener from all synchronization state events.

--- a/lib/src/main/java/io/ably/lib/object/state/ObjectStateChange.java
+++ b/lib/src/main/java/io/ably/lib/object/state/ObjectStateChange.java
@@ -1,0 +1,56 @@
+package io.ably.lib.object.state;
+
+import io.ably.lib.objects.ObjectsSubscription;
+import org.jetbrains.annotations.NonBlocking;
+import org.jetbrains.annotations.NotNull;
+
+public interface ObjectStateChange {
+    /**
+     * Subscribes to a specific Objects synchronization state event.
+     *
+     * <p>This method registers the provided listener to be notified when the specified
+     * synchronization state event occurs. The returned subscription can be used to
+     * unsubscribe later when the notifications are no longer needed.
+     *
+     * @param event the synchronization state event to subscribe to (SYNCING or SYNCED)
+     * @param listener the listener that will be called when the event occurs
+     * @return a subscription object that can be used to unsubscribe from the event
+     */
+    @NonBlocking
+    ObjectsSubscription on(@NotNull ObjectStateEvent event, @NotNull ObjectStateChange.Listener listener);
+
+    /**
+     * Unsubscribes the specified listener from all synchronization state events.
+     *
+     * <p>After calling this method, the provided listener will no longer receive
+     * any synchronization state event notifications.
+     *
+     * @param listener the listener to unregister from all events
+     */
+    @NonBlocking
+    void off(@NotNull ObjectStateChange.Listener listener);
+
+    /**
+     * Unsubscribes all listeners from all synchronization state events.
+     *
+     * <p>After calling this method, no listeners will receive any synchronization
+     * state event notifications until new listeners are registered.
+     */
+    @NonBlocking
+    void offAll();
+
+    /**
+     * Interface for receiving notifications about Objects synchronization state changes.
+     * <p>
+     * Implement this interface and register it with an {@code ObjectStateEmitter} to be notified
+     * when synchronization state transitions occur.
+     */
+    interface Listener {
+        /**
+         * Called when the synchronization state changes.
+         *
+         * @param objectStateEvent The new state event (SYNCING or SYNCED)
+         */
+        void onStateChanged(ObjectStateEvent objectStateEvent);
+    }
+}

--- a/lib/src/main/java/io/ably/lib/object/state/ObjectStateEvent.java
+++ b/lib/src/main/java/io/ably/lib/object/state/ObjectStateEvent.java
@@ -1,0 +1,19 @@
+package io.ably.lib.object.state;
+
+/**
+ * Represents the synchronization state of Ably Objects.
+ * <p>
+ * This enum is used to notify listeners about state changes in the synchronization process.
+ * Clients can register an {@link ObjectStateChange.Listener} to receive these events.
+ */
+public enum ObjectStateEvent {
+    /**
+     * Indicates that synchronization between local and remote objects is in progress.
+     */
+    SYNCING,
+
+    /**
+     * Indicates that synchronization has completed successfully and objects are in sync.
+     */
+    SYNCED
+}

--- a/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
+++ b/lib/src/main/java/io/ably/lib/realtime/ChannelBase.java
@@ -13,6 +13,7 @@ import io.ably.lib.http.BasePaginatedQuery;
 import io.ably.lib.http.Http;
 import io.ably.lib.http.HttpCore;
 import io.ably.lib.http.HttpUtils;
+import io.ably.lib.object.RealtimeObject;
 import io.ably.lib.objects.RealtimeObjects;
 import io.ably.lib.objects.LiveObjectsPlugin;
 import io.ably.lib.rest.MessageEditsMixin;
@@ -111,6 +112,8 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
     @Nullable private final LiveObjectsPlugin liveObjectsPlugin;
 
     private volatile MessageEditsMixin messageEditsMixin;
+
+    public RealtimeObject object;
 
     public RealtimeObjects getObjects() throws AblyException {
         if (liveObjectsPlugin == null) {
@@ -1695,7 +1698,12 @@ public abstract class ChannelBase extends EventEmitter<ChannelEvent, ChannelStat
         this.decodingContext = new DecodingContext();
         this.liveObjectsPlugin = liveObjectsPlugin;
         if (liveObjectsPlugin != null) {
-            liveObjectsPlugin.getInstance(name); // Make objects instance ready to process sync messages
+            liveObjectsPlugin.getInstance(name);
+            // TODO(objects-migration): assign `this.object` to the real RealtimeObject once the
+            // LiveObjects plugin exposes io.ably.lib.object.RealtimeObject (getInstance currently
+            // returns the legacy io.ably.lib.objects.RealtimeObjects type).
+        } else {
+            this.object = RealtimeObject.Unavailable.INSTANCE;
         }
         this.annotations = new RealtimeAnnotations(
             this,


### PR DESCRIPTION
- Fixes https://ably.atlassian.net/browse/AIT-996
- Implemented `object` accessor using `realtimeChannel.object` field. Similar to `realtimeChannel.presence` field i.e. `realtimeChannel.presence.get()`. Aim is to keep API consistent across SDKs. i.e. current `ably-js` liveobjects API is `channel.object.get()`.
- Accessor methods on `object` (for example, `object.get()`) throw a runtime error when the LiveObjects plugin is not available. This is expected behavior and generally does not cause issues, as the LiveObjects feature requires an explicit dependency to be included.

## Summary

Adds the first slice of the public, strongly-typed, **path-based** LiveObjects API to the realtime channel, accessed through `channel.object`. This is the typed-SDK counterpart to the JS `channel.object` surface (spec `RTO23` / `RTL27`).

This PR lands the **entry-point interfaces and the `channel.object` accessor only** — the path/instance type hierarchy already exists on the base branch, and the live implementation that backs the plugin-present path is deferred (see *Out of scope*).

## What `channel.object` exposes

`channel.object` is a `RealtimeObject`, the entry point to the objects graph on a channel. Its public surface:

| Method | Returns | Purpose |
| --- | --- | --- |
| `get()` | `LiveMapPathObject` | The root of the objects graph as a path object (empty path → root `LiveMap`). Requires the `OBJECT_SUBSCRIBE` channel mode; implicitly attaches and waits for sync to complete. |
| `on(event, listener)` | `ObjectsSubscription` | Subscribe to objects **sync-state** events (`SYNCING` / `SYNCED`). |
| `off(listener)` | `void` | Remove a previously registered sync-state listener. |
| `offAll()` | `void` | Remove all sync-state listeners. |

`get()` returns a `LiveMapPathObject` because, per spec `RTO23f`, the root always resolves to a `LiveMap` in typed SDKs. The path-based read/navigation/mutation/subscription methods live on `PathObject` / `LiveMapPathObject` (already on the base branch).

## Changes

- **`RealtimeObject`** (`io.ably.lib.object`) — the channel objects entry point: `get()` plus the inherited sync-state methods via `ObjectStateChange`.
- **`ObjectStateChange` / `ObjectStateEvent`** (`io.ably.lib.object.state`) — the `SYNCING`/`SYNCED` sync-state subscription API and its `Listener`.
- **`ChannelBase.object`** — a new public field giving `channel.object` access.

## Plugin-not-installed behaviour

`channel.object` is a field, so dereferencing it can never throw. To keep `channel.object.get()` (and `on`/`off`/`offAll`) behaving consistently whether or not the LiveObjects plugin is present, the field is assigned a **null-object guard** — `RealtimeObject.Unavailable` — when the plugin is absent. Every method on the guard fails fast with a clear, actionable error (`statusCode` 400, `code` 40019) pointing at the missing `io.ably:liveobjects` dependency, rather than surfacing a `NullPointerException`.

The guard is nested inside `RealtimeObject` (`RealtimeObject.Unavailable`): it must be public anyway (referenced cross-package from `ChannelBase`), and nesting namespaces it to the interface it guards while keeping the "implement every new method or fail compilation" safety net.

## Out of scope (follow-ups)

- **Plugin-present wiring.** When the plugin *is* installed, `channel.object` is not yet assigned the live implementation — there is a `TODO(objects-migration)` in the `ChannelBase` constructor. This is blocked on the LiveObjects plugin exposing the new `io.ably.lib.object.RealtimeObject` type; `LiveObjectsPlugin.getInstance(...)` currently returns the legacy `io.ably.lib.objects.RealtimeObjects`.
- The legacy `channel.getObjects()` accessor is retained for now and will be removed in a later change.

## Testing

`./gradlew :java:compileJava` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RealtimeObject API for accessing real-time synchronized objects on channels.
  * Introduced ObjectStateEvent to monitor synchronization lifecycle with SYNCING and SYNCED states.
  * Added listeners to subscribe to and unsubscribe from state change events.
  * Improved error handling with meaningful exceptions when LiveObjects plugin is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->