### PR TITLE
Release/1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Change Log
 
+## [1.8.0](https://github.com/ably/ably-java/tree/v1.8.0)
+
+[Full Changelog](https://github.com/ably/ably-java/compare/v1.7.2...v1.8.0)
+
+### What's Changed
+
+- Introduce the new path-based LiveObjects API [#1214](https://github.com/ably/ably-java/pull/1214). LiveObjects data is now accessed through `channel.object`, which returns a `RealtimeObject` exposing `PathObject`s — stable references to locations within the channel object that resolve to values dynamically at runtime, instead of explicit `LiveMap`/`LiveCounter` instances. See the [PathObject documentation](https://ably.com/docs/liveobjects/concepts/path-object) for details. This feature was delivered through the following PRs:
+  - Implement the path-based LiveObjects public API interfaces [#1213](https://github.com/ably/ably-java/pull/1213)
+  - Add the path-based `RealtimeObject` and the `channel.object` accessor [#1216](https://github.com/ably/ably-java/pull/1216)
+  - Add basic implementation for the `PathObject` and `Instance` interfaces [#1217](https://github.com/ably/ably-java/pull/1217)
+  - Rename the `object` package to `liveobjects` (`io.ably.lib.liveobjects`) [#1220](https://github.com/ably/ably-java/pull/1220)
+  - Update the LiveObjects `uts-to-kotlin` skill to generate tests for the new API [#1221](https://github.com/ably/ably-java/pull/1221)
+  - Implement core `LiveObjects` functionality on the new path-based API (Kotlin) [#1223](https://github.com/ably/ably-java/pull/1223)
+  - Implement the remaining path-based API — parent references, event bubbling and related behaviour [#1224](https://github.com/ably/ably-java/pull/1224)
+  - Migrate the LiveObjects example app to the path-based API [#1225](https://github.com/ably/ably-java/pull/1225)
+
+### Breaking changes
+
+This release replaces the previous experimental instance-based LiveObjects API with the new path-based API:
+
+- The `channel.getObjects()` accessor (returning `RealtimeObjects`) has been replaced by the `channel.object` field (returning `RealtimeObject`)
+- The `io.ably.lib.objects` package has been renamed to `io.ably.lib.liveobjects`
+- Instead of obtaining and operating on explicit `LiveMap`/`LiveCounter` instances, data is accessed and mutated through `PathObject` references
+
 ## [1.7.2](https://github.com/ably/ably-java/tree/v1.7.2)
 
 [Full Changelog](https://github.com/ably/ably-java/compare/v1.7.1...v1.7.2)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,7 +235,7 @@ You may wish to make changes to Ably Java or Ably Android, and test it immediate
 - Open the directory printed from the output of that command. Inside that folder, get the `ably-android-x.y.z.aar`, and place it your Android project's `libs/` directory. Create this directory if it doesn't exist.
 - Add an `implementation` dependency on the `.aar`:
 ```groovy
-implementation files('libs/ably-android-1.7.2.aar')
+implementation files('libs/ably-android-1.8.0.aar')
 ```
 - Add the `implementation` (not `testImplementation`) dependencies found in `dependencies.gradle` to your project. This is because the `.aar` does not contain dependencies.
 - Build/run your application.

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ The Java SDK is available as a [Maven dependency](https://mvnrepository.com/arti
 <dependency>
     <groupId>io.ably</groupId>
     <artifactId>ably-java</artifactId>
-    <version>1.7.2</version>
+    <version>1.8.0</version>
 </dependency>
 ```
 
 ### Install for Gradle:
 
 ```gradle
-implementation 'io.ably:ably-java:1.7.2'
+implementation 'io.ably:ably-java:1.8.0'
 implementation 'org.slf4j:slf4j-simple:2.0.7'
 ```
 
@@ -113,7 +113,7 @@ Add the following dependency to your `build.gradle` file:
 
 ```groovy
 dependencies {
-    runtimeOnly("io.ably:liveobjects:1.7.2")
+    runtimeOnly("io.ably:liveobjects:1.8.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=io.ably
-VERSION_NAME=1.7.2
+VERSION_NAME=1.8.0
 POM_INCEPTION_YEAR=2015
 POM_URL=https://github.com/ably/ably-java
 POM_SCM_URL=https://github.com/ably/ably-java/

--- a/lib/src/test/java/io/ably/lib/test/realtime/RealtimeHttpHeaderTest.java
+++ b/lib/src/test/java/io/ably/lib/test/realtime/RealtimeHttpHeaderTest.java
@@ -88,7 +88,7 @@ public class RealtimeHttpHeaderTest extends ParameterizedTest {
              * Defaults.ABLY_AGENT_PARAM, as ultimately the request param has been derived from those values.
              */
             assertEquals("Verify correct lib version", requestParameters.get("agent"),
-                    Collections.singletonList("ably-java/1.7.2 jre/" + System.getProperty("java.version")));
+                    Collections.singletonList("ably-java/1.8.0 jre/" + System.getProperty("java.version")));
 
             /* Spec RTN2a */
             assertEquals("Verify correct format", requestParameters.get("format"),


### PR DESCRIPTION
Release PR for version 1.8.0, following the [release process](./CONTRIBUTING.md#release-process): bumps the version to `1.8.0` and updates the [CHANGELOG](./CHANGELOG.md).

### What's Changed

- Introduce the new path-based LiveObjects API [#1214](https://github.com/ably/ably-java/pull/1214). LiveObjects data is now accessed through `channel.object`, which returns a `RealtimeObject` exposing `PathObject`s — stable references to locations within the channel object that resolve to values dynamically at runtime, instead of explicit `LiveMap`/`LiveCounter` instances. See the [PathObject documentation](https://ably.com/docs/liveobjects/concepts/path-object) for details. This feature was delivered through the following PRs:
  - Implement the path-based LiveObjects public API interfaces [#1213](https://github.com/ably/ably-java/pull/1213)
  - Add the path-based `RealtimeObject` and the `channel.object` accessor [#1216](https://github.com/ably/ably-java/pull/1216)
  - Add basic implementation for the `PathObject` and `Instance` interfaces [#1217](https://github.com/ably/ably-java/pull/1217)
  - Implement JSON and MsgPack serializers for path-based LiveObjects [#1218](https://github.com/ably/ably-java/pull/1218)
  - Rename the `object` package to `liveobjects` (`io.ably.lib.liveobjects`) [#1220](https://github.com/ably/ably-java/pull/1220)
  - Update the LiveObjects `uts-to-kotlin` skill to generate tests for the new API [#1221](https://github.com/ably/ably-java/pull/1221)
  - Translate the LiveObjects `objects` UTS test specs to Kotlin tests [#1222](https://github.com/ably/ably-java/pull/1222)
  - Implement core `LiveObjects` functionality on the new path-based API (Kotlin) [#1223](https://github.com/ably/ably-java/pull/1223)
  - Implement the remaining path-based API — parent references, event bubbling and related behaviour [#1224](https://github.com/ably/ably-java/pull/1224)
  - Migrate the LiveObjects example app to the path-based API [#1225](https://github.com/ably/ably-java/pull/1225)
  - Fix LiveObjects UTS unit tests [#1226](https://github.com/ably/ably-java/pull/1226)
- Add unified test suite (UTS) ground work: mock HTTP and WebSocket transports, a `Clock` abstraction with fake timers, and a skill to translate UTS pseudocode specs into Kotlin tests [#1209](https://github.com/ably/ably-java/pull/1209)
- Add `ProxyManager` and `ProxySession` for proxy-driven integration tests [#1210](https://github.com/ably/ably-java/pull/1210)
- Harden CI workflow security: pin GitHub Actions to commit SHAs, scope `GITHUB_TOKEN` permissions and disable credential persistence on checkout [#1211](https://github.com/ably/ably-java/pull/1211)

### Breaking changes

This release replaces the previous experimental instance-based LiveObjects API with the new path-based API:

- The `channel.getObjects()` accessor (returning `RealtimeObjects`) has been replaced by the `channel.object` field (returning `RealtimeObject`)
- The `io.ably.lib.objects` package has been renamed to `io.ably.lib.liveobjects`
- Instead of obtaining and operating on explicit `LiveMap`/`LiveCounter` instances, data is accessed and mutated through `PathObject` references


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release**
  - Released version **1.8.0** and updated library version references throughout the project.

- **Breaking Changes**
  - Replaced the experimental instance-based LiveObjects API with a path-based API via `channel.object` returning a `RealtimeObject`.
  - Removed `channel.getObjects()` in favor of `channel.object`.
  - Updated LiveObjects package naming (`io.ably.lib.objects` → `io.ably.lib.liveobjects`).
  - Switched LiveObjects interaction from explicit LiveMap/LiveCounter instances to **PathObject** references.

- **Documentation**
  - Updated README and contributing instructions with the **1.8.0** dependency/version.
  - Updated `gradle.properties` version name to **1.8.0**.

- **Tests**
  - Adjusted expected realtime WebSocket agent header to reflect **ably-java/1.8.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->