### PR TITLE
[AIT-1038] chore(examples): migrate LiveObjects example app to the path-based API

### DIFF
--- a/examples/src/main/kotlin/com/ably/example/Utils.kt
+++ b/examples/src/main/kotlin/com/ably/example/Utils.kt
@@ -27,8 +27,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import io.ably.lib.liveobjects.ValueType
 import io.ably.lib.liveobjects.path.types.LiveCounterPathObject
 import io.ably.lib.liveobjects.path.types.LiveMapPathObject
+import io.ably.lib.liveobjects.state.ObjectStateEvent
 import io.ably.lib.liveobjects.value.LiveCounter
 import io.ably.lib.liveobjects.value.LiveMap
 import io.ably.lib.liveobjects.value.LiveMapValue
@@ -42,13 +44,17 @@ import kotlinx.coroutines.future.await
 
 /**
  * Returns the counter path object at [key] under [root], creating and linking a fresh
- * zero-value counter when nothing exists at that path yet. Path objects re-resolve on
- * every call, so the returned reference stays valid even if another client replaces the
- * counter object at this key.
+ * zero-value counter when the path is missing or holds a non-counter value. Path objects
+ * re-resolve on every call, so the returned reference stays valid even if another client
+ * replaces the counter object at this key.
+ *
+ * The check-then-set is not atomic: another client can create the same key in between.
+ * That is fine here - the colliding operations converge deterministically via
+ * last-write-wins, and both sides end up bound to whichever counter won.
  */
 suspend fun getOrCreateCounter(root: LiveMapPathObject, key: String): LiveCounterPathObject {
   val path = root.get(key)
-  if (!path.exists()) {
+  if (path.type != ValueType.LIVE_COUNTER) {
     // Creates the counter and links it under root in a single published operation
     root.set(key, LiveMapValue.of(LiveCounter.create())).await()
   }
@@ -57,11 +63,12 @@ suspend fun getOrCreateCounter(root: LiveMapPathObject, key: String): LiveCounte
 
 /**
  * Returns the map path object at [key] under [root], creating and linking a fresh empty
- * map when nothing exists at that path yet.
+ * map when the path is missing or holds a non-map value. Same last-write-wins caveat as
+ * [getOrCreateCounter].
  */
 suspend fun getOrCreateMap(root: LiveMapPathObject, key: String): LiveMapPathObject {
   val path = root.get(key)
-  if (!path.exists()) {
+  if (path.type != ValueType.LIVE_MAP) {
     root.set(key, LiveMapValue.of(LiveMap.create())).await()
   }
   return path.asLiveMap()
@@ -72,7 +79,7 @@ fun observeCounter(root: LiveMapPathObject?, key: String): CounterState {
   var counter by remember { mutableStateOf<LiveCounterPathObject?>(null) }
   var counterValue by remember { mutableStateOf<Int?>(null) }
 
-  LaunchedEffect(root) {
+  LaunchedEffect(root, key) {
     root?.let {
       supressCoroutineExceptions {
         counter = getOrCreateCounter(it, key)
@@ -134,7 +141,7 @@ fun observeMap(root: LiveMapPathObject?, key: String): Pair<Map<String, String>,
       ?.toMap()
       ?: mapOf()
 
-  LaunchedEffect(root) {
+  LaunchedEffect(root, key) {
     root?.let {
       supressCoroutineExceptions {
         map = getOrCreateMap(it, key)
@@ -157,6 +164,29 @@ fun observeMap(root: LiveMapPathObject?, key: String): Pair<Map<String, String>,
   }
 
   return mapValue to map
+}
+
+/**
+ * Observes the channel's objects synchronization state via `channel.object.on(event)`.
+ * Returns the most recent [ObjectStateEvent], or null before any event has been received
+ * (events fire on transitions only, so an already-completed sync emits nothing).
+ */
+@Composable
+fun observeObjectsSyncState(channel: Channel): ObjectStateEvent? {
+  var syncState by remember { mutableStateOf<ObjectStateEvent?>(null) }
+
+  DisposableEffect(channel) {
+    // There is no wildcard subscription - register one listener per event
+    val subscriptions = listOf(ObjectStateEvent.SYNCING, ObjectStateEvent.SYNCED).map { event ->
+      channel.`object`.on(event) { stateEvent -> syncState = stateEvent }
+    }
+
+    onDispose {
+      subscriptions.forEach { it.unsubscribe() }
+    }
+  }
+
+  return syncState
 }
 
 @Composable

--- a/examples/src/main/kotlin/com/ably/example/Utils.kt
+++ b/examples/src/main/kotlin/com/ably/example/Utils.kt
@@ -1,211 +1,108 @@
+/**
+ * The LiveObjects bridge layer for the example app: Compose observers plus coroutine
+ * wrappers over the path-based API (`io.ably.lib.liveobjects`).
+ *
+ * The app works exclusively with [io.ably.lib.liveobjects.path.PathObject]s — references
+ * to a *location* in the channel's objects graph, not to a particular object. A PathObject
+ * resolves its path lazily on every call, so a stored reference stays valid even when the
+ * object at that location is replaced (e.g. "Reset all" swaps in brand-new counters), and
+ * a path subscription automatically observes whatever object currently lives there. The
+ * identity-bound alternative, [io.ably.lib.liveobjects.instance.Instance] (obtained via
+ * `pathObject.instance()`), tracks one specific object wherever it moves — not needed here,
+ * since every screen wants location semantics.
+ *
+ * ably-java's typed flavour of the API: the base PathObject exposes only type-agnostic
+ * methods; type-specific reads/writes live on sub-type views reached via `as*` casts
+ * (`asLiveCounter()`, `asLiveMap()`, `asString()`, ...). The casts never throw — a
+ * wrong-typed view degrades gracefully (reads return null/empty, writes fail with an
+ * AblyException). The root obtained from `channel.object.get()` is already a
+ * [LiveMapPathObject], so no cast is needed there.
+ */
 package com.ably.example
 
-import androidx.compose.runtime.*
-import io.ably.lib.objects.ObjectsCallback
-import io.ably.lib.objects.RealtimeObjects
-import io.ably.lib.objects.type.counter.LiveCounter
-import io.ably.lib.objects.type.counter.LiveCounterUpdate
-import io.ably.lib.objects.type.map.LiveMap
-import io.ably.lib.objects.type.map.LiveMapUpdate
-import io.ably.lib.objects.type.map.LiveMapUpdate.Change.UPDATED
-import io.ably.lib.objects.type.map.LiveMapValue
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import io.ably.lib.liveobjects.path.types.LiveCounterPathObject
+import io.ably.lib.liveobjects.path.types.LiveMapPathObject
+import io.ably.lib.liveobjects.value.LiveCounter
+import io.ably.lib.liveobjects.value.LiveMap
+import io.ably.lib.liveobjects.value.LiveMapValue
 import io.ably.lib.realtime.AblyRealtime
 import io.ably.lib.realtime.Channel
 import io.ably.lib.realtime.ChannelState
 import io.ably.lib.realtime.ChannelStateListener
-import io.ably.lib.types.AblyException
 import io.ably.lib.types.ChannelMode
 import io.ably.lib.types.ChannelOptions
-import io.ably.lib.types.ErrorInfo
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlin.coroutines.resume
+import kotlinx.coroutines.future.await
 
-private suspend fun RealtimeObjects.getRootCoroutines(): LiveMap = suspendCancellableCoroutine { continuation ->
-  getRootAsync(object : ObjectsCallback<LiveMap> {
-    override fun onSuccess(result: LiveMap?) {
-      continuation.resume(result!!)
-    }
-
-    override fun onError(exception: AblyException?) {
-      continuation.cancel(exception)
-    }
-  })
+/**
+ * Returns the counter path object at [key] under [root], creating and linking a fresh
+ * zero-value counter when nothing exists at that path yet. Path objects re-resolve on
+ * every call, so the returned reference stays valid even if another client replaces the
+ * counter object at this key.
+ */
+suspend fun getOrCreateCounter(root: LiveMapPathObject, key: String): LiveCounterPathObject {
+  val path = root.get(key)
+  if (!path.exists()) {
+    // Creates the counter and links it under root in a single published operation
+    root.set(key, LiveMapValue.of(LiveCounter.create())).await()
+  }
+  return path.asLiveCounter()
 }
 
-private suspend fun RealtimeObjects.createCounterCoroutine(): LiveCounter =
-  suspendCancellableCoroutine { continuation ->
-    createCounterAsync(object : ObjectsCallback<LiveCounter> {
-      override fun onSuccess(result: LiveCounter?) {
-        continuation.resume(result!!)
-      }
-
-      override fun onError(exception: AblyException?) {
-        continuation.cancel(exception)
-      }
-    })
+/**
+ * Returns the map path object at [key] under [root], creating and linking a fresh empty
+ * map when nothing exists at that path yet.
+ */
+suspend fun getOrCreateMap(root: LiveMapPathObject, key: String): LiveMapPathObject {
+  val path = root.get(key)
+  if (!path.exists()) {
+    root.set(key, LiveMapValue.of(LiveMap.create())).await()
   }
-
-private suspend fun RealtimeObjects.createMapCoroutine(): LiveMap = suspendCancellableCoroutine { continuation ->
-  createMapAsync(object : ObjectsCallback<LiveMap> {
-    override fun onSuccess(result: LiveMap?) {
-      continuation.resume(result!!)
-    }
-
-    override fun onError(exception: AblyException?) {
-      continuation.cancel(exception)
-    }
-  })
-}
-
-suspend fun LiveCounter.incrementCoroutine(amount: Int): Unit = supressCoroutineExceptions {
-  suspendCancellableCoroutine { continuation ->
-    incrementAsync(amount, object : ObjectsCallback<Void> {
-      override fun onSuccess(result: Void?) {
-        continuation.resume(Unit)
-      }
-
-      override fun onError(exception: AblyException?) {
-        continuation.cancel(exception)
-      }
-    })
-  }
-}
-
-suspend fun LiveCounter.decrementCoroutine(amount: Int): Unit = supressCoroutineExceptions {
-  suspendCancellableCoroutine { continuation ->
-    decrementAsync(amount, object : ObjectsCallback<Void> {
-      override fun onSuccess(result: Void?) {
-        continuation.resume(Unit)
-      }
-
-      override fun onError(exception: AblyException?) {
-        continuation.cancel(exception)
-      }
-    })
-  }
-}
-
-suspend fun Channel.updateOptions(options: ChannelOptions): Unit = supressCoroutineExceptions {
-  suspendCancellableCoroutine { continuation ->
-    setOptions(options, object : io.ably.lib.realtime.CompletionListener {
-      override fun onSuccess() {
-        continuation.resume(Unit)
-      }
-
-      override fun onError(reason: ErrorInfo?) {
-        continuation.cancel(AblyException.fromErrorInfo(reason))
-      }
-    })
-  }
-}
-
-suspend fun getOrCreateCounter(channel: Channel, root: LiveMap?, path: String): LiveCounter {
-  val mapValue = root?.get(path)
-  if (mapValue == null) {
-    val counter = channel.objects.createCounterCoroutine()
-    root?.setCoroutine(path, LiveMapValue.of(counter))
-    return counter
-  } else {
-    return mapValue.asLiveCounter
-  }
-}
-
-suspend fun getOrCreateMap(channel: Channel, root: LiveMap?, path: String): LiveMap {
-  val mapValue = root?.get(path)
-  if (mapValue == null) {
-    val map = channel.objects.createMapCoroutine()
-    root?.setCoroutine(path, LiveMapValue.of(map))
-    return map
-  } else {
-    return mapValue.asLiveMap
-  }
-}
-
-suspend fun LiveMap.setCoroutine(key: String, value: LiveMapValue) = supressCoroutineExceptions {
-  suspendCancellableCoroutine<Unit> { continuation ->
-    setAsync(key, value, object : ObjectsCallback<Void> {
-      override fun onSuccess(result: Void?) {
-        continuation.resume(Unit)
-      }
-
-      override fun onError(exception: AblyException?) {
-        continuation.cancel(exception)
-      }
-    })
-  }
-}
-
-suspend fun LiveMap.removeCoroutine(key: String) = supressCoroutineExceptions {
-  suspendCancellableCoroutine<Unit> { continuation ->
-    removeAsync(key, object : ObjectsCallback<Void> {
-      override fun onSuccess(result: Void?) {
-        continuation.resume(Unit)
-      }
-
-      override fun onError(exception: AblyException?) {
-        continuation.cancel(exception)
-      }
-    })
-  }
+  return path.asLiveMap()
 }
 
 @Composable
-fun observeCounter(channel: Channel, root: LiveMap?, path: String): CounterState {
-  var counter by remember { mutableStateOf<LiveCounter?>(null) }
+fun observeCounter(root: LiveMapPathObject?, key: String): CounterState {
+  var counter by remember { mutableStateOf<LiveCounterPathObject?>(null) }
   var counterValue by remember { mutableStateOf<Int?>(null) }
 
   LaunchedEffect(root) {
-    supressCoroutineExceptions {
-      counter = getOrCreateCounter(channel, root, path)
+    root?.let {
+      supressCoroutineExceptions {
+        counter = getOrCreateCounter(it, key)
+      }
     }
   }
 
   DisposableEffect(counter) {
     counterValue = counter?.value()?.toInt()
 
-    val listener: (LiveCounterUpdate) -> Unit = {
-      counter?.value()?.let {
-        counterValue = it.toInt()
-      }
+    // The path subscription fires both for increments on the counter and for the key
+    // being replaced with a new counter (e.g. "Reset all" on another device); the path
+    // re-resolves on read, so no explicit rebinding is needed.
+    val subscription = counter?.subscribe {
+      counterValue = counter?.value()?.toInt()
     }
-
-    counter?.subscribe(listener)
 
     onDispose {
-      counter?.unsubscribe(listener)
-    }
-  }
-
-  DisposableEffect(root) {
-    val listener: (LiveMapUpdate) -> Unit = { rootUpdate ->
-      val counterHasBeenRemoved = rootUpdate.update
-        .filter { (_, change) -> change == UPDATED }
-        .any { (keyName) -> keyName == path }
-
-      if (counterHasBeenRemoved) root?.get(path)?.asLiveCounter?.let { counter = it }
-    }
-
-    root?.subscribe(listener)
-
-    onDispose {
-      root?.unsubscribe(listener)
+      subscription?.unsubscribe()
     }
   }
 
   return CounterState(counterValue, counter) {
-    coroutineScope {
-      launch {
-        counter = channel.objects.createCounterCoroutine().also {
-          root?.setCoroutine(path, LiveMapValue.of(it))
-        }
-      }
-    }
+    // Reset by replacing the object at this key with a brand-new zero-value counter;
+    // fire-and-forget - the path subscription refreshes the displayed value on ack
+    root?.set(key, LiveMapValue.of(LiveCounter.create()))
   }
 }
 
-data class CounterState(val value: Int?, val counter: LiveCounter?, val reset: suspend () -> Unit)
+data class CounterState(val value: Int?, val counter: LiveCounterPathObject?, val reset: () -> Unit)
 
 @Composable
 fun observeChannelState(channel: Channel): ChannelState {
@@ -227,31 +124,35 @@ fun observeChannelState(channel: Channel): ChannelState {
 }
 
 @Composable
-fun observeMap(channel: Channel, root: LiveMap?, path: String): Pair<Map<String, String>, LiveMap?> {
-  var map by remember { mutableStateOf<LiveMap?>(null) }
+fun observeMap(root: LiveMapPathObject?, key: String): Pair<Map<String, String>, LiveMapPathObject?> {
+  var map by remember { mutableStateOf<LiveMapPathObject?>(null) }
   var mapValue by remember { mutableStateOf<Map<String, String>>(mapOf()) }
 
+  fun readEntries(liveMap: LiveMapPathObject?): Map<String, String> =
+    liveMap?.entries()
+      ?.mapNotNull { (entryKey, valuePath) -> valuePath.asString().value()?.let { entryKey to it } }
+      ?.toMap()
+      ?: mapOf()
+
   LaunchedEffect(root) {
-    supressCoroutineExceptions {
-      map = getOrCreateMap(channel, root, path)
+    root?.let {
+      supressCoroutineExceptions {
+        map = getOrCreateMap(it, key)
+      }
     }
   }
 
   DisposableEffect(map) {
-    map?.entries()?.associate { (key, value) -> key to value.asString }?.let {
-      mapValue = it
-    }
+    mapValue = readEntries(map)
 
-    val listener: (LiveMapUpdate) -> Unit = {
-      map?.entries()?.associate { (key, value) -> key to value.asString }?.let {
-        mapValue = it
-      }
+    // Fires for every entry change on the map at this path (default subscription depth
+    // covers nested updates), after which entries are re-read from the resolved map.
+    val subscription = map?.subscribe {
+      mapValue = readEntries(map)
     }
-
-    map?.subscribe(listener)
 
     onDispose {
-      map?.unsubscribe(listener)
+      subscription?.unsubscribe()
     }
   }
 
@@ -259,14 +160,15 @@ fun observeMap(channel: Channel, root: LiveMap?, path: String): Pair<Map<String,
 }
 
 @Composable
-fun observeRootObject(channel: Channel): LiveMap? {
+fun observeRootObject(channel: Channel): LiveMapPathObject? {
   val channelState = observeChannelState(channel)
-  var root: LiveMap? by remember { mutableStateOf(null) }
+  var root: LiveMapPathObject? by remember { mutableStateOf(null) }
 
   LaunchedEffect(channelState) {
     if (channelState == ChannelState.attached) {
       supressCoroutineExceptions {
-        root = channel.objects.getRootCoroutines()
+        // Completes once the objects synchronization state has reached SYNCED
+        root = channel.`object`.get().await()
       }
     }
   }

--- a/examples/src/main/kotlin/com/ably/example/screen/ColorVotingScreen.kt
+++ b/examples/src/main/kotlin/com/ably/example/screen/ColorVotingScreen.kt
@@ -14,23 +14,20 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ably.example.getRealtimeChannel
-import com.ably.example.incrementCoroutine
 import com.ably.example.observeCounter
 import com.ably.example.observeRootObject
 import io.ably.lib.realtime.AblyRealtime
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ColorVotingScreen(realtimeClient: AblyRealtime) {
-  val scope = rememberCoroutineScope()
   val channel = getRealtimeChannel(realtimeClient, "objects-live-counter")
 
   val root = observeRootObject(channel)
 
-  val (redCount, redCounter, resetRed) = observeCounter(channel, root,"red")
-  val (greenCount, greenCounter, resetGreen) = observeCounter(channel, root,"green")
-  val (blueCount, blueCounter, resetBlue) = observeCounter(channel, root,"blue")
+  val (redCount, redCounter, resetRed) = observeCounter(root, "red")
+  val (greenCount, greenCounter, resetGreen) = observeCounter(root, "green")
+  val (blueCount, blueCounter, resetBlue) = observeCounter(root, "blue")
 
   Column(
     modifier = Modifier
@@ -53,9 +50,8 @@ fun ColorVotingScreen(realtimeClient: AblyRealtime) {
       count = redCount ?: 0,
       enabled = greenCounter != null,
       onVote = {
-        scope.launch {
-          redCounter?.incrementCoroutine(1)
-        }
+        // Fire-and-forget: the path subscription updates the displayed count on ack
+        redCounter?.increment(1)
       }
     )
 
@@ -65,9 +61,7 @@ fun ColorVotingScreen(realtimeClient: AblyRealtime) {
       count = greenCount ?: 0,
       enabled = greenCounter != null,
       onVote = {
-        scope.launch {
-          greenCounter?.incrementCoroutine(1)
-        }
+        greenCounter?.increment(1)
       }
     )
 
@@ -77,20 +71,16 @@ fun ColorVotingScreen(realtimeClient: AblyRealtime) {
       count = blueCount ?: 0,
       enabled = blueCounter != null,
       onVote = {
-        scope.launch {
-          blueCounter?.incrementCoroutine(1)
-        }
+        blueCounter?.increment(1)
       }
     )
 
     Button(
       enabled = redCounter != null && greenCounter != null && blueCounter != null,
       onClick = {
-        scope.launch {
-          resetRed()
-          resetBlue()
-          resetGreen()
-        }
+        resetRed()
+        resetBlue()
+        resetGreen()
       },
     ) {
       Text(

--- a/examples/src/main/kotlin/com/ably/example/screen/ColorVotingScreen.kt
+++ b/examples/src/main/kotlin/com/ably/example/screen/ColorVotingScreen.kt
@@ -44,11 +44,13 @@ fun ColorVotingScreen(realtimeClient: AblyRealtime) {
       modifier = Modifier.padding(vertical = 16.dp)
     )
 
+    ObjectsSyncStatusRow(channel, root)
+
     ColorVoteCard(
       color = Color.Red,
       colorName = "Red",
       count = redCount ?: 0,
-      enabled = greenCounter != null,
+      enabled = redCounter != null,
       onVote = {
         // Fire-and-forget: the path subscription updates the displayed count on ack
         redCounter?.increment(1)

--- a/examples/src/main/kotlin/com/ably/example/screen/ObjectsSyncStatus.kt
+++ b/examples/src/main/kotlin/com/ably/example/screen/ObjectsSyncStatus.kt
@@ -1,0 +1,67 @@
+package com.ably.example.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ably.example.observeObjectsSyncState
+import io.ably.lib.liveobjects.path.types.LiveMapPathObject
+import io.ably.lib.liveobjects.state.ObjectStateEvent
+import io.ably.lib.realtime.Channel
+
+/**
+ * Shows the channel's objects synchronization progress: a spinner with
+ * "Objects syncing..." while the initial sync (or a re-sync) is in flight, and a
+ * check mark with "Objects synced" once local state matches the channel.
+ *
+ * Sync-state events fire on transitions only, so a sync that completed before this
+ * composable subscribed emits nothing; a non-null [root] proves `channel.object.get()`
+ * has completed, which implies SYNCED. A later event (e.g. a re-sync after reattach)
+ * takes precedence over that inference.
+ */
+@Composable
+fun ObjectsSyncStatusRow(channel: Channel, root: LiveMapPathObject?) {
+  val syncState = observeObjectsSyncState(channel)
+  val synced = syncState?.let { it == ObjectStateEvent.SYNCED } ?: (root != null)
+
+  Row(
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(6.dp),
+    modifier = Modifier.testTag("objects_sync_status")
+  ) {
+    if (synced) {
+      Icon(
+        Icons.Default.CheckCircle,
+        contentDescription = "Objects synced",
+        tint = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.size(16.dp)
+      )
+      Text(
+        text = "Objects synced",
+        fontSize = 12.sp,
+        color = MaterialTheme.colorScheme.primary
+      )
+    } else {
+      CircularProgressIndicator(
+        modifier = Modifier.size(14.dp),
+        strokeWidth = 2.dp
+      )
+      Text(
+        text = "Objects syncing...",
+        fontSize = 12.sp,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+      )
+    }
+  }
+}

--- a/examples/src/main/kotlin/com/ably/example/screen/TaskManagementScreen.kt
+++ b/examples/src/main/kotlin/com/ably/example/screen/TaskManagementScreen.kt
@@ -53,6 +53,8 @@ fun TaskManagementScreen(realtimeClient: AblyRealtime) {
       modifier = Modifier.fillMaxWidth()
     )
 
+    ObjectsSyncStatusRow(channel, root)
+
     Card(
       modifier = Modifier.fillMaxWidth(),
       elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
@@ -75,6 +77,9 @@ fun TaskManagementScreen(realtimeClient: AblyRealtime) {
           horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
           Button(
+            // Disabled until the tasks map is bound, so input is never cleared
+            // without the task actually being enqueued
+            enabled = liveTasks != null,
             onClick = {
               if (taskText.isNotBlank()) {
                 val taskId = "${System.currentTimeMillis()}_${Uuid.random().toHexString()}"

--- a/examples/src/main/kotlin/com/ably/example/screen/TaskManagementScreen.kt
+++ b/examples/src/main/kotlin/com/ably/example/screen/TaskManagementScreen.kt
@@ -18,11 +18,8 @@ import androidx.compose.ui.unit.sp
 import com.ably.example.getRealtimeChannel
 import com.ably.example.observeMap
 import com.ably.example.observeRootObject
-import com.ably.example.removeCoroutine
-import com.ably.example.setCoroutine
-import io.ably.lib.objects.type.map.LiveMapValue
+import io.ably.lib.liveobjects.value.LiveMapValue
 import io.ably.lib.realtime.AblyRealtime
-import kotlinx.coroutines.launch
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -33,12 +30,10 @@ fun TaskManagementScreen(realtimeClient: AblyRealtime) {
   var editingTaskId by remember { mutableStateOf<String?>(null) }
   var editingText by remember { mutableStateOf("") }
 
-  val scope = rememberCoroutineScope()
-
   val channel = getRealtimeChannel(realtimeClient, "objects-live-map")
   val root = observeRootObject(channel)
 
-  val (taskIdToTask, liveTasks) = observeMap(channel, root, "tasks")
+  val (taskIdToTask, liveTasks) = observeMap(root, "tasks")
 
   val taskEntries = remember(taskIdToTask) {
     taskIdToTask.entries.sortedBy { it.key }
@@ -82,11 +77,10 @@ fun TaskManagementScreen(realtimeClient: AblyRealtime) {
           Button(
             onClick = {
               if (taskText.isNotBlank()) {
-                scope.launch {
-                  val taskId = "${System.currentTimeMillis()}_${Uuid.random().toHexString()}"
-                  liveTasks?.setCoroutine(taskId, LiveMapValue.of(taskText.trim()))
-                  taskText = ""
-                }
+                val taskId = "${System.currentTimeMillis()}_${Uuid.random().toHexString()}"
+                // Fire-and-forget: the map subscription refreshes the task list on ack
+                liveTasks?.set(taskId, LiveMapValue.of(taskText.trim()))
+                taskText = ""
               }
             },
             modifier = Modifier.weight(1f)
@@ -98,10 +92,8 @@ fun TaskManagementScreen(realtimeClient: AblyRealtime) {
 
           OutlinedButton(
             onClick = {
-              scope.launch {
-                taskIdToTask.forEach { task ->
-                  liveTasks?.removeCoroutine(task.key)
-                }
+              taskIdToTask.forEach { task ->
+                liveTasks?.remove(task.key)
               }
             },
             modifier = Modifier.weight(1f)
@@ -157,20 +149,16 @@ fun TaskManagementScreen(realtimeClient: AblyRealtime) {
                   editingText = task.value
                 },
                 onSave = {
-                  scope.launch {
-                    liveTasks?.setCoroutine(task.key, LiveMapValue.of(editingText.trim()))
-                    editingTaskId = null
-                    editingText = ""
-                  }
+                  liveTasks?.set(task.key, LiveMapValue.of(editingText.trim()))
+                  editingTaskId = null
+                  editingText = ""
                 },
                 onCancel = {
                   editingTaskId = null
                   editingText = ""
                 },
                 onDelete = {
-                  scope.launch {
-                    liveTasks?.removeCoroutine(task.key)
-                  }
+                  liveTasks?.remove(task.key)
                 }
               )
             }


### PR DESCRIPTION
- Fixes https://ably.atlassian.net/browse/AIT-1038

Migrates the LiveObjects example Android app from the removed `io.ably.lib.objects` callback API to the new path-based public API (`io.ably.lib.liveobjects`) introduced by #1224. The app is the integration testbed for the SDK — it consumes `:liveobjects` and `:android` as local Gradle modules — so it needs to track the API it exercises. Verified on an emulator: color voting, reset-all, and task management all sync live.

## What changed

All SDK usage lives in `Utils.kt` (the app's bridge layer); the two screens only needed import/call-site touches. UI, test tags, channel setup (`object_publish`/`object_subscribe` modes) and both instrumentation tests are unchanged.

| Old (callback API) | New (path-based API) |
|---|---|
| `channel.objects.getRootAsync(callback)` → `LiveMap` | `channel.object.get().await()` → root `LiveMapPathObject` (completes once objects are `SYNCED`) |
| `createCounterAsync` / `createMapAsync` + `root.setAsync(key, ...)` (two steps, free-floating object linked afterwards) | `root.set(key, LiveMapValue.of(LiveCounter.create()))` — create + link in one published operation |
| `counter.incrementAsync(n, callback)` wrapped in `incrementCoroutine` | `counterPath.increment(n)` called directly (returns `CompletableFuture`) |
| `map.setAsync` / `removeAsync` wrapped in `setCoroutine` / `removeCoroutine` | `mapPath.set(key, value)` / `mapPath.remove(key)` called directly |
| `counter.subscribe(listener)` + separate **root-map subscription** watching for the key being `UPDATED`, to rebind after "Reset all" replaces the counter | One path subscription — a `PathObject` references a *location* and re-resolves per call, so it follows object replacement automatically |
| `LiveMapValue.asString` on map entries (throws on non-string) | `pathObject.asString().value()` (null-safe; non-string entries are skipped) |

## Design notes

- **Location semantics over identity.** Per the [PathObject concept docs](https://ably.com/docs/liveobjects/concepts/path-object), stored `PathObject` references stay valid across object replacement — which is exactly the app's "Reset all" flow. This deleted the entire rebind bookkeeping the old app carried. The identity-bound `Instance` API isn't needed anywhere in this app; `Utils.kt`'s file-level KDoc documents the distinction for readers using it as reference code.
- **Fire-and-forget mutations.** Button handlers call the `CompletableFuture`-returning mutators directly without awaiting; the path subscription refreshes Compose state when the operation is acknowledged. This removed all `scope.launch` wrappers from the screens. Failures are dropped silently — same observable behaviour as the old app's swallow-all wrapper, and equally demo-only.
- **Awaits kept where ordering matters**: `getOrCreateCounter`/`getOrCreateMap` await the create-and-link before binding (so vote buttons enable only once the counter exists), and the root fetch awaits sync.

## Testing

- `:examples:assembleDebug` and `:examples:compileDebugAndroidTestKotlin` green.
- Manually verified on an emulator: voting increments live, "Reset all" zeroes counters on all clients, tasks add/edit/delete sync across devices.
- Instrumentation tests (`MainScreenTest`, `ColorVotingScreenTest`) are untouched and remain runnable via `:examples:connectedDebugAndroidTest`.

Net: **−120 lines** (116 added, 236 removed), almost all of it callback-adapter and rebind machinery the path-based API makes unnecessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time updates for counters, maps, and task lists so the UI refreshes more reliably when values change.
  * Simplified vote, reset, add, save, and delete actions to respond immediately without extra waiting.
* **Refactor**
  * Updated the example app to use a newer path-based live data approach across the color voting and task management screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->