### PR TITLE
[AIT-928] Added basic impl. for PathObject and Instance interfaces

### DIFF
--- a/lib/src/main/java/io/ably/lib/object/ValueType.java
+++ b/lib/src/main/java/io/ably/lib/object/ValueType.java
@@ -23,6 +23,6 @@ public enum ValueType {
     LIVE_MAP,
     /** Corresponds to a {@code LiveCounter} object. Spec: RTTS2a8 */
     LIVE_COUNTER,
-    /** Returned when path resolution fails or the resolved value has none of the known types; never produced by an {@code Instance} in normal operation. Spec: RTTS2a9 */
+    /** Returned by {@code PathObject#getType()} only when a value is present but matches none of the known types. Never produced by an {@code Instance} in normal operation. Spec: RTTS2a9 */
     UNKNOWN,
 }

--- a/lib/src/main/java/io/ably/lib/object/adapter/AblyClientAdapter.java
+++ b/lib/src/main/java/io/ably/lib/object/adapter/AblyClientAdapter.java
@@ -1,0 +1,53 @@
+package io.ably.lib.object.adapter;
+
+import io.ably.lib.realtime.ChannelBase;
+import io.ably.lib.realtime.Connection;
+import io.ably.lib.types.AblyException;
+import io.ably.lib.types.ClientOptions;
+import org.jetbrains.annotations.Blocking;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Bridges the path-based LiveObjects implementation to the core Ably client, exposing the
+ * client configuration, connection and channel state it needs without coupling it to the
+ * concrete {@link io.ably.lib.realtime.AblyRealtime} type.
+ *
+ * <p>This is the adapter for the path-based {@code io.ably.lib.object} API and is intentionally
+ * kept independent of the legacy {@code io.ably.lib.objects} package.
+ */
+public interface AblyClientAdapter {
+    /**
+     * Retrieves the client options configured for the Ably client.
+     * Used to access client configuration parameters such as echoMessages setting
+     * that affect the behavior of Objects operations.
+     *
+     * @return the client options containing configuration parameters
+     */
+    @NotNull ClientOptions getClientOptions();
+
+    /**
+     * Retrieves the connection instance for handling connection state and operations.
+     * Used to check connection status, obtain error information, and manage
+     * message transmission across the Ably connection.
+     *
+     * @return the connection instance
+     */
+    @NotNull Connection getConnection();
+
+    /**
+     * Retrieves the current time in milliseconds from the Ably server.
+     * Spec: RTO16
+     */
+    @Blocking
+    long getTime() throws AblyException;
+
+    /**
+     * Retrieves the channel instance for the specified channel name.
+     * If the channel does not exist, an AblyException is thrown.
+     *
+     * @param channelName the name of the channel to retrieve
+     * @return the ChannelBase instance for the specified channel
+     * @throws AblyException if the channel is not found or cannot be retrieved
+     */
+    @NotNull ChannelBase getChannel(@NotNull String channelName) throws AblyException;
+}

--- a/lib/src/main/java/io/ably/lib/object/adapter/Adapter.java
+++ b/lib/src/main/java/io/ably/lib/object/adapter/Adapter.java
@@ -1,11 +1,13 @@
 package io.ably.lib.object.adapter;
 
 import io.ably.lib.realtime.AblyRealtime;
+import io.ably.lib.realtime.Channel;
 import io.ably.lib.realtime.ChannelBase;
 import io.ably.lib.realtime.Connection;
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.ClientOptions;
 import io.ably.lib.types.ErrorInfo;
+import io.ably.lib.types.ReadOnlyMap;
 import io.ably.lib.util.Log;
 import org.jetbrains.annotations.NotNull;
 
@@ -39,12 +41,16 @@ public class Adapter implements AblyClientAdapter {
 
     @Override
     public @NotNull ChannelBase getChannel(@NotNull String channelName) throws AblyException {
-        if (ably.channels.containsKey(channelName)) {
-            return ably.channels.get(channelName);
-        } else {
+        // Look up via the read-only map view. Channels#get(String) would create the channel if
+        // absent; ReadOnlyMap only exposes get(Object), which returns null atomically for an
+        // unknown channel instead of silently recreating it.
+        final ReadOnlyMap<String, Channel> channels = ably.channels;
+        final ChannelBase channel = channels.get(channelName);
+        if (channel == null) {
             Log.e(TAG, "getChannel(): channel not found: " + channelName);
             ErrorInfo errorInfo = new ErrorInfo("Channel not found: " + channelName, 404);
             throw AblyException.fromErrorInfo(errorInfo);
         }
+        return channel;
     }
 }

--- a/lib/src/main/java/io/ably/lib/object/adapter/Adapter.java
+++ b/lib/src/main/java/io/ably/lib/object/adapter/Adapter.java
@@ -1,0 +1,50 @@
+package io.ably.lib.object.adapter;
+
+import io.ably.lib.realtime.AblyRealtime;
+import io.ably.lib.realtime.ChannelBase;
+import io.ably.lib.realtime.Connection;
+import io.ably.lib.types.AblyException;
+import io.ably.lib.types.ClientOptions;
+import io.ably.lib.types.ErrorInfo;
+import io.ably.lib.util.Log;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Default {@link AblyClientAdapter} implementation backed by an {@link AblyRealtime} client.
+ * Holding the {@code AblyRealtime} reference gives the path-based LiveObjects implementation
+ * access to the full client configuration and runtime state it may need.
+ */
+public class Adapter implements AblyClientAdapter {
+    private final AblyRealtime ably;
+    private static final String TAG = AblyClientAdapter.class.getName();
+
+    public Adapter(@NotNull AblyRealtime ably) {
+        this.ably = ably;
+    }
+
+    @Override
+    public @NotNull ClientOptions getClientOptions() {
+        return ably.options;
+    }
+
+    @Override
+    public @NotNull Connection getConnection() {
+        return ably.connection;
+    }
+
+    @Override
+    public long getTime() throws AblyException {
+        return ably.time();
+    }
+
+    @Override
+    public @NotNull ChannelBase getChannel(@NotNull String channelName) throws AblyException {
+        if (ably.channels.containsKey(channelName)) {
+            return ably.channels.get(channelName);
+        } else {
+            Log.e(TAG, "getChannel(): channel not found: " + channelName);
+            ErrorInfo errorInfo = new ErrorInfo("Channel not found: " + channelName, 404);
+            throw AblyException.fromErrorInfo(errorInfo);
+        }
+    }
+}

--- a/lib/src/main/java/io/ably/lib/object/adapter/package-info.java
+++ b/lib/src/main/java/io/ably/lib/object/adapter/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Adapter layer bridging the path-based LiveObjects implementation to the core Ably client.
+ * {@link io.ably.lib.object.adapter.AblyClientAdapter} is the abstraction the implementation
+ * depends on; {@link io.ably.lib.object.adapter.Adapter} is the default implementation backed
+ * by an {@link io.ably.lib.realtime.AblyRealtime} client.
+ *
+ * <p>This package is intentionally independent of the legacy {@code io.ably.lib.objects}
+ * package so the path-based API can evolve on its own.
+ */
+package io.ably.lib.object.adapter;

--- a/lib/src/main/java/io/ably/lib/object/instance/Instance.java
+++ b/lib/src/main/java/io/ably/lib/object/instance/Instance.java
@@ -17,15 +17,19 @@ import org.jetbrains.annotations.NotNull;
  * {@code LiveCounter}) or primitive value.
  *
  * <p>Unlike {@code PathObject}, which re-resolves its path on every call, an
- * {@code Instance} is identity-addressed: it is bound to a specific underlying value
- * and dereferenced in O(1), regardless of where that value sits in the graph. Read
- * operations validate the access API preconditions and fail with an
- * {@code AblyException} if they are not satisfied.
+ * {@code Instance} is identity-addressed: it wraps an already-resolved value (typically
+ * obtained from a {@code PathObject}), so its type is fixed and known for the lifetime
+ * of the instance, and it is dereferenced in O(1) regardless of where that value sits
+ * in the graph. Read operations validate the access API preconditions and fail with an
+ * {@code AblyException} if those are not satisfied.
  *
  * <p>This base type exposes only the methods whose behaviour is independent of the
  * wrapped type; everything else - including {@code subscribe} (RTTS7b) - is
  * partitioned onto the sub-types. Use the {@code as*} helpers to obtain a sub-type
- * view without type validation, or discriminate via {@link #getType()}.
+ * view, or discriminate via {@link #getType()}. Because the wrapped type is fixed and
+ * known, a mismatched {@code as*} cast fails fast with an {@link IllegalStateException}
+ * rather than returning a best-effort view (contrast {@code PathObject}, whose casts
+ * never throw).
  *
  * <p>Spec: RTINS1, RTTS7
  *
@@ -65,85 +69,101 @@ public interface Instance {
     @NotNull JsonElement compactJson();
 
     /**
-     * Returns this instance wrapped as a {@link LiveMapInstance}.
+     * Returns this instance viewed as a {@link LiveMapInstance}.
      *
-     * <p>Best-effort cast; does not validate the underlying type. Read operations on
-     * the returned wrapper are always permitted; write/terminal operations will fail
-     * at call time if the wrapped value is not a {@code LiveMap}.
+     * <p>Because an {@code Instance} wraps an already-resolved value of a known, fixed
+     * type, this fails fast: it throws {@link IllegalStateException} if the wrapped value
+     * is not a {@code LiveMap}, rather than returning a best-effort view. Use
+     * {@link #getType()} to discriminate the type before casting.
      *
-     * <p>Spec: RTTS9a
+     * <p>Spec: RTTS9a / RTTS9d
      *
      * @return a {@link LiveMapInstance} view of this instance
+     * @throws IllegalStateException if the wrapped value is not a {@code LiveMap}
      */
     @NotNull LiveMapInstance asLiveMap();
 
     /**
-     * Returns this instance wrapped as a {@link LiveCounterInstance}.
-     * Best-effort cast; does not validate the underlying type.
+     * Returns this instance viewed as a {@link LiveCounterInstance}.
+     * Fails fast: throws {@link IllegalStateException} if the wrapped value is not a
+     * {@code LiveCounter}.
      *
-     * <p>Spec: RTTS9b
+     * <p>Spec: RTTS9b / RTTS9d
      *
      * @return a {@link LiveCounterInstance} view of this instance
+     * @throws IllegalStateException if the wrapped value is not a {@code LiveCounter}
      */
     @NotNull LiveCounterInstance asLiveCounter();
 
     /**
-     * Returns this instance wrapped as a {@link NumberInstance}.
-     * Best-effort cast; does not validate the underlying type.
+     * Returns this instance viewed as a {@link NumberInstance}.
+     * Fails fast: throws {@link IllegalStateException} if the wrapped value is not a
+     * {@code Number}.
      *
-     * <p>Spec: RTTS9c
+     * <p>Spec: RTTS9c / RTTS9d
      *
      * @return a {@link NumberInstance} view of this instance
+     * @throws IllegalStateException if the wrapped value is not a {@code Number}
      */
     @NotNull NumberInstance asNumber();
 
     /**
-     * Returns this instance wrapped as a {@link StringInstance}.
-     * Best-effort cast; does not validate the underlying type.
+     * Returns this instance viewed as a {@link StringInstance}.
+     * Fails fast: throws {@link IllegalStateException} if the wrapped value is not a
+     * {@code String}.
      *
-     * <p>Spec: RTTS9c
+     * <p>Spec: RTTS9c / RTTS9d
      *
      * @return a {@link StringInstance} view of this instance
+     * @throws IllegalStateException if the wrapped value is not a {@code String}
      */
     @NotNull StringInstance asString();
 
     /**
-     * Returns this instance wrapped as a {@link BooleanInstance}.
-     * Best-effort cast; does not validate the underlying type.
+     * Returns this instance viewed as a {@link BooleanInstance}.
+     * Fails fast: throws {@link IllegalStateException} if the wrapped value is not a
+     * {@code Boolean}.
      *
-     * <p>Spec: RTTS9c
+     * <p>Spec: RTTS9c / RTTS9d
      *
      * @return a {@link BooleanInstance} view of this instance
+     * @throws IllegalStateException if the wrapped value is not a {@code Boolean}
      */
     @NotNull BooleanInstance asBoolean();
 
     /**
-     * Returns this instance wrapped as a {@link BinaryInstance}.
-     * Best-effort cast; does not validate the underlying type.
+     * Returns this instance viewed as a {@link BinaryInstance}.
+     * Fails fast: throws {@link IllegalStateException} if the wrapped value is not a
+     * binary value.
      *
-     * <p>Spec: RTTS9c
+     * <p>Spec: RTTS9c / RTTS9d
      *
      * @return a {@link BinaryInstance} view of this instance
+     * @throws IllegalStateException if the wrapped value is not a binary value
      */
     @NotNull BinaryInstance asBinary();
 
     /**
-     * Returns this instance wrapped as a {@link JsonObjectInstance}.
-     * Best-effort cast; does not validate the underlying type.
+     * Returns this instance viewed as a {@link JsonObjectInstance}.
+     * Fails fast: throws {@link IllegalStateException} if the wrapped value is not a
+     * JSON object.
      *
-     * <p>Spec: RTTS9c
+     * <p>Spec: RTTS9c / RTTS9d
      *
      * @return a {@link JsonObjectInstance} view of this instance
+     * @throws IllegalStateException if the wrapped value is not a JSON object
      */
     @NotNull JsonObjectInstance asJsonObject();
 
     /**
-     * Returns this instance wrapped as a {@link JsonArrayInstance}.
-     * Best-effort cast; does not validate the underlying type.
+     * Returns this instance viewed as a {@link JsonArrayInstance}.
+     * Fails fast: throws {@link IllegalStateException} if the wrapped value is not a
+     * JSON array.
      *
-     * <p>Spec: RTTS9c
+     * <p>Spec: RTTS9c / RTTS9d
      *
      * @return a {@link JsonArrayInstance} view of this instance
+     * @throws IllegalStateException if the wrapped value is not a JSON array
      */
     @NotNull JsonArrayInstance asJsonArray();
 }

--- a/lib/src/main/java/io/ably/lib/object/instance/types/BinaryInstance.java
+++ b/lib/src/main/java/io/ably/lib/object/instance/types/BinaryInstance.java
@@ -1,5 +1,6 @@
 package io.ably.lib.object.instance.types;
 
+import com.google.gson.JsonPrimitive;
 import io.ably.lib.object.instance.Instance;
 import org.jetbrains.annotations.NotNull;
 
@@ -22,4 +23,15 @@ public interface BinaryInstance extends Instance {
      * @return the wrapped bytes
      */
     byte @NotNull [] value();
+
+    /**
+     * Returns the compacted JSON snapshot of the wrapped value, narrowed to a
+     * {@link JsonPrimitive}: binary compacts to a base64-encoded JSON string.
+     *
+     * <p>Spec: RTTS7a
+     *
+     * @return the compacted JSON primitive
+     */
+    @Override
+    @NotNull JsonPrimitive compactJson();
 }

--- a/lib/src/main/java/io/ably/lib/object/instance/types/BooleanInstance.java
+++ b/lib/src/main/java/io/ably/lib/object/instance/types/BooleanInstance.java
@@ -1,5 +1,6 @@
 package io.ably.lib.object.instance.types;
 
+import com.google.gson.JsonPrimitive;
 import io.ably.lib.object.instance.Instance;
 import org.jetbrains.annotations.NotNull;
 
@@ -22,4 +23,16 @@ public interface BooleanInstance extends Instance {
      */
     @NotNull
     Boolean value();
+
+    /**
+     * Returns the compacted JSON snapshot of the wrapped value, narrowed to a
+     * {@link JsonPrimitive}: a {@code BooleanInstance} always compacts to a single
+     * JSON primitive.
+     *
+     * <p>Spec: RTTS7a
+     *
+     * @return the compacted JSON primitive
+     */
+    @Override
+    @NotNull JsonPrimitive compactJson();
 }

--- a/lib/src/main/java/io/ably/lib/object/instance/types/JsonArrayInstance.java
+++ b/lib/src/main/java/io/ably/lib/object/instance/types/JsonArrayInstance.java
@@ -23,4 +23,15 @@ public interface JsonArrayInstance extends Instance {
      */
     @NotNull
     JsonArray value();
+
+    /**
+     * Returns the compacted JSON snapshot of the wrapped value, narrowed to a
+     * {@link JsonArray}: a {@code JsonArrayInstance} always compacts to a JSON array.
+     *
+     * <p>Spec: RTTS7a
+     *
+     * @return the compacted JSON array
+     */
+    @Override
+    @NotNull JsonArray compactJson();
 }

--- a/lib/src/main/java/io/ably/lib/object/instance/types/JsonObjectInstance.java
+++ b/lib/src/main/java/io/ably/lib/object/instance/types/JsonObjectInstance.java
@@ -23,4 +23,15 @@ public interface JsonObjectInstance extends Instance {
      */
     @NotNull
     JsonObject value();
+
+    /**
+     * Returns the compacted JSON snapshot of the wrapped value, narrowed to a
+     * {@link JsonObject}: a {@code JsonObjectInstance} always compacts to a JSON object.
+     *
+     * <p>Spec: RTTS7a
+     *
+     * @return the compacted JSON object
+     */
+    @Override
+    @NotNull JsonObject compactJson();
 }

--- a/lib/src/main/java/io/ably/lib/object/instance/types/LiveCounterInstance.java
+++ b/lib/src/main/java/io/ably/lib/object/instance/types/LiveCounterInstance.java
@@ -1,5 +1,6 @@
 package io.ably.lib.object.instance.types;
 
+import com.google.gson.JsonPrimitive;
 import io.ably.lib.object.instance.Instance;
 import io.ably.lib.object.instance.InstanceListener;
 import io.ably.lib.object.Subscription;
@@ -36,6 +37,18 @@ public interface LiveCounterInstance extends Instance {
      */
     @NotNull
     Double value();
+
+    /**
+     * Returns the compacted JSON snapshot of the wrapped value, narrowed to a
+     * {@link JsonPrimitive}: a {@code LiveCounterInstance} always compacts to a numeric
+     * JSON primitive.
+     *
+     * <p>Spec: RTTS7a
+     *
+     * @return the compacted JSON primitive
+     */
+    @Override
+    @NotNull JsonPrimitive compactJson();
 
     /**
      * Increments the wrapped {@code LiveCounter} by {@code 1}. Equivalent to

--- a/lib/src/main/java/io/ably/lib/object/instance/types/LiveMapInstance.java
+++ b/lib/src/main/java/io/ably/lib/object/instance/types/LiveMapInstance.java
@@ -1,5 +1,6 @@
 package io.ably.lib.object.instance.types;
 
+import com.google.gson.JsonObject;
 import io.ably.lib.object.instance.Instance;
 import io.ably.lib.object.instance.InstanceListener;
 import io.ably.lib.object.Subscription;
@@ -33,6 +34,18 @@ public interface LiveMapInstance extends Instance {
      */
     @NotNull
     String getId();
+
+    /**
+     * Returns the compacted JSON snapshot of the wrapped value, narrowed to a
+     * {@link JsonObject}: a {@code LiveMapInstance} compacts to a JSON object (or, for a
+     * cyclic reference, an object-id reference object).
+     *
+     * <p>Spec: RTTS7a
+     *
+     * @return the compacted JSON object
+     */
+    @Override
+    @NotNull JsonObject compactJson();
 
     /**
      * Returns a {@link Instance} wrapping the value at {@code key} of the

--- a/lib/src/main/java/io/ably/lib/object/instance/types/NumberInstance.java
+++ b/lib/src/main/java/io/ably/lib/object/instance/types/NumberInstance.java
@@ -1,5 +1,6 @@
 package io.ably.lib.object.instance.types;
 
+import com.google.gson.JsonPrimitive;
 import io.ably.lib.object.instance.Instance;
 import org.jetbrains.annotations.NotNull;
 
@@ -22,4 +23,16 @@ public interface NumberInstance extends Instance {
      */
     @NotNull
     Number value();
+
+    /**
+     * Returns the compacted JSON snapshot of the wrapped value, narrowed to a
+     * {@link JsonPrimitive}: a {@code NumberInstance} always compacts to a single
+     * JSON primitive.
+     *
+     * <p>Spec: RTTS7a
+     *
+     * @return the compacted JSON primitive
+     */
+    @Override
+    @NotNull JsonPrimitive compactJson();
 }

--- a/lib/src/main/java/io/ably/lib/object/instance/types/StringInstance.java
+++ b/lib/src/main/java/io/ably/lib/object/instance/types/StringInstance.java
@@ -1,5 +1,6 @@
 package io.ably.lib.object.instance.types;
 
+import com.google.gson.JsonPrimitive;
 import io.ably.lib.object.instance.Instance;
 import org.jetbrains.annotations.NotNull;
 
@@ -22,4 +23,16 @@ public interface StringInstance extends Instance {
      */
     @NotNull
     String value();
+
+    /**
+     * Returns the compacted JSON snapshot of the wrapped value, narrowed to a
+     * {@link JsonPrimitive}: a {@code StringInstance} always compacts to a single
+     * JSON primitive.
+     *
+     * <p>Spec: RTTS7a
+     *
+     * @return the compacted JSON primitive
+     */
+    @Override
+    @NotNull JsonPrimitive compactJson();
 }

--- a/lib/src/main/java/io/ably/lib/object/message/ObjectData.java
+++ b/lib/src/main/java/io/ably/lib/object/message/ObjectData.java
@@ -26,7 +26,7 @@ public interface ObjectData {
     /**
      * Returns the string value.
      *
-     * <p>Spec: OD2c
+     * <p>Spec: OD2f
      *
      * @return the string value, or {@code null} if not applicable
      */
@@ -35,7 +35,7 @@ public interface ObjectData {
     /**
      * Returns the numeric value.
      *
-     * <p>Spec: OD2c
+     * <p>Spec: OD2e
      *
      * @return the numeric value, or {@code null} if not applicable
      */
@@ -54,7 +54,7 @@ public interface ObjectData {
      * Returns the binary value. The returned array is the underlying message
      * payload and is not defensively copied; callers must treat it as read-only.
      *
-     * <p>Spec: OD2c
+     * <p>Spec: OD2d
      *
      * @return the binary value, or {@code null} if not applicable
      */
@@ -63,7 +63,7 @@ public interface ObjectData {
     /**
      * Returns the JSON object or array value.
      *
-     * <p>Spec: OD2c
+     * <p>Spec: OD2g
      *
      * @return the JSON value, or {@code null} if not applicable
      */

--- a/lib/src/main/java/io/ably/lib/object/path/PathObject.java
+++ b/lib/src/main/java/io/ably/lib/object/path/PathObject.java
@@ -21,11 +21,17 @@ import org.jetbrains.annotations.Nullable;
  * {@code LiveMap}.
  *
  * <p>A {@code PathObject} stores a path as an ordered list of string segments and
- * resolves it against the local object graph each time a method is called. Resolution
- * is best-effort: the value at a path may change between two calls (e.g. between
+ * resolves it against the local object graph each time a terminal method is called;
+ * the freshly resolved value is the sole basis for that call's result. Resolution is
+ * best-effort: the value at a path may change between two calls (e.g. between
  * {@link #exists()} and a subsequent write) as updates from other clients are applied.
- * Operations that resolve the path validate the access/write API preconditions and
- * fail with an {@code AblyException} if they are not satisfied.
+ *
+ * <p>When the path does not resolve, or resolves to a type the called method does not
+ * apply to, read operations degrade gracefully - returning {@code null} or an empty
+ * result - whereas write operations fail with an {@code AblyException} (code 92005 if
+ * the path does not resolve, 92007 on a type mismatch). All terminal operations
+ * additionally validate the access/write API preconditions and fail with an
+ * {@code AblyException} if those are not satisfied.
  *
  * <p>This base type exposes only the methods whose behaviour is independent of the
  * resolved type; map and counter reads/writes are partitioned onto the sub-types

--- a/lib/src/main/java/io/ably/lib/object/path/PathObject.java
+++ b/lib/src/main/java/io/ably/lib/object/path/PathObject.java
@@ -43,17 +43,22 @@ import org.jetbrains.annotations.Nullable;
 public interface PathObject {
 
     /**
-     * Returns the {@link ValueType} of the value resolved at this path currently.
-     * Use this instead of dedicated {@code isLiveMap}/{@code isLiveCounter}/etc. checks.
+     * Returns the {@link ValueType} of the value currently resolved at this path, or
+     * {@code null} when the path does not resolve to any value. Use this instead of
+     * dedicated {@code isLiveMap}/{@code isLiveCounter}/etc. checks.
      *
-     * <p>Returns {@link ValueType#UNKNOWN} when the path does not resolve or the
-     * resolved value falls into none of the known categories.
+     * <p>A {@code null} result means there is no value at this path - nothing is stored
+     * there (e.g. an absent or removed map entry). This is deliberately distinct from
+     * {@link ValueType#UNKNOWN}, which is returned only when a value <em>is</em> present
+     * but its type matches none of the known categories. In other words: {@code null}
+     * means "no value", {@code UNKNOWN} means "a value of an unrecognized type".
      *
      * <p>Spec: RTTS4b
      *
-     * @return the resolved value type at this path
+     * @return the resolved value type at this path, or {@code null} if the path does
+     *         not resolve to a value
      */
-    @NotNull ValueType getType();
+    @Nullable ValueType getType();
 
     /**
      * Returns a dot-delimited string representation of the stored path segments.

--- a/lib/src/main/java/io/ably/lib/object/value/LiveCounter.java
+++ b/lib/src/main/java/io/ably/lib/object/value/LiveCounter.java
@@ -23,7 +23,7 @@ import java.lang.reflect.InvocationTargetException;
  */
 public abstract class LiveCounter {
 
-    private static final String IMPLEMENTATION_CLASS = "io.ably.lib.object.DefaultLiveCounter";
+    private static final String IMPLEMENTATION_CLASS = "io.ably.lib.object.value.DefaultLiveCounter";
 
     /**
      * Extended by the LiveObjects implementation; not intended for

--- a/lib/src/main/java/io/ably/lib/object/value/LiveMap.java
+++ b/lib/src/main/java/io/ably/lib/object/value/LiveMap.java
@@ -26,7 +26,7 @@ import java.util.Map;
  */
 public abstract class LiveMap {
 
-    private static final String IMPLEMENTATION_CLASS = "io.ably.lib.object.DefaultLiveMap";
+    private static final String IMPLEMENTATION_CLASS = "io.ably.lib.object.value.DefaultLiveMap";
 
     /**
      * Extended by the LiveObjects implementation; not intended for

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/DefaultRealtimeObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/DefaultRealtimeObject.kt
@@ -32,4 +32,10 @@ internal class DefaultRealtimeObject(
   override fun off(listener: ObjectStateChange.Listener): Unit = TODO("Not yet implemented")
 
   override fun offAll(): Unit = TODO("Not yet implemented")
+
+  /** Validates the channel is configured for access (read/subscribe) operations. Spec: RTLO4b1 */
+  internal fun throwIfInvalidAccessApiConfiguration() = adapter.throwIfInvalidAccessApiConfiguration(channelName)
+
+  /** Validates the channel is configured for write (mutation) operations. Spec: RTLO4b2 */
+  internal fun throwIfInvalidWriteApiConfiguration() = adapter.throwIfInvalidWriteApiConfiguration(channelName)
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/DefaultRealtimeObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/DefaultRealtimeObject.kt
@@ -1,0 +1,35 @@
+package io.ably.lib.`object`
+
+import io.ably.lib.`object`.adapter.AblyClientAdapter
+import io.ably.lib.`object`.path.types.LiveMapPathObject
+import io.ably.lib.`object`.state.ObjectStateChange
+import io.ably.lib.`object`.state.ObjectStateEvent
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Default implementation of [RealtimeObject], the entry point to the strongly-typed,
+ * path-based LiveObjects API for a single channel.
+ *
+ * This is currently a skeleton: the path-based read and subscribe operations are not yet
+ * implemented. The method bodies will be filled in as the path-based API is built out.
+ *
+ * Spec: RTO23
+ */
+internal class DefaultRealtimeObject(
+  internal val channelName: String,
+  internal val adapter: AblyClientAdapter,
+) : RealtimeObject {
+
+  override fun get(): CompletableFuture<LiveMapPathObject> = TODO("Not yet implemented")
+
+  override fun on(event: ObjectStateEvent, listener: ObjectStateChange.Listener): Subscription {
+    // TODO - subscribe logic goes here
+    return onceSubscription {
+      // TODO - remove ObjectStateChange.Listener
+    }
+  }
+
+  override fun off(listener: ObjectStateChange.Listener): Unit = TODO("Not yet implemented")
+
+  override fun offAll(): Unit = TODO("Not yet implemented")
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/DefaultRealtimeObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/DefaultRealtimeObject.kt
@@ -33,9 +33,9 @@ internal class DefaultRealtimeObject(
 
   override fun offAll(): Unit = TODO("Not yet implemented")
 
-  /** Validates the channel is configured for access (read/subscribe) operations. Spec: RTLO4b1 */
+  /** Validates the channel is configured for access (read/subscribe) operations. Spec: RTO25 */
   internal fun throwIfInvalidAccessApiConfiguration() = adapter.throwIfInvalidAccessApiConfiguration(channelName)
 
-  /** Validates the channel is configured for write (mutation) operations. Spec: RTLO4b2 */
+  /** Validates the channel is configured for write (mutation) operations. Spec: RTO26 */
   internal fun throwIfInvalidWriteApiConfiguration() = adapter.throwIfInvalidWriteApiConfiguration(channelName)
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/Errors.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/Errors.kt
@@ -1,0 +1,55 @@
+package io.ably.lib.`object`
+
+import io.ably.lib.types.AblyException
+import io.ably.lib.types.ErrorInfo
+
+/**
+ * Error codes and helpers for the path-based public API implementation.
+ * Copied (and extended with the path-API codes) from the legacy package so
+ * this package has no dependency on `io.ably.lib.objects`.
+ */
+internal enum class ObjectErrorCode(val code: Int) {
+  BadRequest(40_000),
+  InternalError(50_000),
+  MaxMessageSizeExceeded(40_009),
+  InvalidObject(92_000),
+  InvalidInputParams(40_003),
+  MapValueDataTypeUnsupported(40_013),
+  PathNotResolved(92_005), // RTPO3c2 - write operation on a path that does not resolve
+  ObjectsTypeMismatch(92_007), // RTTS5d2/RTTS9d2 - operation on a cast wrapper with mismatched resolved type
+  // Channel mode and state validation error codes
+  ChannelModeRequired(40_024),
+  ChannelStateError(90_001),
+  PublishAndApplyFailedDueToChannelState(92_008),
+}
+
+internal enum class ObjectHttpStatusCode(val code: Int) {
+  BadRequest(400),
+  InternalServerError(500),
+}
+
+internal fun objectException(
+  errorMessage: String,
+  errorCode: ObjectErrorCode,
+  statusCode: ObjectHttpStatusCode = ObjectHttpStatusCode.BadRequest,
+  cause: Throwable? = null,
+): AblyException {
+  val errorInfo = ErrorInfo(errorMessage, statusCode.code, errorCode.code)
+  return cause?.let { AblyException.fromErrorInfo(it, errorInfo) } ?: AblyException.fromErrorInfo(errorInfo)
+}
+
+/** ErrorInfo 400 / 40003 - invalid input (RTLMV4a/b, RTLCV4a, key validation). */
+internal fun invalidInputError(message: String) =
+  objectException(message, ObjectErrorCode.InvalidInputParams)
+
+/** ErrorInfo 400 / 92005 - write operation on an unresolvable path (RTPO3c2). */
+internal fun pathNotResolvedError(path: String) =
+  objectException("Path could not be resolved: \"$path\"", ObjectErrorCode.PathNotResolved)
+
+/** ErrorInfo 400 / 92007 - resolved/wrapped type does not match the typed wrapper (RTTS5d2/RTTS9d2). */
+internal fun typeMismatchError(message: String) =
+  objectException(message, ObjectErrorCode.ObjectsTypeMismatch)
+
+/** ErrorInfo 500 / 92000 - invalid internal object state. */
+internal fun objectStateError(message: String) =
+  objectException(message, ObjectErrorCode.InvalidObject, ObjectHttpStatusCode.InternalServerError)

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/Helpers.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/Helpers.kt
@@ -27,7 +27,7 @@ internal fun onceSubscription(onUnsubscribe: () -> Unit): Subscription {
  * attachable (not detached/failed) and have the `object_subscribe` mode. Copied from the
  * legacy `io.ably.lib.objects` helpers so this package has no dependency on that package.
  *
- * Spec: RTLO4b1
+ * Spec: RTO25
  */
 internal fun AblyClientAdapter.throwIfInvalidAccessApiConfiguration(channelName: String) {
   throwIfInChannelState(channelName, arrayOf(ChannelState.detached, ChannelState.failed))
@@ -39,7 +39,7 @@ internal fun AblyClientAdapter.throwIfInvalidAccessApiConfiguration(channelName:
  * enabled, the channel must be usable (not detached/failed/suspended) and have the
  * `object_publish` mode.
  *
- * Spec: RTLO4b2
+ * Spec: RTO26
  */
 internal fun AblyClientAdapter.throwIfInvalidWriteApiConfiguration(channelName: String) {
   throwIfEchoMessagesDisabled()

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/Helpers.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/Helpers.kt
@@ -1,5 +1,8 @@
 package io.ably.lib.`object`
 
+import io.ably.lib.`object`.adapter.AblyClientAdapter
+import io.ably.lib.realtime.ChannelState
+import io.ably.lib.types.ChannelMode
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -16,5 +19,70 @@ internal fun onceSubscription(onUnsubscribe: () -> Unit): Subscription {
     if (unsubscribed.compareAndSet(false, true)) {
       onUnsubscribe()
     }
+  }
+}
+
+/**
+ * Validates that the channel is configured for the access (read/subscribe) API: it must be
+ * attachable (not detached/failed) and have the `object_subscribe` mode. Copied from the
+ * legacy `io.ably.lib.objects` helpers so this package has no dependency on that package.
+ *
+ * Spec: RTLO4b1
+ */
+internal fun AblyClientAdapter.throwIfInvalidAccessApiConfiguration(channelName: String) {
+  throwIfInChannelState(channelName, arrayOf(ChannelState.detached, ChannelState.failed))
+  throwIfMissingChannelMode(channelName, ChannelMode.object_subscribe)
+}
+
+/**
+ * Validates that the channel is configured for the write (mutation) API: message echo must be
+ * enabled, the channel must be usable (not detached/failed/suspended) and have the
+ * `object_publish` mode.
+ *
+ * Spec: RTLO4b2
+ */
+internal fun AblyClientAdapter.throwIfInvalidWriteApiConfiguration(channelName: String) {
+  throwIfEchoMessagesDisabled()
+  throwIfInChannelState(channelName, arrayOf(ChannelState.detached, ChannelState.failed, ChannelState.suspended))
+  throwIfMissingChannelMode(channelName, ChannelMode.object_publish)
+}
+
+/**
+ * Resolves the effective channel modes: the attached `modes` if present, otherwise the
+ * user-provided channel options as a best effort.
+ *
+ * Spec: RTO2a, RTO2b
+ */
+private fun AblyClientAdapter.getChannelModes(channelName: String): Array<ChannelMode>? {
+  val channel = getChannel(channelName)
+  channel.modes?.let { modes -> if (modes.isNotEmpty()) return modes } // RTO2a
+  channel.options?.let { options -> if (options.hasModes()) return options.modes } // RTO2b
+  return null
+}
+
+// Spec: RTO2a2, RTO2b2
+private fun AblyClientAdapter.throwIfMissingChannelMode(channelName: String, channelMode: ChannelMode) {
+  val channelModes = getChannelModes(channelName)
+  if (channelModes == null || !channelModes.contains(channelMode)) {
+    throw objectException(
+      "\"${channelMode.name}\" channel mode must be set for this operation",
+      ObjectErrorCode.ChannelModeRequired,
+    )
+  }
+}
+
+private fun AblyClientAdapter.throwIfInChannelState(channelName: String, channelStates: Array<ChannelState>) {
+  val currentState = getChannel(channelName).state
+  if (currentState == null || channelStates.contains(currentState)) {
+    throw objectException("Channel is in invalid state: $currentState", ObjectErrorCode.ChannelStateError)
+  }
+}
+
+private fun AblyClientAdapter.throwIfEchoMessagesDisabled() {
+  if (!clientOptions.echoMessages) {
+    throw objectException(
+      "\"echoMessages\" client option must be enabled for this operation",
+      ObjectErrorCode.BadRequest,
+    )
   }
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/Helpers.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/Helpers.kt
@@ -1,0 +1,20 @@
+package io.ably.lib.`object`
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Wraps [onUnsubscribe] in a [Subscription] that runs the cleanup at most once; further
+ * calls are no-ops. Use it wherever a [Subscription] is returned: `EventEmitter.off` is
+ * `synchronized`, so this avoids re-acquiring that lock (and re-running teardown) on
+ * repeated unsubscribe calls. Thread-safe.
+ *
+ * Spec: SUB2a, SUB2b
+ */
+internal fun onceSubscription(onUnsubscribe: () -> Unit): Subscription {
+  val unsubscribed = AtomicBoolean(false)
+  return Subscription {
+    if (unsubscribed.compareAndSet(false, true)) {
+      onUnsubscribe()
+    }
+  }
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/DefaultInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/DefaultInstance.kt
@@ -1,0 +1,46 @@
+package io.ably.lib.`object`.instance
+
+import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.instance.types.BinaryInstance
+import io.ably.lib.`object`.instance.types.BooleanInstance
+import io.ably.lib.`object`.instance.types.JsonArrayInstance
+import io.ably.lib.`object`.instance.types.JsonObjectInstance
+import io.ably.lib.`object`.instance.types.LiveCounterInstance
+import io.ably.lib.`object`.instance.types.LiveMapInstance
+import io.ably.lib.`object`.instance.types.NumberInstance
+import io.ably.lib.`object`.instance.types.StringInstance
+
+/**
+ * Default implementation of [Instance], the identity-addressed node in the LiveObjects graph.
+ *
+ * An instance is always bound to a specific resolved value of a known type, so this base is
+ * abstract: each concrete sub-type supplies [getType] and [compactJson] (left abstract here)
+ * and overrides only the single `as*` cast matching its own type to return `this`. The
+ * remaining `as*` casts fall through to the implementations here, which fail fast because the
+ * wrapped value is not of the requested type.
+ *
+ * Only the channel's [channelObject] context is carried; unlike a path object there is no
+ * parent/child path, since an instance is identity-addressed.
+ *
+ * Spec: RTINS1, RTTS7
+ */
+internal abstract class DefaultInstance(
+  internal val channelObject: DefaultRealtimeObject,
+) : Instance {
+
+  override fun asLiveMap(): LiveMapInstance = throw IllegalStateException("Not a LiveMap instance")
+
+  override fun asLiveCounter(): LiveCounterInstance = throw IllegalStateException("Not a LiveCounter instance")
+
+  override fun asNumber(): NumberInstance = throw IllegalStateException("Not a Number instance")
+
+  override fun asString(): StringInstance = throw IllegalStateException("Not a String instance")
+
+  override fun asBoolean(): BooleanInstance = throw IllegalStateException("Not a Boolean instance")
+
+  override fun asBinary(): BinaryInstance = throw IllegalStateException("Not a Binary instance")
+
+  override fun asJsonObject(): JsonObjectInstance = throw IllegalStateException("Not a JsonObject instance")
+
+  override fun asJsonArray(): JsonArrayInstance = throw IllegalStateException("Not a JsonArray instance")
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/DefaultInstanceSubscriptionEvent.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/DefaultInstanceSubscriptionEvent.kt
@@ -1,0 +1,20 @@
+package io.ably.lib.`object`.instance
+
+import io.ably.lib.`object`.message.ObjectMessage
+
+/**
+ * Default implementation of [InstanceSubscriptionEvent], the event delivered to an
+ * [InstanceListener] when the wrapped LiveObject is updated. A plain holder for the updated
+ * [Instance] and the source [ObjectMessage] (if any).
+ *
+ * Spec: RTINS16e
+ */
+internal class DefaultInstanceSubscriptionEvent(
+  private val objectAt: Instance,
+  private val message: ObjectMessage?,
+) : InstanceSubscriptionEvent {
+
+  override fun getObject(): Instance = objectAt
+
+  override fun getMessage(): ObjectMessage? = message
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/DefaultInstanceSubscriptionEvent.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/DefaultInstanceSubscriptionEvent.kt
@@ -10,11 +10,11 @@ import io.ably.lib.`object`.message.ObjectMessage
  * Spec: RTINS16e
  */
 internal class DefaultInstanceSubscriptionEvent(
-  private val objectAt: Instance,
+  private val instance: Instance,
   private val message: ObjectMessage?,
 ) : InstanceSubscriptionEvent {
 
-  override fun getObject(): Instance = objectAt
+  override fun getObject(): Instance = instance
 
   override fun getMessage(): ObjectMessage? = message
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultBinaryInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultBinaryInstance.kt
@@ -1,6 +1,6 @@
 package io.ably.lib.`object`.instance.types
 
-import com.google.gson.JsonElement
+import com.google.gson.JsonPrimitive
 import io.ably.lib.`object`.DefaultRealtimeObject
 import io.ably.lib.`object`.ValueType
 import io.ably.lib.`object`.instance.DefaultInstance
@@ -17,7 +17,7 @@ internal class DefaultBinaryInstance(
 
   override fun getType(): ValueType = ValueType.BINARY
 
-  override fun compactJson(): JsonElement = TODO("Not yet implemented")
+  override fun compactJson(): JsonPrimitive = TODO("Not yet implemented")
 
   override fun asBinary(): BinaryInstance = this
 

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultBinaryInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultBinaryInstance.kt
@@ -17,9 +17,15 @@ internal class DefaultBinaryInstance(
 
   override fun getType(): ValueType = ValueType.BINARY
 
-  override fun compactJson(): JsonPrimitive = TODO("Not yet implemented")
+  override fun compactJson(): JsonPrimitive {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    TODO("Not yet implemented")
+  }
 
   override fun asBinary(): BinaryInstance = this
 
-  override fun value(): ByteArray = TODO("Not yet implemented")
+  override fun value(): ByteArray {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    TODO("Not yet implemented")
+  }
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultBinaryInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultBinaryInstance.kt
@@ -1,0 +1,25 @@
+package io.ably.lib.`object`.instance.types
+
+import com.google.gson.JsonElement
+import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.ValueType
+import io.ably.lib.`object`.instance.DefaultInstance
+
+/**
+ * Default implementation of [BinaryInstance], a read-only primitive view that only adds a
+ * type-narrowed, non-null [value]; left unimplemented for now.
+ *
+ * Spec: RTTS10c
+ */
+internal class DefaultBinaryInstance(
+  channelObject: DefaultRealtimeObject,
+) : DefaultInstance(channelObject), BinaryInstance {
+
+  override fun getType(): ValueType = ValueType.BINARY
+
+  override fun compactJson(): JsonElement = TODO("Not yet implemented")
+
+  override fun asBinary(): BinaryInstance = this
+
+  override fun value(): ByteArray = TODO("Not yet implemented")
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultBooleanInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultBooleanInstance.kt
@@ -1,0 +1,25 @@
+package io.ably.lib.`object`.instance.types
+
+import com.google.gson.JsonElement
+import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.ValueType
+import io.ably.lib.`object`.instance.DefaultInstance
+
+/**
+ * Default implementation of [BooleanInstance], a read-only primitive view that only adds a
+ * type-narrowed, non-null [value]; left unimplemented for now.
+ *
+ * Spec: RTTS10c
+ */
+internal class DefaultBooleanInstance(
+  channelObject: DefaultRealtimeObject,
+) : DefaultInstance(channelObject), BooleanInstance {
+
+  override fun getType(): ValueType = ValueType.BOOLEAN
+
+  override fun compactJson(): JsonElement = TODO("Not yet implemented")
+
+  override fun asBoolean(): BooleanInstance = this
+
+  override fun value(): Boolean = TODO("Not yet implemented")
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultBooleanInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultBooleanInstance.kt
@@ -1,6 +1,6 @@
 package io.ably.lib.`object`.instance.types
 
-import com.google.gson.JsonElement
+import com.google.gson.JsonPrimitive
 import io.ably.lib.`object`.DefaultRealtimeObject
 import io.ably.lib.`object`.ValueType
 import io.ably.lib.`object`.instance.DefaultInstance
@@ -17,7 +17,7 @@ internal class DefaultBooleanInstance(
 
   override fun getType(): ValueType = ValueType.BOOLEAN
 
-  override fun compactJson(): JsonElement = TODO("Not yet implemented")
+  override fun compactJson(): JsonPrimitive = TODO("Not yet implemented")
 
   override fun asBoolean(): BooleanInstance = this
 

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultBooleanInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultBooleanInstance.kt
@@ -17,9 +17,15 @@ internal class DefaultBooleanInstance(
 
   override fun getType(): ValueType = ValueType.BOOLEAN
 
-  override fun compactJson(): JsonPrimitive = TODO("Not yet implemented")
+  override fun compactJson(): JsonPrimitive {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    TODO("Not yet implemented")
+  }
 
   override fun asBoolean(): BooleanInstance = this
 
-  override fun value(): Boolean = TODO("Not yet implemented")
+  override fun value(): Boolean {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    TODO("Not yet implemented")
+  }
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultJsonArrayInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultJsonArrayInstance.kt
@@ -17,9 +17,15 @@ internal class DefaultJsonArrayInstance(
 
   override fun getType(): ValueType = ValueType.JSON_ARRAY
 
-  override fun compactJson(): JsonArray = TODO("Not yet implemented")
+  override fun compactJson(): JsonArray {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    TODO("Not yet implemented")
+  }
 
   override fun asJsonArray(): JsonArrayInstance = this
 
-  override fun value(): JsonArray = TODO("Not yet implemented")
+  override fun value(): JsonArray {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    TODO("Not yet implemented")
+  }
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultJsonArrayInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultJsonArrayInstance.kt
@@ -1,7 +1,6 @@
 package io.ably.lib.`object`.instance.types
 
 import com.google.gson.JsonArray
-import com.google.gson.JsonElement
 import io.ably.lib.`object`.DefaultRealtimeObject
 import io.ably.lib.`object`.ValueType
 import io.ably.lib.`object`.instance.DefaultInstance
@@ -18,7 +17,7 @@ internal class DefaultJsonArrayInstance(
 
   override fun getType(): ValueType = ValueType.JSON_ARRAY
 
-  override fun compactJson(): JsonElement = TODO("Not yet implemented")
+  override fun compactJson(): JsonArray = TODO("Not yet implemented")
 
   override fun asJsonArray(): JsonArrayInstance = this
 

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultJsonArrayInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultJsonArrayInstance.kt
@@ -1,0 +1,26 @@
+package io.ably.lib.`object`.instance.types
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.ValueType
+import io.ably.lib.`object`.instance.DefaultInstance
+
+/**
+ * Default implementation of [JsonArrayInstance], a read-only primitive view that only adds
+ * a type-narrowed, non-null [value]; left unimplemented for now.
+ *
+ * Spec: RTTS10c
+ */
+internal class DefaultJsonArrayInstance(
+  channelObject: DefaultRealtimeObject,
+) : DefaultInstance(channelObject), JsonArrayInstance {
+
+  override fun getType(): ValueType = ValueType.JSON_ARRAY
+
+  override fun compactJson(): JsonElement = TODO("Not yet implemented")
+
+  override fun asJsonArray(): JsonArrayInstance = this
+
+  override fun value(): JsonArray = TODO("Not yet implemented")
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultJsonObjectInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultJsonObjectInstance.kt
@@ -17,9 +17,15 @@ internal class DefaultJsonObjectInstance(
 
   override fun getType(): ValueType = ValueType.JSON_OBJECT
 
-  override fun compactJson(): JsonObject = TODO("Not yet implemented")
+  override fun compactJson(): JsonObject {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    TODO("Not yet implemented")
+  }
 
   override fun asJsonObject(): JsonObjectInstance = this
 
-  override fun value(): JsonObject = TODO("Not yet implemented")
+  override fun value(): JsonObject {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    TODO("Not yet implemented")
+  }
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultJsonObjectInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultJsonObjectInstance.kt
@@ -1,6 +1,5 @@
 package io.ably.lib.`object`.instance.types
 
-import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import io.ably.lib.`object`.DefaultRealtimeObject
 import io.ably.lib.`object`.ValueType
@@ -18,7 +17,7 @@ internal class DefaultJsonObjectInstance(
 
   override fun getType(): ValueType = ValueType.JSON_OBJECT
 
-  override fun compactJson(): JsonElement = TODO("Not yet implemented")
+  override fun compactJson(): JsonObject = TODO("Not yet implemented")
 
   override fun asJsonObject(): JsonObjectInstance = this
 

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultJsonObjectInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultJsonObjectInstance.kt
@@ -1,0 +1,26 @@
+package io.ably.lib.`object`.instance.types
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.ValueType
+import io.ably.lib.`object`.instance.DefaultInstance
+
+/**
+ * Default implementation of [JsonObjectInstance], a read-only primitive view that only adds
+ * a type-narrowed, non-null [value]; left unimplemented for now.
+ *
+ * Spec: RTTS10c
+ */
+internal class DefaultJsonObjectInstance(
+  channelObject: DefaultRealtimeObject,
+) : DefaultInstance(channelObject), JsonObjectInstance {
+
+  override fun getType(): ValueType = ValueType.JSON_OBJECT
+
+  override fun compactJson(): JsonElement = TODO("Not yet implemented")
+
+  override fun asJsonObject(): JsonObjectInstance = this
+
+  override fun value(): JsonObject = TODO("Not yet implemented")
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultLiveCounterInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultLiveCounterInstance.kt
@@ -1,6 +1,6 @@
 package io.ably.lib.`object`.instance.types
 
-import com.google.gson.JsonElement
+import com.google.gson.JsonPrimitive
 import io.ably.lib.`object`.DefaultRealtimeObject
 import io.ably.lib.`object`.Subscription
 import io.ably.lib.`object`.ValueType
@@ -21,7 +21,7 @@ internal class DefaultLiveCounterInstance(
 
   override fun getType(): ValueType = ValueType.LIVE_COUNTER
 
-  override fun compactJson(): JsonElement = TODO("Not yet implemented")
+  override fun compactJson(): JsonPrimitive = TODO("Not yet implemented")
 
   override fun asLiveCounter(): LiveCounterInstance = this
 

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultLiveCounterInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultLiveCounterInstance.kt
@@ -1,0 +1,46 @@
+package io.ably.lib.`object`.instance.types
+
+import com.google.gson.JsonElement
+import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.Subscription
+import io.ably.lib.`object`.ValueType
+import io.ably.lib.`object`.instance.DefaultInstance
+import io.ably.lib.`object`.instance.InstanceListener
+import io.ably.lib.`object`.onceSubscription
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Default implementation of [LiveCounterInstance], adding counter operations and subscribe
+ * on top of [DefaultInstance]; all left unimplemented for now.
+ *
+ * Spec: RTTS10b
+ */
+internal class DefaultLiveCounterInstance(
+  channelObject: DefaultRealtimeObject,
+) : DefaultInstance(channelObject), LiveCounterInstance {
+
+  override fun getType(): ValueType = ValueType.LIVE_COUNTER
+
+  override fun compactJson(): JsonElement = TODO("Not yet implemented")
+
+  override fun asLiveCounter(): LiveCounterInstance = this
+
+  override fun getId(): String = TODO("Not yet implemented")
+
+  override fun value(): Double = TODO("Not yet implemented")
+
+  override fun increment(): CompletableFuture<Void> = TODO("Not yet implemented")
+
+  override fun increment(amount: Number): CompletableFuture<Void> = TODO("Not yet implemented")
+
+  override fun decrement(): CompletableFuture<Void> = TODO("Not yet implemented")
+
+  override fun decrement(amount: Number): CompletableFuture<Void> = TODO("Not yet implemented")
+
+  override fun subscribe(listener: InstanceListener): Subscription {
+    // TODO - subscribe logic goes here
+    return onceSubscription {
+      // TODO - remove InstanceListener
+    }
+  }
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultLiveCounterInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultLiveCounterInstance.kt
@@ -21,23 +21,42 @@ internal class DefaultLiveCounterInstance(
 
   override fun getType(): ValueType = ValueType.LIVE_COUNTER
 
-  override fun compactJson(): JsonPrimitive = TODO("Not yet implemented")
+  override fun compactJson(): JsonPrimitive {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    TODO("Not yet implemented")
+  }
 
   override fun asLiveCounter(): LiveCounterInstance = this
 
   override fun getId(): String = TODO("Not yet implemented")
 
-  override fun value(): Double = TODO("Not yet implemented")
+  override fun value(): Double {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    TODO("Not yet implemented")
+  }
 
-  override fun increment(): CompletableFuture<Void> = TODO("Not yet implemented")
+  override fun increment(): CompletableFuture<Void> {
+    channelObject.throwIfInvalidWriteApiConfiguration()
+    TODO("Not yet implemented")
+  }
 
-  override fun increment(amount: Number): CompletableFuture<Void> = TODO("Not yet implemented")
+  override fun increment(amount: Number): CompletableFuture<Void> {
+    channelObject.throwIfInvalidWriteApiConfiguration()
+    TODO("Not yet implemented")
+  }
 
-  override fun decrement(): CompletableFuture<Void> = TODO("Not yet implemented")
+  override fun decrement(): CompletableFuture<Void> {
+    channelObject.throwIfInvalidWriteApiConfiguration()
+    TODO("Not yet implemented")
+  }
 
-  override fun decrement(amount: Number): CompletableFuture<Void> = TODO("Not yet implemented")
+  override fun decrement(amount: Number): CompletableFuture<Void> {
+    channelObject.throwIfInvalidWriteApiConfiguration()
+    TODO("Not yet implemented")
+  }
 
   override fun subscribe(listener: InstanceListener): Subscription {
+    channelObject.throwIfInvalidAccessApiConfiguration()
     // TODO - subscribe logic goes here
     return onceSubscription {
       // TODO - remove InstanceListener

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultLiveMapInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultLiveMapInstance.kt
@@ -1,0 +1,53 @@
+package io.ably.lib.`object`.instance.types
+
+import com.google.gson.JsonElement
+import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.Subscription
+import io.ably.lib.`object`.ValueType
+import io.ably.lib.`object`.instance.DefaultInstance
+import io.ably.lib.`object`.instance.Instance
+import io.ably.lib.`object`.instance.InstanceListener
+import io.ably.lib.`object`.onceSubscription
+import io.ably.lib.`object`.value.LiveMapValue
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Default implementation of [LiveMapInstance], adding map reads, writes and subscribe on top
+ * of [DefaultInstance]; all left unimplemented for now.
+ *
+ * Spec: RTTS10a
+ */
+internal class DefaultLiveMapInstance(
+  channelObject: DefaultRealtimeObject,
+) : DefaultInstance(channelObject), LiveMapInstance {
+
+  override fun getType(): ValueType = ValueType.LIVE_MAP
+
+  override fun compactJson(): JsonElement = TODO("Not yet implemented")
+
+  override fun asLiveMap(): LiveMapInstance = this
+
+  override fun getId(): String = TODO("Not yet implemented")
+
+  @Suppress("RedundantNullableReturnType")
+  override fun get(key: String): Instance? = TODO("Not yet implemented")
+
+  override fun entries(): Iterable<Map.Entry<String, Instance>> = TODO("Not yet implemented")
+
+  override fun keys(): Iterable<String> = TODO("Not yet implemented")
+
+  override fun values(): Iterable<Instance> = TODO("Not yet implemented")
+
+  override fun size(): Long = TODO("Not yet implemented")
+
+  override fun set(key: String, value: LiveMapValue): CompletableFuture<Void> = TODO("Not yet implemented")
+
+  override fun remove(key: String): CompletableFuture<Void> = TODO("Not yet implemented")
+
+  override fun subscribe(listener: InstanceListener): Subscription {
+    // TODO - subscribe logic goes here
+    return onceSubscription {
+      // TODO - remove InstanceListener
+    }
+  }
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultLiveMapInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultLiveMapInstance.kt
@@ -1,6 +1,6 @@
 package io.ably.lib.`object`.instance.types
 
-import com.google.gson.JsonElement
+import com.google.gson.JsonObject
 import io.ably.lib.`object`.DefaultRealtimeObject
 import io.ably.lib.`object`.Subscription
 import io.ably.lib.`object`.ValueType
@@ -23,7 +23,7 @@ internal class DefaultLiveMapInstance(
 
   override fun getType(): ValueType = ValueType.LIVE_MAP
 
-  override fun compactJson(): JsonElement = TODO("Not yet implemented")
+  override fun compactJson(): JsonObject = TODO("Not yet implemented")
 
   override fun asLiveMap(): LiveMapInstance = this
 

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultLiveMapInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultLiveMapInstance.kt
@@ -23,28 +23,53 @@ internal class DefaultLiveMapInstance(
 
   override fun getType(): ValueType = ValueType.LIVE_MAP
 
-  override fun compactJson(): JsonObject = TODO("Not yet implemented")
+  override fun compactJson(): JsonObject {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    TODO("Not yet implemented")
+  }
 
   override fun asLiveMap(): LiveMapInstance = this
 
   override fun getId(): String = TODO("Not yet implemented")
 
   @Suppress("RedundantNullableReturnType")
-  override fun get(key: String): Instance? = TODO("Not yet implemented")
+  override fun get(key: String): Instance? {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    TODO("Not yet implemented")
+  }
 
-  override fun entries(): Iterable<Map.Entry<String, Instance>> = TODO("Not yet implemented")
+  override fun entries(): Iterable<Map.Entry<String, Instance>> {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    TODO("Not yet implemented")
+  }
 
-  override fun keys(): Iterable<String> = TODO("Not yet implemented")
+  override fun keys(): Iterable<String> {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    TODO("Not yet implemented")
+  }
 
-  override fun values(): Iterable<Instance> = TODO("Not yet implemented")
+  override fun values(): Iterable<Instance> {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    TODO("Not yet implemented")
+  }
 
-  override fun size(): Long = TODO("Not yet implemented")
+  override fun size(): Long {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    TODO("Not yet implemented")
+  }
 
-  override fun set(key: String, value: LiveMapValue): CompletableFuture<Void> = TODO("Not yet implemented")
+  override fun set(key: String, value: LiveMapValue): CompletableFuture<Void> {
+    channelObject.throwIfInvalidWriteApiConfiguration()
+    TODO("Not yet implemented")
+  }
 
-  override fun remove(key: String): CompletableFuture<Void> = TODO("Not yet implemented")
+  override fun remove(key: String): CompletableFuture<Void> {
+    channelObject.throwIfInvalidWriteApiConfiguration()
+    TODO("Not yet implemented")
+  }
 
   override fun subscribe(listener: InstanceListener): Subscription {
+    channelObject.throwIfInvalidAccessApiConfiguration()
     // TODO - subscribe logic goes here
     return onceSubscription {
       // TODO - remove InstanceListener

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultNumberInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultNumberInstance.kt
@@ -17,9 +17,15 @@ internal class DefaultNumberInstance(
 
   override fun getType(): ValueType = ValueType.NUMBER
 
-  override fun compactJson(): JsonPrimitive = TODO("Not yet implemented")
+  override fun compactJson(): JsonPrimitive {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    TODO("Not yet implemented")
+  }
 
   override fun asNumber(): NumberInstance = this
 
-  override fun value(): Number = TODO("Not yet implemented")
+  override fun value(): Number {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    TODO("Not yet implemented")
+  }
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultNumberInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultNumberInstance.kt
@@ -1,0 +1,25 @@
+package io.ably.lib.`object`.instance.types
+
+import com.google.gson.JsonElement
+import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.ValueType
+import io.ably.lib.`object`.instance.DefaultInstance
+
+/**
+ * Default implementation of [NumberInstance], a read-only primitive view that only adds a
+ * type-narrowed, non-null [value]; left unimplemented for now.
+ *
+ * Spec: RTTS10c
+ */
+internal class DefaultNumberInstance(
+  channelObject: DefaultRealtimeObject,
+) : DefaultInstance(channelObject), NumberInstance {
+
+  override fun getType(): ValueType = ValueType.NUMBER
+
+  override fun compactJson(): JsonElement = TODO("Not yet implemented")
+
+  override fun asNumber(): NumberInstance = this
+
+  override fun value(): Number = TODO("Not yet implemented")
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultNumberInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultNumberInstance.kt
@@ -1,6 +1,6 @@
 package io.ably.lib.`object`.instance.types
 
-import com.google.gson.JsonElement
+import com.google.gson.JsonPrimitive
 import io.ably.lib.`object`.DefaultRealtimeObject
 import io.ably.lib.`object`.ValueType
 import io.ably.lib.`object`.instance.DefaultInstance
@@ -17,7 +17,7 @@ internal class DefaultNumberInstance(
 
   override fun getType(): ValueType = ValueType.NUMBER
 
-  override fun compactJson(): JsonElement = TODO("Not yet implemented")
+  override fun compactJson(): JsonPrimitive = TODO("Not yet implemented")
 
   override fun asNumber(): NumberInstance = this
 

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultStringInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultStringInstance.kt
@@ -17,9 +17,15 @@ internal class DefaultStringInstance(
 
   override fun getType(): ValueType = ValueType.STRING
 
-  override fun compactJson(): JsonPrimitive = TODO("Not yet implemented")
+  override fun compactJson(): JsonPrimitive {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    TODO("Not yet implemented")
+  }
 
   override fun asString(): StringInstance = this
 
-  override fun value(): String = TODO("Not yet implemented")
+  override fun value(): String {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    TODO("Not yet implemented")
+  }
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultStringInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultStringInstance.kt
@@ -1,6 +1,6 @@
 package io.ably.lib.`object`.instance.types
 
-import com.google.gson.JsonElement
+import com.google.gson.JsonPrimitive
 import io.ably.lib.`object`.DefaultRealtimeObject
 import io.ably.lib.`object`.ValueType
 import io.ably.lib.`object`.instance.DefaultInstance
@@ -17,7 +17,7 @@ internal class DefaultStringInstance(
 
   override fun getType(): ValueType = ValueType.STRING
 
-  override fun compactJson(): JsonElement = TODO("Not yet implemented")
+  override fun compactJson(): JsonPrimitive = TODO("Not yet implemented")
 
   override fun asString(): StringInstance = this
 

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultStringInstance.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/instance/types/DefaultStringInstance.kt
@@ -1,0 +1,25 @@
+package io.ably.lib.`object`.instance.types
+
+import com.google.gson.JsonElement
+import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.ValueType
+import io.ably.lib.`object`.instance.DefaultInstance
+
+/**
+ * Default implementation of [StringInstance], a read-only primitive view that only adds a
+ * type-narrowed, non-null [value]; left unimplemented for now.
+ *
+ * Spec: RTTS10c
+ */
+internal class DefaultStringInstance(
+  channelObject: DefaultRealtimeObject,
+) : DefaultInstance(channelObject), StringInstance {
+
+  override fun getType(): ValueType = ValueType.STRING
+
+  override fun compactJson(): JsonElement = TODO("Not yet implemented")
+
+  override fun asString(): StringInstance = this
+
+  override fun value(): String = TODO("Not yet implemented")
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/message/DefaultObjectMessage.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/message/DefaultObjectMessage.kt
@@ -1,0 +1,146 @@
+package io.ably.lib.`object`.message
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import io.ably.lib.`object`.objectStateError
+import java.util.*
+
+/**
+ * Builds the user-facing PublicAPI::ObjectMessage from an inbound wire
+ * ObjectMessage that carried an operation. Mirrors ably-js
+ * `objectmessage.ts#toUserFacingMessage`.
+ *
+ * Precondition (PAOM3a1): the source message has its `operation` populated.
+ *
+ * Spec: PAOM3
+ */
+internal fun WireObjectMessage.toPublicMessage(channelName: String): ObjectMessage =
+  DefaultObjectMessage(this, channelName)
+
+/**
+ * PublicAPI::ObjectMessage implementation - a read-only view over the source
+ * wire message. Spec: PAOM1, PAOM2
+ */
+internal class DefaultObjectMessage(
+  private val message: WireObjectMessage,
+  private val channelName: String,
+) : ObjectMessage {
+
+  private val operation: ObjectOperation = DefaultObjectOperation(
+    message.operation ?: throw objectStateError("Cannot build public ObjectMessage without an operation") // PAOM3a1
+  )
+
+  override fun getId(): String? = message.id // PAOM2a
+  override fun getClientId(): String? = message.clientId // PAOM2b
+  override fun getConnectionId(): String? = message.connectionId // PAOM2c
+  override fun getTimestamp(): Long? = message.timestamp // PAOM2d
+  override fun getChannel(): String = channelName // PAOM2e, PAOM3b
+  override fun getOperation(): ObjectOperation = operation // PAOM2f
+  override fun getSerial(): String? = message.serial // PAOM2g
+  override fun getSerialTimestamp(): Long? = message.serialTimestamp // PAOM2h
+  override fun getSiteCode(): String? = message.siteCode // PAOM2i
+  override fun getExtras(): JsonObject? = message.extras // PAOM2j
+}
+
+/**
+ * PublicAPI::ObjectOperation implementation. Resolves the outbound-only
+ * `*CreateWithObjectId` variants back to their derived MapCreate/CounterCreate
+ * forms. Spec: PAOOP1, PAOOP2, PAOOP3
+ */
+internal class DefaultObjectOperation(private val operation: WireObjectOperation) : ObjectOperation {
+
+  override fun getAction(): ObjectOperationAction = operation.action.toPublic() // PAOOP2a
+
+  override fun getObjectId(): String = operation.objectId // PAOOP2b
+
+  // PAOOP3b - prefer mapCreate, else the MapCreate the WithObjectId variant was derived from
+  override fun getMapCreate(): MapCreate? =
+    (operation.mapCreate ?: operation.mapCreateWithObjectId?.derivedFrom)?.let { DefaultMapCreate(it) }
+
+  override fun getMapSet(): MapSet? = operation.mapSet?.let { DefaultMapSet(it) } // PAOOP2d
+
+  override fun getMapRemove(): MapRemove? = operation.mapRemove?.let { DefaultMapRemove(it) } // PAOOP2e
+
+  // PAOOP3c - prefer counterCreate, else the derived CounterCreate
+  override fun getCounterCreate(): CounterCreate? =
+    (operation.counterCreate ?: operation.counterCreateWithObjectId?.derivedFrom)?.let { DefaultCounterCreate(it) }
+
+  override fun getCounterInc(): CounterInc? = operation.counterInc?.let { DefaultCounterInc(it) } // PAOOP2g
+
+  override fun getObjectDelete(): ObjectDelete? = operation.objectDelete?.let { DefaultObjectDelete } // PAOOP2h
+
+  override fun getMapClear(): MapClear? = operation.mapClear?.let { DefaultMapClear } // PAOOP2i
+}
+
+/** Spec: MCR2 */
+internal class DefaultMapCreate(private val mapCreate: WireMapCreate) : MapCreate {
+  override fun getSemantics(): ObjectsMapSemantics = mapCreate.semantics.toPublic()
+  override fun getEntries(): Map<String, ObjectsMapEntry> =
+    Collections.unmodifiableMap(mapCreate.entries.mapValues { (_, entry) -> DefaultObjectsMapEntry(entry) })
+}
+
+/** Spec: MST2 */
+internal class DefaultMapSet(private val mapSet: WireMapSet) : MapSet {
+  override fun getKey(): String = mapSet.key
+  override fun getValue(): ObjectData = DefaultObjectData(mapSet.value)
+}
+
+/** Spec: MRM2 */
+internal class DefaultMapRemove(private val mapRemove: WireMapRemove) : MapRemove {
+  override fun getKey(): String = mapRemove.key
+}
+
+/** Spec: CCR2 */
+internal class DefaultCounterCreate(private val counterCreate: WireCounterCreate) : CounterCreate {
+  override fun getCount(): Double = counterCreate.count
+}
+
+/** Spec: CIN2 */
+internal class DefaultCounterInc(private val counterInc: WireCounterInc) : CounterInc {
+  override fun getNumber(): Double = counterInc.number
+}
+
+/** Spec: ODE2 - no attributes */
+internal object DefaultObjectDelete : ObjectDelete
+
+/** Spec: MCL2 - no attributes */
+internal object DefaultMapClear : MapClear
+
+/** Spec: OME2 */
+internal class DefaultObjectsMapEntry(private val entry: WireObjectsMapEntry) : ObjectsMapEntry {
+  override fun getTombstone(): Boolean? = entry.tombstone
+  override fun getTimeserial(): String? = entry.timeserial
+  override fun getSerialTimestamp(): Long? = entry.serialTimestamp
+  override fun getData(): ObjectData? = entry.data?.let { DefaultObjectData(it) }
+}
+
+/**
+ * Decoded public ObjectData: binary is delivered decoded (the wire form is
+ * base64); there is no `encoding` field in the public shape. Spec: OD2
+ */
+internal class DefaultObjectData(private val data: WireObjectData) : ObjectData {
+  override fun getObjectId(): String? = data.objectId
+  override fun getString(): String? = data.string
+  override fun getNumber(): Double? = data.number
+  override fun getBoolean(): Boolean? = data.boolean
+  override fun getBytes(): ByteArray? = data.bytes?.let { Base64.getDecoder().decode(it) }
+  override fun getJson(): JsonElement? = data.json
+}
+
+/** Internal action -> public enum; unrecognized wire values map to UNKNOWN. Spec: PAOOP2a, OOP2 */
+internal fun WireObjectOperationAction.toPublic(): ObjectOperationAction = when (this) {
+  WireObjectOperationAction.MapCreate -> ObjectOperationAction.MAP_CREATE
+  WireObjectOperationAction.MapSet -> ObjectOperationAction.MAP_SET
+  WireObjectOperationAction.MapRemove -> ObjectOperationAction.MAP_REMOVE
+  WireObjectOperationAction.CounterCreate -> ObjectOperationAction.COUNTER_CREATE
+  WireObjectOperationAction.CounterInc -> ObjectOperationAction.COUNTER_INC
+  WireObjectOperationAction.ObjectDelete -> ObjectOperationAction.OBJECT_DELETE
+  WireObjectOperationAction.MapClear -> ObjectOperationAction.MAP_CLEAR
+  WireObjectOperationAction.Unknown -> ObjectOperationAction.UNKNOWN
+}
+
+/** Internal semantics -> public enum. Spec: OMP2 */
+internal fun WireObjectsMapSemantics.toPublic(): ObjectsMapSemantics = when (this) {
+  WireObjectsMapSemantics.LWW -> ObjectsMapSemantics.LWW
+  WireObjectsMapSemantics.Unknown -> ObjectsMapSemantics.UNKNOWN
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/message/WireObjectMessage.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/message/WireObjectMessage.kt
@@ -1,0 +1,297 @@
+package io.ably.lib.`object`.message
+
+import com.google.gson.Gson
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+/**
+ * Wire-level object model for the path-based public API implementation.
+ *
+ * Copied from the legacy internal model (`io.ably.lib.objects.ObjectMessage`)
+ * so that this package has no dependency on `io.ably.lib.objects`. The `Wire`
+ * prefix distinguishes these internal carriers from the public interfaces in
+ * `io.ably.lib.object.message`.
+ *
+ * Spec: OM*, OOP*, OD*, MCR*, MST*, MRM*, CCR*, CIN*, ODE*, MCL*, OME*, MCRO*, CCRO*, OMP*, OCN*, OST*
+ */
+
+/** Spec: OOP2 */
+internal enum class WireObjectOperationAction(val code: Int) {
+  MapCreate(0),
+  MapSet(1),
+  MapRemove(2),
+  CounterCreate(3),
+  CounterInc(4),
+  ObjectDelete(5),
+  MapClear(6),
+  Unknown(-1); // code for unknown value during deserialization
+}
+
+/** Spec: OMP2 */
+internal enum class WireObjectsMapSemantics(val code: Int) {
+  LWW(0),
+  Unknown(-1); // code for unknown value during deserialization
+}
+
+/** Spec: OD1, OD2 - binary carried as base64 string on the wire */
+internal data class WireObjectData(
+  val objectId: String? = null, // OD2a
+  val string: String? = null, // OD2f
+  val number: Double? = null, // OD2e
+  val boolean: Boolean? = null, // OD2c
+  val bytes: String? = null, // OD2d - base64
+  val json: JsonElement? = null, // decoded JSON leaf
+)
+
+/** Spec: MCR2 */
+internal data class WireMapCreate(
+  val semantics: WireObjectsMapSemantics, // MCR2a
+  val entries: Map<String, WireObjectsMapEntry>, // MCR2b
+)
+
+/** Spec: MST2 */
+internal data class WireMapSet(
+  val key: String, // MST2a
+  val value: WireObjectData, // MST2b
+)
+
+/** Spec: MRM2 */
+internal data class WireMapRemove(
+  val key: String, // MRM2a
+)
+
+/** Spec: CCR2 */
+internal data class WireCounterCreate(
+  val count: Double, // CCR2a
+)
+
+/** Spec: CIN2 */
+internal data class WireCounterInc(
+  val number: Double, // CIN2a
+)
+
+/** Spec: ODE2 - no attributes */
+internal object WireObjectDelete
+
+/** Spec: MCL2 - no attributes */
+internal object WireMapClear
+
+/** Spec: MCRO2 */
+internal data class WireMapCreateWithObjectId(
+  val initialValue: String, // MCRO2a
+  val nonce: String, // MCRO2b
+  @Transient val derivedFrom: WireMapCreate? = null, // RTLMV4j5 - local use only
+)
+
+/** Spec: CCRO2 */
+internal data class WireCounterCreateWithObjectId(
+  val initialValue: String, // CCRO2a
+  val nonce: String, // CCRO2b
+  @Transient val derivedFrom: WireCounterCreate? = null, // RTLCV4g5 - local use only
+)
+
+/** Spec: OME2 */
+internal data class WireObjectsMapEntry(
+  val tombstone: Boolean? = null, // OME2a
+  val timeserial: String? = null, // OME2b
+  val serialTimestamp: Long? = null, // OME2d
+  val data: WireObjectData? = null, // OME2c
+)
+
+/** Spec: OMP1 */
+internal data class WireObjectsMap(
+  val semantics: WireObjectsMapSemantics? = null, // OMP3a
+  val entries: Map<String, WireObjectsMapEntry>? = null, // OMP3b
+  val clearTimeserial: String? = null, // OMP3c
+)
+
+/** Spec: OCN1 */
+internal data class WireObjectsCounter(
+  val count: Double? = null, // OCN2a
+)
+
+/** Spec: OOP3 */
+internal data class WireObjectOperation(
+  val action: WireObjectOperationAction, // OOP3a
+  val objectId: String, // OOP3b
+  val mapCreate: WireMapCreate? = null, // OOP3j
+  val mapSet: WireMapSet? = null, // OOP3k
+  val mapRemove: WireMapRemove? = null, // OOP3l
+  val counterCreate: WireCounterCreate? = null, // OOP3m
+  val counterInc: WireCounterInc? = null, // OOP3n
+  val objectDelete: WireObjectDelete? = null, // OOP3o
+  val mapCreateWithObjectId: WireMapCreateWithObjectId? = null, // OOP3p
+  val counterCreateWithObjectId: WireCounterCreateWithObjectId? = null, // OOP3q
+  val mapClear: WireMapClear? = null, // OOP3r
+)
+
+/** Spec: OST1 */
+internal data class WireObjectState(
+  val objectId: String, // OST2a
+  val siteTimeserials: Map<String, String>, // OST2b
+  val tombstone: Boolean, // OST2c
+  val createOp: WireObjectOperation? = null, // OST2d
+  val map: WireObjectsMap? = null, // OST2e
+  val counter: WireObjectsCounter? = null, // OST2f
+)
+
+/** Spec: OM2 */
+internal data class WireObjectMessage(
+  val id: String? = null, // OM2a
+  val timestamp: Long? = null, // OM2e
+  val clientId: String? = null, // OM2b
+  val connectionId: String? = null, // OM2c
+  val extras: JsonObject? = null, // OM2d
+  val operation: WireObjectOperation? = null, // OM2f
+  val objectState: WireObjectState? = null, // OM2g - wire key "object"
+  val serial: String? = null, // OM2h
+  val serialTimestamp: Long? = null, // OM2j
+  val siteCode: String? = null, // OM2i
+)
+
+// Gson instance for serializing the opaque `extras` field during size calculation.
+// Kept file-local so this package has no dependency on `io.ably.lib.objects`.
+private val gson = Gson()
+
+/**
+ * Calculates the byte size of a string.
+ * For non-ASCII, the byte size can be 2–4x the character count. For ASCII, there is no difference.
+ * e.g. "Hello" has a byte size of 5, while "你" has a byte size of 3 and "😊" has a byte size of 4.
+ */
+private val String.byteSize: Int
+  get() = this.toByteArray(StandardCharsets.UTF_8).size
+
+/**
+ * Calculates the size of an ObjectMessage in bytes.
+ * Spec: OM3
+ */
+internal fun WireObjectMessage.size(): Int {
+  val clientIdSize = clientId?.byteSize ?: 0 // Spec: OM3f
+  val operationSize = operation?.size() ?: 0 // Spec: OM3b, OOP4
+  val objectStateSize = objectState?.size() ?: 0 // Spec: OM3c, OST3
+  val extrasSize = extras?.let { gson.toJson(it).length } ?: 0 // Spec: OM3d
+
+  return clientIdSize + operationSize + objectStateSize + extrasSize
+}
+
+/**
+ * Calculates the size of an ObjectOperation in bytes.
+ * Spec: OOP4
+ */
+private fun WireObjectOperation.size(): Int {
+  val mapCreateSize = mapCreate?.size() ?: mapCreateWithObjectId?.derivedFrom?.size() ?: 0
+  val mapSetSize = mapSet?.size() ?: 0
+  val mapRemoveSize = mapRemove?.size() ?: 0
+  val counterCreateSize = counterCreate?.size() ?: counterCreateWithObjectId?.derivedFrom?.size() ?: 0
+  val counterIncSize = counterInc?.size() ?: 0
+
+  return mapCreateSize + mapSetSize + mapRemoveSize +
+    counterCreateSize + counterIncSize
+}
+
+/**
+ * Calculates the size of an ObjectState in bytes.
+ * Spec: OST3
+ */
+private fun WireObjectState.size(): Int {
+  val mapSize = map?.size() ?: 0 // Spec: OST3b, OMP4
+  val counterSize = counter?.size() ?: 0 // Spec: OST3c, OCN3
+  val createOpSize = createOp?.size() ?: 0 // Spec: OST3d, OOP4
+
+  return mapSize + counterSize + createOpSize
+}
+
+/**
+ * Calculates the size of a MapCreate payload in bytes.
+ */
+private fun WireMapCreate.size(): Int {
+  return entries.entries.sumOf { it.key.byteSize + it.value.size() }
+}
+
+/**
+ * Calculates the size of a MapSet payload in bytes.
+ */
+private fun WireMapSet.size(): Int {
+  return key.byteSize + value.size()
+}
+
+/**
+ * Calculates the size of a MapRemove payload in bytes.
+ */
+private fun WireMapRemove.size(): Int {
+  return key.byteSize
+}
+
+/**
+ * Calculates the size of a CounterCreate payload in bytes.
+ */
+private fun WireCounterCreate.size(): Int {
+  return 8 // Double is 8 bytes
+}
+
+/**
+ * Calculates the size of a CounterInc payload in bytes.
+ */
+private fun WireCounterInc.size(): Int {
+  return 8 // Double is 8 bytes
+}
+
+/**
+ * Calculates the size of a MapCreateWithObjectId payload in bytes.
+ */
+private fun WireMapCreateWithObjectId.size(): Int {
+  return initialValue.byteSize + nonce.byteSize
+}
+
+/**
+ * Calculates the size of a CounterCreateWithObjectId payload in bytes.
+ */
+private fun WireCounterCreateWithObjectId.size(): Int {
+  return initialValue.byteSize + nonce.byteSize
+}
+
+/**
+ * Calculates the size of an ObjectMap in bytes.
+ * Spec: OMP4
+ */
+private fun WireObjectsMap.size(): Int {
+  // Calculate the size of all map entries in the map property
+  val entriesSize = entries?.entries?.sumOf {
+    it.key.length + it.value.size() // // Spec: OMP4a1, OMP4a2
+  } ?: 0
+
+  return entriesSize
+}
+
+/**
+ * Calculates the size of an ObjectCounter in bytes.
+ * Spec: OCN3
+ */
+private fun WireObjectsCounter.size(): Int {
+  // Size is 8 if count is a number, 0 if count is null or omitted
+  return if (count != null) 8 else 0
+}
+
+/**
+ * Calculates the size of a MapEntry in bytes.
+ * Spec: OME3
+ */
+private fun WireObjectsMapEntry.size(): Int {
+  // The size is equal to the size of the data property, calculated per "OD3"
+  return data?.size() ?: 0
+}
+
+/**
+ * Calculates the size of an ObjectData in bytes.
+ * Spec: OD3
+ */
+private fun WireObjectData.size(): Int {
+  string?.let { return it.byteSize } // Spec: OD3e
+  number?.let { return 8 } // Spec: OD3d
+  boolean?.let { return 1 } // Spec: OD3b
+  bytes?.let { return Base64.getDecoder().decode(it).size } // Spec: OD3c
+  json?.let { return it.toString().byteSize } // Spec: OD3e
+  return 0
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/DefaultPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/DefaultPathObject.kt
@@ -44,9 +44,20 @@ internal open class DefaultPathObject(
 
   override fun getType(): ValueType? = resolveValueAtPath(path)?.valueType()
 
-  override fun instance(): Instance? = TODO("Not yet implemented")
+  override fun instance(): Instance? {
+    val resolvedValue = resolveValueAtPath(path) ?: return null // unresolved path -> no instance
+    return when (resolvedValue) {
+      is ResolvedValue.Leaf -> null // primitives have no Instance; only live objects do
+      // TODO - wrap the resolved live object (LiveMap/LiveCounter) in an Instance
+      is ResolvedValue.MapRef, is ResolvedValue.CounterRef -> TODO("Not yet implemented")
+    }
+  }
 
-  override fun compactJson(): JsonElement? = TODO("Not yet implemented")
+  override fun compactJson(): JsonElement? {
+    resolveValueAtPath(path) ?: return null // unresolved path -> null
+    // TODO - build the compacted JSON snapshot (LiveMap -> JsonObject, LiveCounter -> number, leaf -> JSON value)
+    TODO("Not yet implemented")
+  }
 
   override fun exists(): Boolean = resolveValueAtPath(path) != null
 

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/DefaultPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/DefaultPathObject.kt
@@ -1,0 +1,74 @@
+package io.ably.lib.`object`.path
+
+import com.google.gson.JsonElement
+import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.Subscription
+import io.ably.lib.`object`.ValueType
+import io.ably.lib.`object`.instance.Instance
+import io.ably.lib.`object`.onceSubscription
+import io.ably.lib.`object`.path.types.BinaryPathObject
+import io.ably.lib.`object`.path.types.BooleanPathObject
+import io.ably.lib.`object`.path.types.DefaultBinaryPathObject
+import io.ably.lib.`object`.path.types.DefaultBooleanPathObject
+import io.ably.lib.`object`.path.types.DefaultJsonArrayPathObject
+import io.ably.lib.`object`.path.types.DefaultJsonObjectPathObject
+import io.ably.lib.`object`.path.types.DefaultLiveCounterPathObject
+import io.ably.lib.`object`.path.types.DefaultLiveMapPathObject
+import io.ably.lib.`object`.path.types.DefaultNumberPathObject
+import io.ably.lib.`object`.path.types.DefaultStringPathObject
+import io.ably.lib.`object`.path.types.JsonArrayPathObject
+import io.ably.lib.`object`.path.types.JsonObjectPathObject
+import io.ably.lib.`object`.path.types.LiveCounterPathObject
+import io.ably.lib.`object`.path.types.LiveMapPathObject
+import io.ably.lib.`object`.path.types.NumberPathObject
+import io.ably.lib.`object`.path.types.StringPathObject
+
+/**
+ * Default implementation of [PathObject], the untyped node in the path-addressed view of
+ * the LiveObjects graph.
+ *
+ * This is a skeleton. The `as*` casts return a typed view of the same position; the
+ * operations that require resolving the path against the live objects graph are left
+ * unimplemented for now and will be filled in as the path-based API is built out.
+ *
+ * Spec: RTPO1, RTPO2, RTTS3
+ */
+internal open class DefaultPathObject(
+  internal val channelObject: DefaultRealtimeObject,
+) : PathObject {
+
+  override fun path(): String = TODO("Not yet implemented")
+
+  override fun getType(): ValueType = TODO("Not yet implemented")
+
+  override fun instance(): Instance? = TODO("Not yet implemented")
+
+  override fun compactJson(): JsonElement? = TODO("Not yet implemented")
+
+  override fun exists(): Boolean = TODO("Not yet implemented")
+
+  override fun asLiveMap(): LiveMapPathObject = DefaultLiveMapPathObject(channelObject)
+
+  override fun asLiveCounter(): LiveCounterPathObject = DefaultLiveCounterPathObject(channelObject)
+
+  override fun asNumber(): NumberPathObject = DefaultNumberPathObject(channelObject)
+
+  override fun asString(): StringPathObject = DefaultStringPathObject(channelObject)
+
+  override fun asBoolean(): BooleanPathObject = DefaultBooleanPathObject(channelObject)
+
+  override fun asBinary(): BinaryPathObject = DefaultBinaryPathObject(channelObject)
+
+  override fun asJsonObject(): JsonObjectPathObject = DefaultJsonObjectPathObject(channelObject)
+
+  override fun asJsonArray(): JsonArrayPathObject = DefaultJsonArrayPathObject(channelObject)
+
+  override fun subscribe(listener: PathObjectListener): Subscription = subscribe(listener, null)
+
+  override fun subscribe(listener: PathObjectListener, options: PathObjectSubscriptionOptions?): Subscription {
+    // TODO - subscribe logic goes here
+    return onceSubscription {
+      // TODO - remove PathObjectListener from list
+    }
+  }
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/DefaultPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/DefaultPathObject.kt
@@ -97,6 +97,6 @@ internal open class DefaultPathObject(
 
   protected fun resolveValueAtPath(path: String): ResolvedValue? {
     // TODO - resolve the path against the live objects graph and return the value at that position
-    return null
+    TODO("Not yet implemented")
   }
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/DefaultPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/DefaultPathObject.kt
@@ -42,9 +42,13 @@ internal open class DefaultPathObject(
 
   override fun path(): String = path
 
-  override fun getType(): ValueType? = resolveValueAtPath(path)?.valueType()
+  override fun getType(): ValueType? {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    return resolveValueAtPath(path)?.valueType()
+  }
 
   override fun instance(): Instance? {
+    channelObject.throwIfInvalidAccessApiConfiguration()
     val resolvedValue = resolveValueAtPath(path) ?: return null // unresolved path -> no instance
     return when (resolvedValue) {
       is ResolvedValue.Leaf -> null // primitives have no Instance; only live objects do
@@ -54,12 +58,16 @@ internal open class DefaultPathObject(
   }
 
   override fun compactJson(): JsonElement? {
+    channelObject.throwIfInvalidAccessApiConfiguration()
     resolveValueAtPath(path) ?: return null // unresolved path -> null
     // TODO - build the compacted JSON snapshot (LiveMap -> JsonObject, LiveCounter -> number, leaf -> JSON value)
     TODO("Not yet implemented")
   }
 
-  override fun exists(): Boolean = resolveValueAtPath(path) != null
+  override fun exists(): Boolean {
+    channelObject.throwIfInvalidAccessApiConfiguration()
+    return resolveValueAtPath(path) != null
+  }
 
   override fun asLiveMap(): LiveMapPathObject = DefaultLiveMapPathObject(channelObject, path)
 
@@ -80,6 +88,7 @@ internal open class DefaultPathObject(
   override fun subscribe(listener: PathObjectListener): Subscription = subscribe(listener, null)
 
   override fun subscribe(listener: PathObjectListener, options: PathObjectSubscriptionOptions?): Subscription {
+    channelObject.throwIfInvalidAccessApiConfiguration()
     // TODO - subscribe logic goes here
     return onceSubscription {
       // TODO - remove PathObjectListener from list

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/DefaultPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/DefaultPathObject.kt
@@ -22,6 +22,8 @@ import io.ably.lib.`object`.path.types.LiveCounterPathObject
 import io.ably.lib.`object`.path.types.LiveMapPathObject
 import io.ably.lib.`object`.path.types.NumberPathObject
 import io.ably.lib.`object`.path.types.StringPathObject
+import io.ably.lib.`object`.value.ResolvedValue
+import io.ably.lib.`object`.value.valueType
 
 /**
  * Default implementation of [PathObject], the untyped node in the path-addressed view of
@@ -35,33 +37,34 @@ import io.ably.lib.`object`.path.types.StringPathObject
  */
 internal open class DefaultPathObject(
   internal val channelObject: DefaultRealtimeObject,
+  internal val path: String
 ) : PathObject {
 
-  override fun path(): String = TODO("Not yet implemented")
+  override fun path(): String = path
 
-  override fun getType(): ValueType = TODO("Not yet implemented")
+  override fun getType(): ValueType? = resolveValueAtPath(path)?.valueType()
 
   override fun instance(): Instance? = TODO("Not yet implemented")
 
   override fun compactJson(): JsonElement? = TODO("Not yet implemented")
 
-  override fun exists(): Boolean = TODO("Not yet implemented")
+  override fun exists(): Boolean = resolveValueAtPath(path) != null
 
-  override fun asLiveMap(): LiveMapPathObject = DefaultLiveMapPathObject(channelObject)
+  override fun asLiveMap(): LiveMapPathObject = DefaultLiveMapPathObject(channelObject, path)
 
-  override fun asLiveCounter(): LiveCounterPathObject = DefaultLiveCounterPathObject(channelObject)
+  override fun asLiveCounter(): LiveCounterPathObject = DefaultLiveCounterPathObject(channelObject, path)
 
-  override fun asNumber(): NumberPathObject = DefaultNumberPathObject(channelObject)
+  override fun asNumber(): NumberPathObject = DefaultNumberPathObject(channelObject, path)
 
-  override fun asString(): StringPathObject = DefaultStringPathObject(channelObject)
+  override fun asString(): StringPathObject = DefaultStringPathObject(channelObject, path)
 
-  override fun asBoolean(): BooleanPathObject = DefaultBooleanPathObject(channelObject)
+  override fun asBoolean(): BooleanPathObject = DefaultBooleanPathObject(channelObject, path)
 
-  override fun asBinary(): BinaryPathObject = DefaultBinaryPathObject(channelObject)
+  override fun asBinary(): BinaryPathObject = DefaultBinaryPathObject(channelObject, path)
 
-  override fun asJsonObject(): JsonObjectPathObject = DefaultJsonObjectPathObject(channelObject)
+  override fun asJsonObject(): JsonObjectPathObject = DefaultJsonObjectPathObject(channelObject, path)
 
-  override fun asJsonArray(): JsonArrayPathObject = DefaultJsonArrayPathObject(channelObject)
+  override fun asJsonArray(): JsonArrayPathObject = DefaultJsonArrayPathObject(channelObject, path)
 
   override fun subscribe(listener: PathObjectListener): Subscription = subscribe(listener, null)
 
@@ -70,5 +73,10 @@ internal open class DefaultPathObject(
     return onceSubscription {
       // TODO - remove PathObjectListener from list
     }
+  }
+
+  protected fun resolveValueAtPath(path: String): ResolvedValue? {
+    // TODO - resolve the path against the live objects graph and return the value at that position
+    return null
   }
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/DefaultPathObjectSubscriptionEvent.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/DefaultPathObjectSubscriptionEvent.kt
@@ -10,11 +10,11 @@ import io.ably.lib.`object`.message.ObjectMessage
  * Spec: RTPO19e / RTTS3d
  */
 internal class DefaultPathObjectSubscriptionEvent(
-  private val objectAt: PathObject,
+  private val pathObject: PathObject,
   private val message: ObjectMessage?,
 ) : PathObjectSubscriptionEvent {
 
-  override fun getObject(): PathObject = objectAt
+  override fun getObject(): PathObject = pathObject
 
   override fun getMessage(): ObjectMessage? = message
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/DefaultPathObjectSubscriptionEvent.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/DefaultPathObjectSubscriptionEvent.kt
@@ -1,0 +1,20 @@
+package io.ably.lib.`object`.path
+
+import io.ably.lib.`object`.message.ObjectMessage
+
+/**
+ * Default implementation of [PathObjectSubscriptionEvent], the event delivered to a
+ * [PathObjectListener] when a change affects the subscribed path. A plain holder for the
+ * changed [PathObject] and the source [ObjectMessage] (if any).
+ *
+ * Spec: RTPO19e / RTTS3d
+ */
+internal class DefaultPathObjectSubscriptionEvent(
+  private val objectAt: PathObject,
+  private val message: ObjectMessage?,
+) : PathObjectSubscriptionEvent {
+
+  override fun getObject(): PathObject = objectAt
+
+  override fun getMessage(): ObjectMessage? = message
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultBinaryPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultBinaryPathObject.kt
@@ -2,6 +2,7 @@ package io.ably.lib.`object`.path.types
 
 import io.ably.lib.`object`.DefaultRealtimeObject
 import io.ably.lib.`object`.path.DefaultPathObject
+import io.ably.lib.`object`.value.ResolvedValue
 
 /**
  * Default implementation of [BinaryPathObject], a terminal primitive view that only adds a
@@ -14,6 +15,9 @@ internal class DefaultBinaryPathObject(
   path: String,
 ) : DefaultPathObject(channelObject, path), BinaryPathObject {
 
-  @Suppress("RedundantNullableReturnType")
-  override fun value(): ByteArray? = TODO("Not yet implemented")
+  override fun value(): ByteArray? {
+    if (resolveValueAtPath(path) !is ResolvedValue.Leaf) return null // live object or unresolved -> no primitive value
+    // TODO - extract the primitive value from the resolved leaf, narrowed to ByteArray (base64-decoded)
+    TODO("Not yet implemented")
+  }
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultBinaryPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultBinaryPathObject.kt
@@ -1,0 +1,18 @@
+package io.ably.lib.`object`.path.types
+
+import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.path.DefaultPathObject
+
+/**
+ * Default implementation of [BinaryPathObject], a terminal primitive view that only adds a
+ * type-narrowed [value]; left unimplemented for now.
+ *
+ * Spec: RTTS6c
+ */
+internal class DefaultBinaryPathObject(
+  channelObject: DefaultRealtimeObject,
+) : DefaultPathObject(channelObject), BinaryPathObject {
+
+  @Suppress("RedundantNullableReturnType")
+  override fun value(): ByteArray? = TODO("Not yet implemented")
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultBinaryPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultBinaryPathObject.kt
@@ -1,8 +1,9 @@
 package io.ably.lib.`object`.path.types
 
 import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.ValueType
 import io.ably.lib.`object`.path.DefaultPathObject
-import io.ably.lib.`object`.value.ResolvedValue
+import io.ably.lib.`object`.value.valueType
 
 /**
  * Default implementation of [BinaryPathObject], a terminal primitive view that only adds a
@@ -17,7 +18,7 @@ internal class DefaultBinaryPathObject(
 
   override fun value(): ByteArray? {
     channelObject.throwIfInvalidAccessApiConfiguration()
-    if (resolveValueAtPath(path) !is ResolvedValue.Leaf) return null // live object or unresolved -> no primitive value
+    if (resolveValueAtPath(path)?.valueType() != ValueType.BINARY) return null // not a Binary value at this path -> no value
     // TODO - extract the primitive value from the resolved leaf, narrowed to ByteArray (base64-decoded)
     TODO("Not yet implemented")
   }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultBinaryPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultBinaryPathObject.kt
@@ -16,6 +16,7 @@ internal class DefaultBinaryPathObject(
 ) : DefaultPathObject(channelObject, path), BinaryPathObject {
 
   override fun value(): ByteArray? {
+    channelObject.throwIfInvalidAccessApiConfiguration()
     if (resolveValueAtPath(path) !is ResolvedValue.Leaf) return null // live object or unresolved -> no primitive value
     // TODO - extract the primitive value from the resolved leaf, narrowed to ByteArray (base64-decoded)
     TODO("Not yet implemented")

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultBinaryPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultBinaryPathObject.kt
@@ -11,7 +11,8 @@ import io.ably.lib.`object`.path.DefaultPathObject
  */
 internal class DefaultBinaryPathObject(
   channelObject: DefaultRealtimeObject,
-) : DefaultPathObject(channelObject), BinaryPathObject {
+  path: String,
+) : DefaultPathObject(channelObject, path), BinaryPathObject {
 
   @Suppress("RedundantNullableReturnType")
   override fun value(): ByteArray? = TODO("Not yet implemented")

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultBooleanPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultBooleanPathObject.kt
@@ -1,0 +1,18 @@
+package io.ably.lib.`object`.path.types
+
+import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.path.DefaultPathObject
+
+/**
+ * Default implementation of [BooleanPathObject], a terminal primitive view that only adds a
+ * type-narrowed [value]; left unimplemented for now.
+ *
+ * Spec: RTTS6c
+ */
+internal class DefaultBooleanPathObject(
+  channelObject: DefaultRealtimeObject,
+) : DefaultPathObject(channelObject), BooleanPathObject {
+
+  @Suppress("RedundantNullableReturnType")
+  override fun value(): Boolean? = TODO("Not yet implemented")
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultBooleanPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultBooleanPathObject.kt
@@ -2,6 +2,7 @@ package io.ably.lib.`object`.path.types
 
 import io.ably.lib.`object`.DefaultRealtimeObject
 import io.ably.lib.`object`.path.DefaultPathObject
+import io.ably.lib.`object`.value.ResolvedValue
 
 /**
  * Default implementation of [BooleanPathObject], a terminal primitive view that only adds a
@@ -14,6 +15,9 @@ internal class DefaultBooleanPathObject(
   path: String,
 ) : DefaultPathObject(channelObject, path), BooleanPathObject {
 
-  @Suppress("RedundantNullableReturnType")
-  override fun value(): Boolean? = TODO("Not yet implemented")
+  override fun value(): Boolean? {
+    if (resolveValueAtPath(path) !is ResolvedValue.Leaf) return null // live object or unresolved -> no primitive value
+    // TODO - extract the primitive value from the resolved leaf, narrowed to Boolean
+    TODO("Not yet implemented")
+  }
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultBooleanPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultBooleanPathObject.kt
@@ -16,6 +16,7 @@ internal class DefaultBooleanPathObject(
 ) : DefaultPathObject(channelObject, path), BooleanPathObject {
 
   override fun value(): Boolean? {
+    channelObject.throwIfInvalidAccessApiConfiguration()
     if (resolveValueAtPath(path) !is ResolvedValue.Leaf) return null // live object or unresolved -> no primitive value
     // TODO - extract the primitive value from the resolved leaf, narrowed to Boolean
     TODO("Not yet implemented")

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultBooleanPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultBooleanPathObject.kt
@@ -1,8 +1,9 @@
 package io.ably.lib.`object`.path.types
 
 import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.ValueType
 import io.ably.lib.`object`.path.DefaultPathObject
-import io.ably.lib.`object`.value.ResolvedValue
+import io.ably.lib.`object`.value.valueType
 
 /**
  * Default implementation of [BooleanPathObject], a terminal primitive view that only adds a
@@ -17,7 +18,7 @@ internal class DefaultBooleanPathObject(
 
   override fun value(): Boolean? {
     channelObject.throwIfInvalidAccessApiConfiguration()
-    if (resolveValueAtPath(path) !is ResolvedValue.Leaf) return null // live object or unresolved -> no primitive value
+    if (resolveValueAtPath(path)?.valueType() != ValueType.BOOLEAN) return null // not a Boolean at this path -> no value
     // TODO - extract the primitive value from the resolved leaf, narrowed to Boolean
     TODO("Not yet implemented")
   }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultBooleanPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultBooleanPathObject.kt
@@ -11,7 +11,8 @@ import io.ably.lib.`object`.path.DefaultPathObject
  */
 internal class DefaultBooleanPathObject(
   channelObject: DefaultRealtimeObject,
-) : DefaultPathObject(channelObject), BooleanPathObject {
+  path: String,
+) : DefaultPathObject(channelObject, path), BooleanPathObject {
 
   @Suppress("RedundantNullableReturnType")
   override fun value(): Boolean? = TODO("Not yet implemented")

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultJsonArrayPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultJsonArrayPathObject.kt
@@ -17,6 +17,7 @@ internal class DefaultJsonArrayPathObject(
 ) : DefaultPathObject(channelObject, path), JsonArrayPathObject {
 
   override fun value(): JsonArray? {
+    channelObject.throwIfInvalidAccessApiConfiguration()
     if (resolveValueAtPath(path) !is ResolvedValue.Leaf) return null // live object or unresolved -> no primitive value
     // TODO - extract the primitive value from the resolved leaf, narrowed to JsonArray
     TODO("Not yet implemented")

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultJsonArrayPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultJsonArrayPathObject.kt
@@ -2,8 +2,9 @@ package io.ably.lib.`object`.path.types
 
 import com.google.gson.JsonArray
 import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.ValueType
 import io.ably.lib.`object`.path.DefaultPathObject
-import io.ably.lib.`object`.value.ResolvedValue
+import io.ably.lib.`object`.value.valueType
 
 /**
  * Default implementation of [JsonArrayPathObject], a terminal primitive view that only adds
@@ -18,7 +19,7 @@ internal class DefaultJsonArrayPathObject(
 
   override fun value(): JsonArray? {
     channelObject.throwIfInvalidAccessApiConfiguration()
-    if (resolveValueAtPath(path) !is ResolvedValue.Leaf) return null // live object or unresolved -> no primitive value
+    if (resolveValueAtPath(path)?.valueType() != ValueType.JSON_ARRAY) return null // not a JSON array at this path -> no value
     // TODO - extract the primitive value from the resolved leaf, narrowed to JsonArray
     TODO("Not yet implemented")
   }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultJsonArrayPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultJsonArrayPathObject.kt
@@ -12,7 +12,8 @@ import io.ably.lib.`object`.path.DefaultPathObject
  */
 internal class DefaultJsonArrayPathObject(
   channelObject: DefaultRealtimeObject,
-) : DefaultPathObject(channelObject), JsonArrayPathObject {
+  path: String,
+) : DefaultPathObject(channelObject, path), JsonArrayPathObject {
 
   @Suppress("RedundantNullableReturnType")
   override fun value(): JsonArray? = TODO("Not yet implemented")

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultJsonArrayPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultJsonArrayPathObject.kt
@@ -1,0 +1,19 @@
+package io.ably.lib.`object`.path.types
+
+import com.google.gson.JsonArray
+import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.path.DefaultPathObject
+
+/**
+ * Default implementation of [JsonArrayPathObject], a terminal primitive view that only adds
+ * a type-narrowed [value]; left unimplemented for now.
+ *
+ * Spec: RTTS6c
+ */
+internal class DefaultJsonArrayPathObject(
+  channelObject: DefaultRealtimeObject,
+) : DefaultPathObject(channelObject), JsonArrayPathObject {
+
+  @Suppress("RedundantNullableReturnType")
+  override fun value(): JsonArray? = TODO("Not yet implemented")
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultJsonArrayPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultJsonArrayPathObject.kt
@@ -3,6 +3,7 @@ package io.ably.lib.`object`.path.types
 import com.google.gson.JsonArray
 import io.ably.lib.`object`.DefaultRealtimeObject
 import io.ably.lib.`object`.path.DefaultPathObject
+import io.ably.lib.`object`.value.ResolvedValue
 
 /**
  * Default implementation of [JsonArrayPathObject], a terminal primitive view that only adds
@@ -15,6 +16,9 @@ internal class DefaultJsonArrayPathObject(
   path: String,
 ) : DefaultPathObject(channelObject, path), JsonArrayPathObject {
 
-  @Suppress("RedundantNullableReturnType")
-  override fun value(): JsonArray? = TODO("Not yet implemented")
+  override fun value(): JsonArray? {
+    if (resolveValueAtPath(path) !is ResolvedValue.Leaf) return null // live object or unresolved -> no primitive value
+    // TODO - extract the primitive value from the resolved leaf, narrowed to JsonArray
+    TODO("Not yet implemented")
+  }
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultJsonObjectPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultJsonObjectPathObject.kt
@@ -2,8 +2,9 @@ package io.ably.lib.`object`.path.types
 
 import com.google.gson.JsonObject
 import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.ValueType
 import io.ably.lib.`object`.path.DefaultPathObject
-import io.ably.lib.`object`.value.ResolvedValue
+import io.ably.lib.`object`.value.valueType
 
 /**
  * Default implementation of [JsonObjectPathObject], a terminal primitive view that only adds
@@ -18,7 +19,7 @@ internal class DefaultJsonObjectPathObject(
 
   override fun value(): JsonObject? {
     channelObject.throwIfInvalidAccessApiConfiguration()
-    if (resolveValueAtPath(path) !is ResolvedValue.Leaf) return null // live object or unresolved -> no primitive value
+    if (resolveValueAtPath(path)?.valueType() != ValueType.JSON_OBJECT) return null // not a JSON object at this path -> no value
     // TODO - extract the primitive value from the resolved leaf, narrowed to JsonObject
     TODO("Not yet implemented")
   }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultJsonObjectPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultJsonObjectPathObject.kt
@@ -17,6 +17,7 @@ internal class DefaultJsonObjectPathObject(
 ) : DefaultPathObject(channelObject, path), JsonObjectPathObject {
 
   override fun value(): JsonObject? {
+    channelObject.throwIfInvalidAccessApiConfiguration()
     if (resolveValueAtPath(path) !is ResolvedValue.Leaf) return null // live object or unresolved -> no primitive value
     // TODO - extract the primitive value from the resolved leaf, narrowed to JsonObject
     TODO("Not yet implemented")

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultJsonObjectPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultJsonObjectPathObject.kt
@@ -1,0 +1,19 @@
+package io.ably.lib.`object`.path.types
+
+import com.google.gson.JsonObject
+import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.path.DefaultPathObject
+
+/**
+ * Default implementation of [JsonObjectPathObject], a terminal primitive view that only adds
+ * a type-narrowed [value]; left unimplemented for now.
+ *
+ * Spec: RTTS6c
+ */
+internal class DefaultJsonObjectPathObject(
+  channelObject: DefaultRealtimeObject,
+) : DefaultPathObject(channelObject), JsonObjectPathObject {
+
+  @Suppress("RedundantNullableReturnType")
+  override fun value(): JsonObject? = TODO("Not yet implemented")
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultJsonObjectPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultJsonObjectPathObject.kt
@@ -3,6 +3,7 @@ package io.ably.lib.`object`.path.types
 import com.google.gson.JsonObject
 import io.ably.lib.`object`.DefaultRealtimeObject
 import io.ably.lib.`object`.path.DefaultPathObject
+import io.ably.lib.`object`.value.ResolvedValue
 
 /**
  * Default implementation of [JsonObjectPathObject], a terminal primitive view that only adds
@@ -15,6 +16,9 @@ internal class DefaultJsonObjectPathObject(
   path: String,
 ) : DefaultPathObject(channelObject, path), JsonObjectPathObject {
 
-  @Suppress("RedundantNullableReturnType")
-  override fun value(): JsonObject? = TODO("Not yet implemented")
+  override fun value(): JsonObject? {
+    if (resolveValueAtPath(path) !is ResolvedValue.Leaf) return null // live object or unresolved -> no primitive value
+    // TODO - extract the primitive value from the resolved leaf, narrowed to JsonObject
+    TODO("Not yet implemented")
+  }
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultJsonObjectPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultJsonObjectPathObject.kt
@@ -12,7 +12,8 @@ import io.ably.lib.`object`.path.DefaultPathObject
  */
 internal class DefaultJsonObjectPathObject(
   channelObject: DefaultRealtimeObject,
-) : DefaultPathObject(channelObject), JsonObjectPathObject {
+  path: String,
+) : DefaultPathObject(channelObject, path), JsonObjectPathObject {
 
   @Suppress("RedundantNullableReturnType")
   override fun value(): JsonObject? = TODO("Not yet implemented")

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultLiveCounterPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultLiveCounterPathObject.kt
@@ -1,0 +1,29 @@
+package io.ably.lib.`object`.path.types
+
+import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.path.DefaultPathObject
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Default implementation of [LiveCounterPathObject].
+ *
+ * Counters are terminal nodes (no navigation), so this only adds the counter read/write
+ * operations on top of [DefaultPathObject]; they are left unimplemented for now.
+ *
+ * Spec: RTTS6b
+ */
+internal class DefaultLiveCounterPathObject(
+  channelObject: DefaultRealtimeObject,
+) : DefaultPathObject(channelObject), LiveCounterPathObject {
+
+  @Suppress("RedundantNullableReturnType")
+  override fun value(): Double? = TODO("Not yet implemented")
+
+  override fun increment(): CompletableFuture<Void> = TODO("Not yet implemented")
+
+  override fun increment(amount: Number): CompletableFuture<Void> = TODO("Not yet implemented")
+
+  override fun decrement(): CompletableFuture<Void> = TODO("Not yet implemented")
+
+  override fun decrement(amount: Number): CompletableFuture<Void> = TODO("Not yet implemented")
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultLiveCounterPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultLiveCounterPathObject.kt
@@ -21,12 +21,14 @@ internal class DefaultLiveCounterPathObject(
 ) : DefaultPathObject(channelObject, path), LiveCounterPathObject {
 
   override fun value(): Double? {
+    channelObject.throwIfInvalidAccessApiConfiguration()
     if (resolveValueAtPath(path) !is ResolvedValue.CounterRef) return null // not a LiveCounter (or unresolved) -> null
     // TODO - return the resolved counter's value
     TODO("Not yet implemented")
   }
 
   override fun increment(): CompletableFuture<Void> {
+    channelObject.throwIfInvalidWriteApiConfiguration()
     val resolvedValue = resolveValueAtPath(path) ?: throw pathNotResolvedError(path)
     if (resolvedValue !is ResolvedValue.CounterRef) {
       throw typeMismatchError("Cannot increment a non-LiveCounter object at path: \"$path\"")
@@ -36,6 +38,7 @@ internal class DefaultLiveCounterPathObject(
   }
 
   override fun increment(amount: Number): CompletableFuture<Void> {
+    channelObject.throwIfInvalidWriteApiConfiguration()
     val resolvedValue = resolveValueAtPath(path) ?: throw pathNotResolvedError(path)
     if (resolvedValue !is ResolvedValue.CounterRef) {
       throw typeMismatchError("Cannot increment a non-LiveCounter object at path: \"$path\"")
@@ -45,6 +48,7 @@ internal class DefaultLiveCounterPathObject(
   }
 
   override fun decrement(): CompletableFuture<Void> {
+    channelObject.throwIfInvalidWriteApiConfiguration()
     val resolvedValue = resolveValueAtPath(path) ?: throw pathNotResolvedError(path)
     if (resolvedValue !is ResolvedValue.CounterRef) {
       throw typeMismatchError("Cannot decrement a non-LiveCounter object at path: \"$path\"")
@@ -54,6 +58,7 @@ internal class DefaultLiveCounterPathObject(
   }
 
   override fun decrement(amount: Number): CompletableFuture<Void> {
+    channelObject.throwIfInvalidWriteApiConfiguration()
     val resolvedValue = resolveValueAtPath(path) ?: throw pathNotResolvedError(path)
     if (resolvedValue !is ResolvedValue.CounterRef) {
       throw typeMismatchError("Cannot decrement a non-LiveCounter object at path: \"$path\"")

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultLiveCounterPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultLiveCounterPathObject.kt
@@ -14,7 +14,8 @@ import java.util.concurrent.CompletableFuture
  */
 internal class DefaultLiveCounterPathObject(
   channelObject: DefaultRealtimeObject,
-) : DefaultPathObject(channelObject), LiveCounterPathObject {
+  path: String,
+) : DefaultPathObject(channelObject, path), LiveCounterPathObject {
 
   @Suppress("RedundantNullableReturnType")
   override fun value(): Double? = TODO("Not yet implemented")

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultLiveCounterPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultLiveCounterPathObject.kt
@@ -2,6 +2,9 @@ package io.ably.lib.`object`.path.types
 
 import io.ably.lib.`object`.DefaultRealtimeObject
 import io.ably.lib.`object`.path.DefaultPathObject
+import io.ably.lib.`object`.pathNotResolvedError
+import io.ably.lib.`object`.typeMismatchError
+import io.ably.lib.`object`.value.ResolvedValue
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -17,14 +20,45 @@ internal class DefaultLiveCounterPathObject(
   path: String,
 ) : DefaultPathObject(channelObject, path), LiveCounterPathObject {
 
-  @Suppress("RedundantNullableReturnType")
-  override fun value(): Double? = TODO("Not yet implemented")
+  override fun value(): Double? {
+    if (resolveValueAtPath(path) !is ResolvedValue.CounterRef) return null // not a LiveCounter (or unresolved) -> null
+    // TODO - return the resolved counter's value
+    TODO("Not yet implemented")
+  }
 
-  override fun increment(): CompletableFuture<Void> = TODO("Not yet implemented")
+  override fun increment(): CompletableFuture<Void> {
+    val resolvedValue = resolveValueAtPath(path) ?: throw pathNotResolvedError(path)
+    if (resolvedValue !is ResolvedValue.CounterRef) {
+      throw typeMismatchError("Cannot increment a non-LiveCounter object at path: \"$path\"")
+    }
+    // TODO - delegate the COUNTER_INC (amount 1) to the resolved LiveCounter
+    TODO("Not yet implemented")
+  }
 
-  override fun increment(amount: Number): CompletableFuture<Void> = TODO("Not yet implemented")
+  override fun increment(amount: Number): CompletableFuture<Void> {
+    val resolvedValue = resolveValueAtPath(path) ?: throw pathNotResolvedError(path)
+    if (resolvedValue !is ResolvedValue.CounterRef) {
+      throw typeMismatchError("Cannot increment a non-LiveCounter object at path: \"$path\"")
+    }
+    // TODO - delegate the COUNTER_INC to the resolved LiveCounter
+    TODO("Not yet implemented")
+  }
 
-  override fun decrement(): CompletableFuture<Void> = TODO("Not yet implemented")
+  override fun decrement(): CompletableFuture<Void> {
+    val resolvedValue = resolveValueAtPath(path) ?: throw pathNotResolvedError(path)
+    if (resolvedValue !is ResolvedValue.CounterRef) {
+      throw typeMismatchError("Cannot decrement a non-LiveCounter object at path: \"$path\"")
+    }
+    // TODO - delegate the COUNTER_INC (negated amount 1) to the resolved LiveCounter
+    TODO("Not yet implemented")
+  }
 
-  override fun decrement(amount: Number): CompletableFuture<Void> = TODO("Not yet implemented")
+  override fun decrement(amount: Number): CompletableFuture<Void> {
+    val resolvedValue = resolveValueAtPath(path) ?: throw pathNotResolvedError(path)
+    if (resolvedValue !is ResolvedValue.CounterRef) {
+      throw typeMismatchError("Cannot decrement a non-LiveCounter object at path: \"$path\"")
+    }
+    // TODO - delegate the COUNTER_INC (negated amount) to the resolved LiveCounter
+    TODO("Not yet implemented")
+  }
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultLiveMapPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultLiveMapPathObject.kt
@@ -25,30 +25,35 @@ internal class DefaultLiveMapPathObject(
   override fun at(path: String): PathObject = TODO("Not yet implemented")
 
   override fun entries(): Iterable<Map.Entry<String, PathObject>> {
+    channelObject.throwIfInvalidAccessApiConfiguration()
     if (resolveValueAtPath(path) !is ResolvedValue.MapRef) return emptyList() // not a LiveMap (or unresolved) -> empty
     // TODO - iterate the resolved map's entries, yielding (key, child PathObject)
     TODO("Not yet implemented")
   }
 
   override fun keys(): Iterable<String> {
+    channelObject.throwIfInvalidAccessApiConfiguration()
     if (resolveValueAtPath(path) !is ResolvedValue.MapRef) return emptyList() // not a LiveMap (or unresolved) -> empty
     // TODO - return the resolved map's keys
     TODO("Not yet implemented")
   }
 
   override fun values(): Iterable<PathObject> {
+    channelObject.throwIfInvalidAccessApiConfiguration()
     if (resolveValueAtPath(path) !is ResolvedValue.MapRef) return emptyList() // not a LiveMap (or unresolved) -> empty
     // TODO - return a child PathObject for each entry of the resolved map
     TODO("Not yet implemented")
   }
 
   override fun size(): Long? {
+    channelObject.throwIfInvalidAccessApiConfiguration()
     if (resolveValueAtPath(path) !is ResolvedValue.MapRef) return null // not a LiveMap (or unresolved) -> null
     // TODO - return the resolved map's size
     TODO("Not yet implemented")
   }
 
   override fun set(key: String, value: LiveMapValue): CompletableFuture<Void> {
+    channelObject.throwIfInvalidWriteApiConfiguration()
     val resolvedValue = resolveValueAtPath(path) ?: throw pathNotResolvedError(path)
     if (resolvedValue !is ResolvedValue.MapRef) {
       throw typeMismatchError("Cannot set a key on a non-LiveMap object at path: \"$path\"")
@@ -58,6 +63,7 @@ internal class DefaultLiveMapPathObject(
   }
 
   override fun remove(key: String): CompletableFuture<Void> {
+    channelObject.throwIfInvalidWriteApiConfiguration()
     val resolvedValue = resolveValueAtPath(path) ?: throw pathNotResolvedError(path)
     if (resolvedValue !is ResolvedValue.MapRef) {
       throw typeMismatchError("Cannot remove a key from a non-LiveMap object at path: \"$path\"")

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultLiveMapPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultLiveMapPathObject.kt
@@ -3,7 +3,10 @@ package io.ably.lib.`object`.path.types
 import io.ably.lib.`object`.DefaultRealtimeObject
 import io.ably.lib.`object`.path.DefaultPathObject
 import io.ably.lib.`object`.path.PathObject
+import io.ably.lib.`object`.pathNotResolvedError
+import io.ably.lib.`object`.typeMismatchError
 import io.ably.lib.`object`.value.LiveMapValue
+import io.ably.lib.`object`.value.ResolvedValue
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -21,16 +24,45 @@ internal class DefaultLiveMapPathObject(
 
   override fun at(path: String): PathObject = TODO("Not yet implemented")
 
-  override fun entries(): Iterable<Map.Entry<String, PathObject>> = TODO("Not yet implemented")
+  override fun entries(): Iterable<Map.Entry<String, PathObject>> {
+    if (resolveValueAtPath(path) !is ResolvedValue.MapRef) return emptyList() // not a LiveMap (or unresolved) -> empty
+    // TODO - iterate the resolved map's entries, yielding (key, child PathObject)
+    TODO("Not yet implemented")
+  }
 
-  override fun keys(): Iterable<String> = TODO("Not yet implemented")
+  override fun keys(): Iterable<String> {
+    if (resolveValueAtPath(path) !is ResolvedValue.MapRef) return emptyList() // not a LiveMap (or unresolved) -> empty
+    // TODO - return the resolved map's keys
+    TODO("Not yet implemented")
+  }
 
-  override fun values(): Iterable<PathObject> = TODO("Not yet implemented")
+  override fun values(): Iterable<PathObject> {
+    if (resolveValueAtPath(path) !is ResolvedValue.MapRef) return emptyList() // not a LiveMap (or unresolved) -> empty
+    // TODO - return a child PathObject for each entry of the resolved map
+    TODO("Not yet implemented")
+  }
 
-  @Suppress("RedundantNullableReturnType")
-  override fun size(): Long? = TODO("Not yet implemented")
+  override fun size(): Long? {
+    if (resolveValueAtPath(path) !is ResolvedValue.MapRef) return null // not a LiveMap (or unresolved) -> null
+    // TODO - return the resolved map's size
+    TODO("Not yet implemented")
+  }
 
-  override fun set(key: String, value: LiveMapValue): CompletableFuture<Void> = TODO("Not yet implemented")
+  override fun set(key: String, value: LiveMapValue): CompletableFuture<Void> {
+    val resolvedValue = resolveValueAtPath(path) ?: throw pathNotResolvedError(path)
+    if (resolvedValue !is ResolvedValue.MapRef) {
+      throw typeMismatchError("Cannot set a key on a non-LiveMap object at path: \"$path\"")
+    }
+    // TODO - delegate the MAP_SET to the resolved LiveMap
+    TODO("Not yet implemented")
+  }
 
-  override fun remove(key: String): CompletableFuture<Void> = TODO("Not yet implemented")
+  override fun remove(key: String): CompletableFuture<Void> {
+    val resolvedValue = resolveValueAtPath(path) ?: throw pathNotResolvedError(path)
+    if (resolvedValue !is ResolvedValue.MapRef) {
+      throw typeMismatchError("Cannot remove a key from a non-LiveMap object at path: \"$path\"")
+    }
+    // TODO - delegate the MAP_REMOVE to the resolved LiveMap
+    TODO("Not yet implemented")
+  }
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultLiveMapPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultLiveMapPathObject.kt
@@ -14,7 +14,8 @@ import java.util.concurrent.CompletableFuture
  */
 internal class DefaultLiveMapPathObject(
   channelObject: DefaultRealtimeObject,
-) : DefaultPathObject(channelObject), LiveMapPathObject {
+  path: String,
+) : DefaultPathObject(channelObject, path), LiveMapPathObject {
 
   override fun get(key: String): PathObject = TODO("Not yet implemented")
 

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultLiveMapPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultLiveMapPathObject.kt
@@ -1,0 +1,35 @@
+package io.ably.lib.`object`.path.types
+
+import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.path.DefaultPathObject
+import io.ably.lib.`object`.path.PathObject
+import io.ably.lib.`object`.value.LiveMapValue
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Default implementation of [LiveMapPathObject], adding map navigation and read/write
+ * operations on top of [DefaultPathObject]; all left unimplemented for now.
+ *
+ * Spec: RTTS6a
+ */
+internal class DefaultLiveMapPathObject(
+  channelObject: DefaultRealtimeObject,
+) : DefaultPathObject(channelObject), LiveMapPathObject {
+
+  override fun get(key: String): PathObject = TODO("Not yet implemented")
+
+  override fun at(path: String): PathObject = TODO("Not yet implemented")
+
+  override fun entries(): Iterable<Map.Entry<String, PathObject>> = TODO("Not yet implemented")
+
+  override fun keys(): Iterable<String> = TODO("Not yet implemented")
+
+  override fun values(): Iterable<PathObject> = TODO("Not yet implemented")
+
+  @Suppress("RedundantNullableReturnType")
+  override fun size(): Long? = TODO("Not yet implemented")
+
+  override fun set(key: String, value: LiveMapValue): CompletableFuture<Void> = TODO("Not yet implemented")
+
+  override fun remove(key: String): CompletableFuture<Void> = TODO("Not yet implemented")
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultNumberPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultNumberPathObject.kt
@@ -1,0 +1,18 @@
+package io.ably.lib.`object`.path.types
+
+import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.path.DefaultPathObject
+
+/**
+ * Default implementation of [NumberPathObject], a terminal primitive view that only adds a
+ * type-narrowed [value]; left unimplemented for now.
+ *
+ * Spec: RTTS6c
+ */
+internal class DefaultNumberPathObject(
+  channelObject: DefaultRealtimeObject,
+) : DefaultPathObject(channelObject), NumberPathObject {
+
+  @Suppress("RedundantNullableReturnType")
+  override fun value(): Number? = TODO("Not yet implemented")
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultNumberPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultNumberPathObject.kt
@@ -2,6 +2,7 @@ package io.ably.lib.`object`.path.types
 
 import io.ably.lib.`object`.DefaultRealtimeObject
 import io.ably.lib.`object`.path.DefaultPathObject
+import io.ably.lib.`object`.value.ResolvedValue
 
 /**
  * Default implementation of [NumberPathObject], a terminal primitive view that only adds a
@@ -14,6 +15,9 @@ internal class DefaultNumberPathObject(
   path: String,
 ) : DefaultPathObject(channelObject, path), NumberPathObject {
 
-  @Suppress("RedundantNullableReturnType")
-  override fun value(): Number? = TODO("Not yet implemented")
+  override fun value(): Number? {
+    if (resolveValueAtPath(path) !is ResolvedValue.Leaf) return null // live object or unresolved -> no primitive value
+    // TODO - extract the primitive value from the resolved leaf, narrowed to Number
+    TODO("Not yet implemented")
+  }
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultNumberPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultNumberPathObject.kt
@@ -16,6 +16,7 @@ internal class DefaultNumberPathObject(
 ) : DefaultPathObject(channelObject, path), NumberPathObject {
 
   override fun value(): Number? {
+    channelObject.throwIfInvalidAccessApiConfiguration()
     if (resolveValueAtPath(path) !is ResolvedValue.Leaf) return null // live object or unresolved -> no primitive value
     // TODO - extract the primitive value from the resolved leaf, narrowed to Number
     TODO("Not yet implemented")

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultNumberPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultNumberPathObject.kt
@@ -11,7 +11,8 @@ import io.ably.lib.`object`.path.DefaultPathObject
  */
 internal class DefaultNumberPathObject(
   channelObject: DefaultRealtimeObject,
-) : DefaultPathObject(channelObject), NumberPathObject {
+  path: String,
+) : DefaultPathObject(channelObject, path), NumberPathObject {
 
   @Suppress("RedundantNullableReturnType")
   override fun value(): Number? = TODO("Not yet implemented")

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultNumberPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultNumberPathObject.kt
@@ -1,8 +1,9 @@
 package io.ably.lib.`object`.path.types
 
 import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.ValueType
 import io.ably.lib.`object`.path.DefaultPathObject
-import io.ably.lib.`object`.value.ResolvedValue
+import io.ably.lib.`object`.value.valueType
 
 /**
  * Default implementation of [NumberPathObject], a terminal primitive view that only adds a
@@ -17,7 +18,7 @@ internal class DefaultNumberPathObject(
 
   override fun value(): Number? {
     channelObject.throwIfInvalidAccessApiConfiguration()
-    if (resolveValueAtPath(path) !is ResolvedValue.Leaf) return null // live object or unresolved -> no primitive value
+    if (resolveValueAtPath(path)?.valueType() != ValueType.NUMBER) return null // not a Number at this path -> no value
     // TODO - extract the primitive value from the resolved leaf, narrowed to Number
     TODO("Not yet implemented")
   }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultStringPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultStringPathObject.kt
@@ -11,7 +11,8 @@ import io.ably.lib.`object`.path.DefaultPathObject
  */
 internal class DefaultStringPathObject(
   channelObject: DefaultRealtimeObject,
-) : DefaultPathObject(channelObject), StringPathObject {
+  path: String,
+) : DefaultPathObject(channelObject, path), StringPathObject {
 
   @Suppress("RedundantNullableReturnType")
   override fun value(): String? = TODO("Not yet implemented")

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultStringPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultStringPathObject.kt
@@ -1,0 +1,18 @@
+package io.ably.lib.`object`.path.types
+
+import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.path.DefaultPathObject
+
+/**
+ * Default implementation of [StringPathObject], a terminal primitive view that only adds a
+ * type-narrowed [value]; left unimplemented for now.
+ *
+ * Spec: RTTS6c
+ */
+internal class DefaultStringPathObject(
+  channelObject: DefaultRealtimeObject,
+) : DefaultPathObject(channelObject), StringPathObject {
+
+  @Suppress("RedundantNullableReturnType")
+  override fun value(): String? = TODO("Not yet implemented")
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultStringPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultStringPathObject.kt
@@ -1,8 +1,9 @@
 package io.ably.lib.`object`.path.types
 
 import io.ably.lib.`object`.DefaultRealtimeObject
+import io.ably.lib.`object`.ValueType
 import io.ably.lib.`object`.path.DefaultPathObject
-import io.ably.lib.`object`.value.ResolvedValue
+import io.ably.lib.`object`.value.valueType
 
 /**
  * Default implementation of [StringPathObject], a terminal primitive view that only adds a
@@ -17,7 +18,7 @@ internal class DefaultStringPathObject(
 
   override fun value(): String? {
     channelObject.throwIfInvalidAccessApiConfiguration()
-    if (resolveValueAtPath(path) !is ResolvedValue.Leaf) return null // live object or unresolved -> no primitive value
+    if (resolveValueAtPath(path)?.valueType() != ValueType.STRING) return null // not a String at this path -> no value
     // TODO - extract the primitive value from the resolved leaf, narrowed to String
     TODO("Not yet implemented")
   }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultStringPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultStringPathObject.kt
@@ -16,6 +16,7 @@ internal class DefaultStringPathObject(
 ) : DefaultPathObject(channelObject, path), StringPathObject {
 
   override fun value(): String? {
+    channelObject.throwIfInvalidAccessApiConfiguration()
     if (resolveValueAtPath(path) !is ResolvedValue.Leaf) return null // live object or unresolved -> no primitive value
     // TODO - extract the primitive value from the resolved leaf, narrowed to String
     TODO("Not yet implemented")

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultStringPathObject.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/path/types/DefaultStringPathObject.kt
@@ -2,6 +2,7 @@ package io.ably.lib.`object`.path.types
 
 import io.ably.lib.`object`.DefaultRealtimeObject
 import io.ably.lib.`object`.path.DefaultPathObject
+import io.ably.lib.`object`.value.ResolvedValue
 
 /**
  * Default implementation of [StringPathObject], a terminal primitive view that only adds a
@@ -14,6 +15,9 @@ internal class DefaultStringPathObject(
   path: String,
 ) : DefaultPathObject(channelObject, path), StringPathObject {
 
-  @Suppress("RedundantNullableReturnType")
-  override fun value(): String? = TODO("Not yet implemented")
+  override fun value(): String? {
+    if (resolveValueAtPath(path) !is ResolvedValue.Leaf) return null // live object or unresolved -> no primitive value
+    // TODO - extract the primitive value from the resolved leaf, narrowed to String
+    TODO("Not yet implemented")
+  }
 }

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/value/DefaultLiveCounter.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/value/DefaultLiveCounter.kt
@@ -1,0 +1,22 @@
+package io.ably.lib.`object`.value
+
+/**
+ * Default implementation of the [LiveCounter] value type - an immutable holder for
+ * the initial count of a LiveCounter object to be created. Mirrors ably-js
+ * `LiveCounterValueType`.
+ *
+ * Instantiated reflectively by [LiveCounter.create] through the constructor that
+ * takes the initial count; the count is retained internally with no public accessor
+ * (Spec: RTLCV3d).
+ *
+ * This is currently a skeleton: it only retains the initial value. Producing the
+ * `COUNTER_CREATE` operation/message from this count is not yet implemented.
+ *
+ * Spec: RTLCV1, RTLCV2, RTLCV3
+ */
+internal class DefaultLiveCounter(
+  internal val initialCount: Number,
+) : LiveCounter() {
+  // TODO - build the COUNTER_CREATE ObjectMessage from `initialCount`, mirroring
+  //  ably-js LiveCounterValueType.createCounterCreateMessage. Spec: RTO12f
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/value/DefaultLiveMap.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/value/DefaultLiveMap.kt
@@ -1,0 +1,24 @@
+package io.ably.lib.`object`.value
+
+/**
+ * Default implementation of the [LiveMap] value type - an immutable holder for the
+ * initial entries of a LiveMap object to be created. Mirrors ably-js
+ * `LiveMapValueType`.
+ *
+ * Instantiated reflectively by [LiveMap.create] through the constructor that takes
+ * the initial entries map; the entries are retained internally with no public
+ * accessor (Spec: RTLMV3d).
+ *
+ * This is currently a skeleton: it only retains the initial value. Producing the
+ * `MAP_CREATE` operation/message from these entries (including nested object create
+ * messages for nested [LiveMap]/[LiveCounter] value types) is not yet implemented.
+ *
+ * Spec: RTLMV1, RTLMV2, RTLMV3
+ */
+internal class DefaultLiveMap(
+  internal val entries: Map<String, LiveMapValue>,
+) : LiveMap() {
+  // TODO - build the MAP_CREATE ObjectMessage (plus nested object create messages)
+  //  from `entries`, mirroring ably-js LiveMapValueType.createMapCreateMessage.
+  //  Spec: RTO11f
+}

--- a/liveobjects/src/main/kotlin/io/ably/lib/object/value/ResolvedValue.kt
+++ b/liveobjects/src/main/kotlin/io/ably/lib/object/value/ResolvedValue.kt
@@ -1,0 +1,39 @@
+package io.ably.lib.`object`.value
+
+import io.ably.lib.`object`.ValueType
+import io.ably.lib.`object`.message.WireObjectData
+
+/**
+ * The result of resolving a path segment / map entry against the objects
+ * graph: either a node view of a live object, or a primitive leaf carried as
+ * wire ObjectData.
+ */
+internal sealed interface ResolvedValue {
+  data class MapRef(val map: LiveMap) : ResolvedValue // TODO: LiveMap will be replaced by InternalLiveMap
+  data class CounterRef(val counter: LiveCounter) : ResolvedValue // TODO: LiveCounter will be replaced by InternalLiveCounter
+  data class Leaf(val data: WireObjectData) : ResolvedValue
+}
+
+/**
+ * Maps a resolved value to the public ValueType enum.
+ *
+ * Only ever invoked on a value that resolved to something - absence at a path is
+ * represented by a `null` [ResolvedValue] and surfaced as a `null` type by the
+ * caller, never as [ValueType.UNKNOWN]. UNKNOWN is reserved for a value that is
+ * present but matches none of the known categories.
+ *
+ * Spec: RTTS2a, RTTS4b3
+ */
+internal fun ResolvedValue.valueType(): ValueType = when (this) {
+  is ResolvedValue.MapRef -> ValueType.LIVE_MAP
+  is ResolvedValue.CounterRef -> ValueType.LIVE_COUNTER
+  is ResolvedValue.Leaf -> when {
+    data.string != null -> ValueType.STRING
+    data.number != null -> ValueType.NUMBER
+    data.boolean != null -> ValueType.BOOLEAN
+    data.bytes != null -> ValueType.BINARY
+    data.json?.isJsonObject == true -> ValueType.JSON_OBJECT
+    data.json?.isJsonArray == true -> ValueType.JSON_ARRAY
+    else -> ValueType.UNKNOWN
+  }
+}


### PR DESCRIPTION
- Fixes https://ably.atlassian.net/browse/AIT-928
- Reference spec -> https://github.com/ably/specification/pull/491

## Overview

This PR introduces the new **path-based, strongly-typed LiveObjects API** for `ably-java`, following the LiveObjects specification. It adds the complete **public API surface** (Java interfaces) plus a **Kotlin skeleton implementation** that wires up structure, type-resolution, and precondition checks — leaving the actual data read/write bodies as clearly-marked `TODO`s to be filled in by follow-up PRs.

The goal of this PR is to land the foundation — the public types, package layout, and core plumbing — so that subsequent PRs can implement individual operations against a stable, reviewed API.

> **Note on scope:** This is a foundational/skeleton PR. Public interfaces and the supporting model are complete; most terminal read/write method bodies are stubbed with `TODO`, but the surrounding logic that this PR *does* implement (path resolution, type checks, error throwing, and access/write guards) is real and reviewable.

## What's a "path object" vs an "instance"?

The API offers two ways to address data in the objects graph:

- **`PathObject`** — a *lazy, path-based* reference (e.g. `root.get("a").get("b")`). It re-resolves its path on every call, so it survives the underlying object being replaced. Reads are **best-effort** (return `null`/empty when the path doesn't resolve or the type doesn't match); writes throw on mismatch.
- **`Instance`** — a *direct reference* to an already-resolved value of a known, fixed type. Because its type is known, cast helpers (`as*`) **fail fast** with `IllegalStateException` on a type mismatch.

This split is reflected throughout the type hierarchy and is the main design decision reviewers should be aware of.

## What's included

**Public API (`lib/.../io/ably/lib/object`)**
- Entry point: `RealtimeObject` (`get()` root accessor, sync-state events via `on`/`off`/`offAll`), wired into `ChannelBase`.
- `PathObject` + typed sub-types (`LiveMap`/`LiveCounter`/`Number`/`String`/`Boolean`/`Binary`/`JsonObject`/`JsonArray` path objects).
- `Instance` + matching typed sub-types.
- Value types for writes: `LiveMap`, `LiveCounter`, and the `LiveMapValue` union wrapper.
- Message model: `ObjectMessage`, `ObjectOperation`, `ObjectData`, the per-operation payloads (`MapSet`/`MapCreate`/`MapRemove`/`MapClear`/`CounterCreate`/`CounterInc`/`ObjectDelete`), and enums (`ObjectOperationAction`, `ObjectsMapSemantics`, `ValueType`).
- Subscriptions/events/listeners and the adapter interfaces (`AblyClientAdapter`/`Adapter`).

**Skeleton implementation (`liveobjects/.../io/ably/lib/object`)**
- `Default*` implementations for every public interface above.
- **Implemented now:** path resolution (`ResolvedValue` + `resolveValueAtPath`), the read-vs-write behaviour split (best-effort reads vs throwing writes), `getType()` resolution, the wire/decoded message model (`WireObjectMessage`/`DefaultObjectMessage`) incl. message-size calculation, error codes (`Errors.kt`), and the access/write API precondition guards (`Helpers.kt`).
- **Stubbed (`TODO`):** the actual data mutation/read bodies (e.g. building `MAP_SET`/`COUNTER_INC` operations, materialising values), to follow in later PRs.

## Key design decisions
- **Fully decoupled** from the legacy `io.ably.lib.objects` package — no imports across the boundary (helpers/wire types/guards are copied rather than shared) so the new typed API can evolve independently.
- **`getType()` is nullable on `PathObject`**: `null` = no value at the path; `ValueType.UNKNOWN` = a value exists but its type is unrecognised. (On `Instance` it's non-null, since an instance always wraps a resolved value.)
- **`PathObject` casts are best-effort; `Instance` casts fail fast** (see above).

## Companion spec updates
A few inconsistencies were found and reconciled in the LiveObjects specification while building this (treating `ably-java` as the source of truth): `PathObject#getType` made nullable; counter `value()` narrowing permitted; `Instance` `as*` documented as fail-fast; `ObjectData.json` (OD2g) added to the wire model; and a client-side `UNKNOWN` forward-compat sentinel added to the action/semantics enums.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes
* **New Features**
  * Added an adapter layer bridging the path-based object API with the realtime client.
  * Laid groundwork for typed, path-based LiveObjects access, message wrapping, and subscription event handling.
* **Bug Fixes**
  * Updated path type resolution: `getType()` now returns `null` when no value exists at the path.
* **Documentation**
  * Clarified `UNKNOWN` value-type behavior and refined `PathObject`/`Instance` casting and JSON compaction contracts across instance types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
